### PR TITLE
feat(ci): Add supply chain protection with provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
   packages: write
   issues: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   # Job 1: Run all CI checks first
@@ -112,6 +114,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -122,6 +125,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest Docker image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   # Job 4: Build and attach frontend assets
   assets:
@@ -173,6 +185,11 @@ jobs:
         run: |
           cd apps/frontend
           tar -czvf "../../frontend-${VERSION}.tar.gz" build/
+
+      - name: Attest frontend assets
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: frontend-${{ needs.release.outputs.new_release_version }}.tar.gz
 
       - name: Upload frontend assets to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Add SLSA provenance and SBOM generation to Docker builds
- Add GitHub artifact attestations for Docker images and frontend assets
- Enable cryptographic verification linking published artifacts to CI builds

## Changes

| Change | Description |
|--------|-------------|
| `id-token: write` | Required for OIDC token (Sigstore signing) |
| `attestations: write` | Required for GitHub attestations |
| `provenance: mode=max` | Generates SLSA provenance for Docker images |
| `sbom: true` | Generates Software Bill of Materials |
| `attest-build-provenance` | Creates verifiable attestations |

## Verification

After release, artifacts can be verified:

```bash
# Verify Docker image
gh attestation verify oci://ghcr.io/datenknoten/freundebuch2:<version> --owner datenknoten

# Verify frontend tarball
gh attestation verify frontend-<version>.tar.gz --owner datenknoten
```

## Test plan

- [ ] Merge to main and trigger a release
- [ ] Verify Docker image attestation with `gh attestation verify`
- [ ] Verify frontend tarball attestation
- [ ] Check SBOM is attached to the Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)