### PR TITLE
fix(mobile): lock viewport and prevent horizontal overflow

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -14,6 +14,11 @@
 }
 
 @layer base {
+  html,
+  body {
+    @apply overflow-x-hidden;
+  }
+
   body {
     @apply font-body text-gray-900;
   }

--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Yanone+Kaffeesatz:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
- Add maximum-scale=1 and viewport-fit=cover to viewport meta tag
- Add overflow-x: hidden to html and body elements