### PR TITLE
fix(ci): make attestation steps conditional on public visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
           sbom: true
 
       - name: Attest Docker image
+        if: ${{ github.event.repository.visibility == 'public' }}
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ghcr.io/${{ github.repository }}
@@ -187,6 +188,7 @@ jobs:
           tar -czvf "../../frontend-${VERSION}.tar.gz" build/
 
       - name: Attest frontend assets
+        if: ${{ github.event.repository.visibility == 'public' }}
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: frontend-${{ needs.release.outputs.new_release_version }}.tar.gz


### PR DESCRIPTION
Attestations require GitHub Enterprise Cloud for private repos.
Skip attestation steps for private repos to prevent release failures.
Attestations will automatically enable when repo becomes public.