### PR TITLE
fix(navbar): make navbar fixed at top for mobile and desktop

### DIFF
--- a/apps/frontend/src/lib/components/NavBar.svelte
+++ b/apps/frontend/src/lib/components/NavBar.svelte
@@ -192,7 +192,7 @@ $effect(() => {
   </nav>
 </div>
 
-<nav class="bg-white border-b border-gray-200">
+<nav class="bg-white border-b border-gray-200 fixed top-0 left-0 right-0 z-30">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center h-16">
       <!-- Mobile: Hamburger menu button -->
@@ -279,3 +279,6 @@ $effect(() => {
     </div>
   </div>
 </nav>
+
+<!-- Spacer to prevent content from being hidden behind fixed navbar -->
+<div class="h-16"></div>


### PR DESCRIPTION
- Added fixed positioning (fixed top-0 left-0 right-0 z-30) to main nav
- Added spacer div (h-16) below navbar to prevent content overlap
- Works consistently across all viewport sizes