### PR TITLE
feat(frontend): add cache buster for static assets

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,6 +3,19 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [sveltekit()],
+  build: {
+    // Ensure content hashes are included in filenames for cache busting
+    rollupOptions: {
+      output: {
+        // Include hash in entry filenames
+        entryFileNames: 'assets/[name]-[hash].js',
+        // Include hash in chunk filenames
+        chunkFileNames: 'assets/[name]-[hash].js',
+        // Include hash in asset filenames (CSS, images, etc.)
+        assetFileNames: 'assets/[name]-[hash][extname]',
+      },
+    },
+  },
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     globals: true,

--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -84,7 +84,22 @@ http {
             client_max_body_size 10M;
         }
 
-        # SvelteKit static files with caching
+        # HTML files - no caching to ensure users get latest version with updated asset references
+        location ~* \.html$ {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            try_files $uri =404;
+        }
+
+        # SvelteKit immutable assets (hashed filenames) - long-term caching
+        location /_app/immutable/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # Other static files with content hashes - long-term caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
@@ -92,7 +107,11 @@ http {
         }
 
         # SvelteKit fallback for client-side routing
+        # index.html should not be cached to ensure cache busting works
         location / {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
             try_files $uri $uri/ /index.html;
         }
     }


### PR DESCRIPTION
Configure Vite to include content hashes in bundle filenames for
proper cache invalidation on deployments. Update Nginx to:
- Prevent caching of HTML files so users always get latest asset refs
- Explicitly cache SvelteKit immutable assets for 1 year
- Keep long-term caching for other hashed static files