### PR TITLE
feat(frontend): Display app version in footer and mobile menu

### DIFF
--- a/apps/frontend/src/app.d.ts
+++ b/apps/frontend/src/app.d.ts
@@ -1,6 +1,9 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
+  // Injected by Vite at build time
+  const __APP_VERSION__: string;
+
   namespace App {
     // interface Error {}
     interface Locals {

--- a/apps/frontend/src/lib/components/Footer.svelte
+++ b/apps/frontend/src/lib/components/Footer.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+const version = __APP_VERSION__;
+</script>
+
+<footer class="hidden sm:block border-t border-gray-200 bg-white py-4">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <p class="text-center text-gray-500 text-sm font-body">
+      Freundebuch v{version}
+    </p>
+  </div>
+</footer>

--- a/apps/frontend/src/lib/components/NavBar.svelte
+++ b/apps/frontend/src/lib/components/NavBar.svelte
@@ -6,6 +6,8 @@ import { auth, currentUser, isAuthenticated } from '$lib/stores/auth';
 
 let mobileMenuOpen = $state(false);
 
+const version = __APP_VERSION__;
+
 // Derive page title from current route
 const pageTitle = $derived.by(() => {
   const pathname = $page.url.pathname;
@@ -190,6 +192,10 @@ $effect(() => {
       </div>
     {/if}
   </nav>
+
+  <div class="absolute bottom-4 left-0 right-0 px-4">
+    <p class="text-center text-gray-400 text-xs font-body">v{version}</p>
+  </div>
 </div>
 
 <nav class="bg-white border-b border-gray-200 fixed top-0 left-0 right-0 z-30">

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 import '../app.css';
 import { onMount } from 'svelte';
 import { page } from '$app/stores';
+import Footer from '$lib/components/Footer.svelte';
 import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
 import NavBar from '$lib/components/NavBar.svelte';
 import { auth, isAuthenticated } from '$lib/stores/auth';
@@ -22,6 +23,7 @@ const showFab = $derived($isAuthenticated && !$page.url.pathname.includes('/cont
 	<main class="flex-1">
 		<slot />
 	</main>
+	<Footer />
 
 	<!-- Floating Action Button for mobile -->
 	{#if showFab}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,8 +1,14 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
   plugins: [sveltekit()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   build: {
     // Ensure content hashes are included in filenames for cache busting
     rollupOptions: {


### PR DESCRIPTION
Add version display to improve user awareness of the current app version.
Version is shown in the footer on desktop and at the bottom of the
mobile slide-out menu.