### PR TITLE
fix(ci): Skip git hooks during semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: 0
         run: |
           npx semantic-release
 


### PR DESCRIPTION
Set HUSKY=0 environment variable to disable husky hooks during the
semantic-release step. These checks are redundant because the CI job
already runs all quality gates before the release job starts.