### PR TITLE
fix(frontend): Add Sentry project slug to Vite config

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     sentrySvelteKit({
       autoUploadSourceMaps: !!process.env.SENTRY_AUTH_TOKEN,
       adapter: 'other', // Using static adapter
+      sourceMapsUploadOptions: {
+        project: 'freundebuch',
+      },
     }),
     sveltekit(),
   ],


### PR DESCRIPTION
Configure the 'freundebuch' project slug in sourceMapsUploadOptions
to fix the sentry-vite-plugin warning about missing project config.