### PR TITLE
Fix CardDAV server connection error on iPhone

### DIFF
--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -69,14 +69,10 @@ http {
 
         # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)
         location ~ ^/(carddav|caldav)(/.*)?$ {
-            # Remove the /carddav or /caldav prefix
-            rewrite ^/(carddav|caldav)(/.*)$ $2 break;
-            rewrite ^/(carddav|caldav)$ / break;
-
             fastcgi_pass sabredav;
             fastcgi_param SCRIPT_FILENAME /app/apps/sabredav/public/index.php;
             fastcgi_param SCRIPT_NAME /index.php;
-            fastcgi_param REQUEST_URI $uri;
+            fastcgi_param REQUEST_URI $request_uri;
             fastcgi_param REQUEST_METHOD $request_method;
             fastcgi_param CONTENT_TYPE $content_type;
             fastcgi_param CONTENT_LENGTH $content_length;


### PR DESCRIPTION
The production nginx config was stripping the /carddav prefix via rewrite rules and passing $uri (the rewritten path) to PHP. However, SabreDAV is configured with base_uri='/carddav/', causing a mismatch that resulted in 500 errors.

This change aligns the production config with the development config by using $request_uri instead of $uri, preserving the original request path.

Fixes iPhone CardDAV connection error "SSL connection impossible" which was actually caused by the server returning HTTP 500.