### PR TITLE
Fix PHP and Hono logging in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ RUN apt-get update && \
     # Ensure PHP-FPM directory exists
     mkdir -p /run/php
 
+# Copy PHP-FPM pool configuration for logging
+COPY docker/php-fpm-pool.conf /etc/php/8.2/fpm/pool.d/zz-logging.conf
+
 # Enable corepack for pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -2,9 +2,9 @@ import { serve } from '@hono/node-server';
 import * as Sentry from '@sentry/node';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { logger as honoLogger } from 'hono/logger';
 import { secureHeaders } from 'hono/secure-headers';
 import type pg from 'pg';
+import { httpLoggerMiddleware } from './middleware/http-logger.js';
 import { sentryTracingMiddleware } from './middleware/sentry.js';
 import appPasswordsRoutes from './routes/app-passwords.js';
 import authRoutes from './routes/auth.js';
@@ -58,7 +58,7 @@ export async function createApp(pool: pg.Pool) {
   });
 
   // Middleware
-  app.use('*', honoLogger());
+  app.use('*', httpLoggerMiddleware);
   app.use(
     '*',
     secureHeaders({

--- a/apps/backend/src/middleware/http-logger.ts
+++ b/apps/backend/src/middleware/http-logger.ts
@@ -1,0 +1,28 @@
+import type { MiddlewareHandler } from 'hono';
+import type { AppContext } from '../types/context.js';
+
+/**
+ * HTTP request logger middleware using Pino.
+ * Logs incoming requests and outgoing responses with timing information.
+ */
+export const httpLoggerMiddleware: MiddlewareHandler<AppContext> = async (c, next) => {
+  const start = Date.now();
+  const method = c.req.method;
+  const path = c.req.path;
+
+  await next();
+
+  const duration = Date.now() - start;
+  const status = c.res.status;
+  const logger = c.get('logger');
+
+  logger.info(
+    {
+      method,
+      path,
+      status,
+      duration,
+    },
+    `${method} ${path} ${status} ${duration}ms`,
+  );
+};

--- a/docker/php-fpm-pool.conf
+++ b/docker/php-fpm-pool.conf
@@ -1,0 +1,19 @@
+; PHP-FPM pool configuration for production
+; This file configures worker output capture and error logging
+
+[www]
+; Capture PHP worker output (errors, var_dump, etc.) and send to main error log
+catch_workers_output = yes
+
+; Decorate worker output with context information
+decorate_workers_output = no
+
+; Send PHP errors to stderr so they appear in container logs
+php_admin_value[error_log] = /proc/self/fd/2
+php_admin_flag[log_errors] = on
+
+; Disable display_errors in production (errors go to logs, not response body)
+php_admin_flag[display_errors] = off
+
+; Clear any default error log path that might interfere
+clear_env = no


### PR DESCRIPTION
- Add PHP-FPM pool config (zz-logging.conf) to capture worker output and send PHP errors to stderr for container log visibility
- Replace Hono's built-in logger with Pino-based httpLoggerMiddleware for consistent structured JSON logging in production