### PR TITLE
Configure logging for PHP, Hono, and Nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ SMTP_PASSWORD=
 LOG_LEVEL=debug
 ENABLE_API_DOCS=true
 
+# Nginx Logging (production only)
+# NGINX_ACCESS_LOG: "off" (default) to disable, "/dev/stdout" to enable access logs
+NGINX_ACCESS_LOG=off
+# NGINX_ERROR_LOG_LEVEL: debug, info, notice, warn (default), error, crit, alert, emerg
+NGINX_ERROR_LOG_LEVEL=warn
+
 # Sentry (optional, for error tracking)
 # Get your DSN from https://sentry.io
 SENTRY_DSN=

--- a/apps/backend/src/middleware/http-logger.ts
+++ b/apps/backend/src/middleware/http-logger.ts
@@ -16,7 +16,7 @@ export const httpLoggerMiddleware: MiddlewareHandler<AppContext> = async (c, nex
   const status = c.res.status;
   const logger = c.get('logger');
 
-  logger.info(
+  logger.debug(
     {
       method,
       path,

--- a/apps/sabredav/src/Logging/Logger.php
+++ b/apps/sabredav/src/Logging/Logger.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freundebuch\DAV\Logging;
+
+/**
+ * Simple logger for CardDAV server
+ * Logs to stderr for Docker container compatibility
+ */
+class Logger
+{
+    private const LEVELS = [
+        'trace' => 0,
+        'debug' => 1,
+        'info' => 2,
+        'warn' => 3,
+        'error' => 4,
+        'fatal' => 5,
+    ];
+
+    private string $level;
+    private int $levelValue;
+    private ?string $requestId;
+
+    public function __construct(string $level = 'info', ?string $requestId = null)
+    {
+        $this->level = strtolower($level);
+        $this->levelValue = self::LEVELS[$this->level] ?? self::LEVELS['info'];
+        $this->requestId = $requestId ?? $this->generateRequestId();
+    }
+
+    private function generateRequestId(): string
+    {
+        return bin2hex(random_bytes(8));
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
+    }
+
+    private function shouldLog(string $level): bool
+    {
+        $targetLevel = self::LEVELS[$level] ?? self::LEVELS['info'];
+        return $targetLevel >= $this->levelValue;
+    }
+
+    private function log(string $level, string $message, array $context = []): void
+    {
+        if (!$this->shouldLog($level)) {
+            return;
+        }
+
+        $logEntry = [
+            'level' => $level,
+            'time' => date('c'),
+            'requestId' => $this->requestId,
+            'msg' => $message,
+        ];
+
+        if (!empty($context)) {
+            $logEntry = array_merge($logEntry, $context);
+        }
+
+        // Write JSON to stderr for structured logging
+        error_log(json_encode($logEntry, JSON_UNESCAPED_SLASHES));
+    }
+
+    public function trace(string $message, array $context = []): void
+    {
+        $this->log('trace', $message, $context);
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+        $this->log('debug', $message, $context);
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+        $this->log('info', $message, $context);
+    }
+
+    public function warn(string $message, array $context = []): void
+    {
+        $this->log('warn', $message, $context);
+    }
+
+    public function error(string $message, array $context = []): void
+    {
+        $this->log('error', $message, $context);
+    }
+
+    public function fatal(string $message, array $context = []): void
+    {
+        $this->log('fatal', $message, $context);
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
 
       # Logging
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      NGINX_ACCESS_LOG: ${NGINX_ACCESS_LOG:-off}
+      NGINX_ERROR_LOG_LEVEL: ${NGINX_ERROR_LOG_LEVEL:-warn}
     volumes:
       - freundebuch_uploads:/app/uploads
     networks:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Default values for nginx logging configuration
+export NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG:-off}"
+export NGINX_ERROR_LOG_LEVEL="${NGINX_ERROR_LOG_LEVEL:-warn}"
+
+# Generate nginx config from template
+envsubst '${NGINX_ACCESS_LOG} ${NGINX_ERROR_LOG_LEVEL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+# Start supervisord
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,0 +1,154 @@
+worker_processes auto;
+error_log /dev/stderr ${NGINX_ERROR_LOG_LEVEL};
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    # Access log: configurable via environment variable
+    # Use "off" to disable, or "/dev/stdout" to enable
+    access_log ${NGINX_ACCESS_LOG} main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript
+               application/xml application/xml+rss text/javascript application/x-javascript
+               image/svg+xml;
+
+    # Upstream for Node.js backend
+    upstream backend {
+        server 127.0.0.1:3000;
+        keepalive 32;
+    }
+
+    # Upstream for PHP-FPM (SabreDAV)
+    upstream sabredav {
+        server 127.0.0.1:9000;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        # Security headers (Traefik handles HTTPS, so these are internal)
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+
+        # Increase client body size for vCard uploads
+        client_max_body_size 10M;
+
+        # Static frontend files
+        root /app/apps/frontend/build;
+        index index.html;
+
+        # Well-known CardDAV/CalDAV discovery (RFC 6764)
+        location = /.well-known/carddav {
+            return 301 /carddav/;
+        }
+
+        location = /.well-known/caldav {
+            return 301 /caldav/;
+        }
+
+        # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)
+        location ~ ^/(carddav|caldav)(/.*)?$ {
+            fastcgi_pass sabredav;
+            fastcgi_param SCRIPT_FILENAME /app/apps/sabredav/public/index.php;
+            fastcgi_param SCRIPT_NAME /index.php;
+            fastcgi_param REQUEST_URI $request_uri;
+            fastcgi_param REQUEST_METHOD $request_method;
+            fastcgi_param CONTENT_TYPE $content_type;
+            fastcgi_param CONTENT_LENGTH $content_length;
+
+            include fastcgi_params;
+
+            # WebDAV methods need longer timeouts
+            fastcgi_read_timeout 300;
+            fastcgi_send_timeout 300;
+
+            # Pass through authentication headers
+            fastcgi_param HTTP_AUTHORIZATION $http_authorization;
+        }
+
+        # Health check endpoint (directly from backend)
+        location = /health {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # API routes - proxy to Node.js backend
+        location /api/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Timeouts
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+
+            # Don't buffer for streaming
+            proxy_buffering off;
+        }
+
+        # HTML files - no caching to ensure users get latest version with updated asset references
+        location ~* \.html$ {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            try_files $uri =404;
+        }
+
+        # SvelteKit immutable assets (hashed filenames) - long-term caching
+        location /_app/immutable/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # Other static files with content hashes - long-term caching
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # SvelteKit fallback for client-side routing
+        # index.html should not be cached to ensure cache busting works
+        location / {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
- Change Hono HTTP request logging from info to debug level to reduce log spam
- Add structured JSON logging to PHP/SabreDAV with request tracking
- Make nginx access and error logs configurable via environment variables:
  - NGINX_ACCESS_LOG: "off" (default) or "/dev/stdout" to enable
  - NGINX_ERROR_LOG_LEVEL: debug|info|notice|warn|error|crit|alert|emerg
- Use entrypoint script with envsubst for nginx config templating