### PR TITLE
Fix invalid nginx configuration parameter

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,11 +2,19 @@
 set -e
 
 # Default values for nginx logging configuration
-export NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG:-off}"
 export NGINX_ERROR_LOG_LEVEL="${NGINX_ERROR_LOG_LEVEL:-warn}"
 
+# Handle access log configuration
+# When "off", we can't append a log format - nginx rejects "off main"
+# When a path is specified, use the "main" format
+if [ "${NGINX_ACCESS_LOG:-off}" = "off" ]; then
+    export NGINX_ACCESS_LOG_LINE="off"
+else
+    export NGINX_ACCESS_LOG_LINE="${NGINX_ACCESS_LOG} main"
+fi
+
 # Generate nginx config from template
-envsubst '${NGINX_ACCESS_LOG} ${NGINX_ERROR_LOG_LEVEL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst '${NGINX_ACCESS_LOG_LINE} ${NGINX_ERROR_LOG_LEVEL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 # Start supervisord
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -16,7 +16,7 @@ http {
 
     # Access log: configurable via environment variable
     # Use "off" to disable, or "/dev/stdout" to enable
-    access_log ${NGINX_ACCESS_LOG} main;
+    access_log ${NGINX_ACCESS_LOG_LINE};
 
     sendfile on;
     tcp_nopush on;


### PR DESCRIPTION
When NGINX_ACCESS_LOG was set to "off" (the default), the template produced "access_log off main;" which is invalid nginx syntax - the log format parameter cannot be used with "off".

The entrypoint now conditionally builds the access_log line:
- "off" when logging is disabled
- "<path> main" when logging to a file/stdout