### PR TITLE
Exclude Sentry tunnel route from tracing

### DIFF
--- a/apps/backend/src/middleware/sentry.ts
+++ b/apps/backend/src/middleware/sentry.ts
@@ -3,7 +3,7 @@ import type { MiddlewareHandler } from 'hono';
 import type { AppContext } from '../types/context.js';
 
 // Routes that should not be traced to avoid noise and recursive tracing
-const EXCLUDED_TRACE_PATHS = ['/api/sentry-tunnel'];
+const EXCLUDED_TRACE_PATHS = ['/api/sentry-tunnel', '/health'];
 
 /**
  * Sentry tracing middleware for Hono


### PR DESCRIPTION
Skip tracing for POST /api/sentry-tunnel to avoid noise in the Sentry dashboard and prevent recursive tracing when forwarding Sentry events.