### PR TITLE
fix(frontend): Streamline Add Relationship to match other subresources

### DIFF
--- a/apps/frontend/src/lib/components/KeyboardShortcuts.svelte
+++ b/apps/frontend/src/lib/components/KeyboardShortcuts.svelte
@@ -127,6 +127,9 @@ function handleKeydown(e: KeyboardEvent) {
       case 's':
         window.dispatchEvent(new CustomEvent('shortcut:add-social'));
         break;
+      case 'r':
+        window.dispatchEvent(new CustomEvent('shortcut:add-relationship'));
+        break;
     }
     return;
   }
@@ -183,14 +186,6 @@ function handleKeydown(e: KeyboardEvent) {
       if ($currentContact && $page.url.pathname.match(/^\/contacts\/[^/]+$/)) {
         e.preventDefault();
         goto(`/contacts/${$currentContact.id}/edit`);
-      }
-      break;
-
-    case 'r':
-      // Add relationship if on contact detail page
-      if ($currentContact && $page.url.pathname.match(/^\/contacts\/[^/]+$/)) {
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent('shortcut:add-relationship'));
       }
       break;
 
@@ -306,10 +301,6 @@ function closeHelp() {
                 <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">e</kbd>
               </div>
               <div class="flex justify-between items-center">
-                <span class="text-gray-700">Add Relationship</span>
-                <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">r</kbd>
-              </div>
-              <div class="flex justify-between items-center">
                 <span class="text-gray-700">Focus Search</span>
                 <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">/</kbd>
               </div>
@@ -376,6 +367,14 @@ function closeHelp() {
                   <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">a</kbd>
                   <span class="text-gray-400">then</span>
                   <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">s</kbd>
+                </div>
+              </div>
+              <div class="flex justify-between items-center">
+                <span class="text-gray-700">Add Relationship</span>
+                <div class="flex gap-1">
+                  <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">a</kbd>
+                  <span class="text-gray-400">then</span>
+                  <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-sm font-mono">r</kbd>
                 </div>
               </div>
             </div>
@@ -461,6 +460,10 @@ function closeHelp() {
       <div class="flex items-center justify-between px-2 py-1.5 rounded hover:bg-gray-50">
         <span class="text-gray-700">Social Profile</span>
         <kbd class="px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs font-mono">s</kbd>
+      </div>
+      <div class="flex items-center justify-between px-2 py-1.5 rounded hover:bg-gray-50">
+        <span class="text-gray-700">Relationship</span>
+        <kbd class="px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs font-mono">r</kbd>
       </div>
     </div>
   </div>

--- a/apps/frontend/src/lib/components/contacts/RelationshipsSection.svelte
+++ b/apps/frontend/src/lib/components/contacts/RelationshipsSection.svelte
@@ -122,34 +122,36 @@ function handleAddCancel() {
   autofocusForm = false;
   isModalOpen.set(false);
 }
+
+function handleBackdropClick(e: MouseEvent) {
+  if (e.target === e.currentTarget) {
+    handleAddCancel();
+  }
+}
 </script>
 
 <div class="space-y-4">
-  <div class="flex items-center justify-between">
-    <h3 class="text-lg font-heading text-gray-900">Relationships</h3>
-    {#if !showAddForm}
-      <button
-        type="button"
-        onclick={() => { showAddForm = true; isModalOpen.set(true); }}
-        class="text-sm text-forest font-body font-semibold hover:text-forest-light"
-      >
-        + Add Relationship
-      </button>
-    {/if}
+  <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
+    <h3 class="text-lg font-heading flex items-center gap-2">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+      </svg>
+      Relationships
+    </h3>
+    <button
+      type="button"
+      onclick={() => { showAddForm = true; isModalOpen.set(true); }}
+      class="text-sm font-body font-semibold text-white/90 hover:text-white
+             flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+      </svg>
+      Add Relationship
+    </button>
   </div>
 
-  {#if showAddForm}
-    <div class="bg-gray-50 p-4 rounded-lg">
-      <AddRelationshipForm
-        {contactId}
-        autofocus={autofocusForm}
-        onSuccess={handleAddSuccess}
-        onCancel={handleAddCancel}
-      />
-    </div>
-  {/if}
-
-  {#if relationships.length === 0 && !showAddForm}
+  {#if relationships.length === 0}
     <p class="text-sm text-gray-500 font-body py-4">
       No relationships yet. Add relationships to connect this contact with others.
     </p>
@@ -259,3 +261,45 @@ function handleAddCancel() {
     {/each}
   {/if}
 </div>
+
+<!-- Add Relationship Modal -->
+{#if showAddForm}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4"
+    onclick={handleBackdropClick}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="add-relationship-modal-title"
+    tabindex="-1"
+  >
+    <div class="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] flex flex-col">
+      <!-- Header -->
+      <div class="flex items-center justify-between p-4 border-b border-gray-200 flex-shrink-0">
+        <h2 id="add-relationship-modal-title" class="text-xl font-heading text-gray-900">
+          Add Relationship
+        </h2>
+        <button
+          type="button"
+          onclick={handleAddCancel}
+          class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
+          aria-label="Close"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Form content -->
+      <div class="p-4 overflow-y-auto flex-1">
+        <AddRelationshipForm
+          {contactId}
+          autofocus={autofocusForm}
+          onSuccess={handleAddSuccess}
+          onCancel={handleAddCancel}
+        />
+      </div>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
- Update RelationshipsSection header to use forest background style with
  icon, matching other subresource sections (Phone, Email, Address, etc.)
- Change keyboard shortcut from single-key 'r' to two-key 'a + r' to be
  consistent with other subresource shortcuts (a + p, a + e, etc.)
- Update help panel to show the new shortcut under Add Details section
- Add Relationship option to the 'Add...' popup panel
- Convert inline Add Relationship form to a modal for consistency with
  other subresource forms