### PR TITLE
fix(sabredav): Embed contact photos as base64 in vCards for iOS compatibility

### DIFF
--- a/docker/Dockerfile.sabredav
+++ b/docker/Dockerfile.sabredav
@@ -1,11 +1,12 @@
 # SabreDAV PHP-FPM container for CardDAV/CalDAV
 FROM php:8.4-fpm-bookworm
 
-# Install PostgreSQL PDO extension
+# Install PostgreSQL PDO and cURL extensions
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
+    libcurl4-openssl-dev \
     unzip \
-    && docker-php-ext-install pdo pdo_pgsql \
+    && docker-php-ext-install pdo pdo_pgsql curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
iOS and many CardDAV clients don't fetch photos from URLs in vCards.
Instead, they expect the photo data to be embedded as base64.

Changes:
- Add fetchAndEncodeImage() to fetch photos from URLs and encode as base64
- Add detectImageMediaType() to validate images using magic bytes
- Update contactToVCard() to embed photos as data URIs
- Add cURL extension to Dockerfile for HTTP image fetching
- Include image cache to avoid repeated HTTP requests for same URL