### PR TITLE
feat(sabredav): Save raw vCard as JSON blob for debugging

### DIFF
--- a/apps/sabredav/src/CardDAV/FreundebuchCardDAVBackend.php
+++ b/apps/sabredav/src/CardDAV/FreundebuchCardDAVBackend.php
@@ -221,7 +221,7 @@ class FreundebuchCardDAVBackend extends AbstractBackend implements SyncSupport
                 'department' => $contactData['department'] ?? null,
                 'interests' => $contactData['interests'] ?? null,
                 'work_notes' => $contactData['work_notes'] ?? null,
-                'vcard_raw_json' => json_encode($vcardJson),
+                'vcard_raw_json' => json_encode($vcardJson, JSON_THROW_ON_ERROR),
             ]);
             $result = $stmt->fetch();
             $contactId = (int) $result['id'];
@@ -314,7 +314,7 @@ class FreundebuchCardDAVBackend extends AbstractBackend implements SyncSupport
                 'department' => $contactData['department'] ?? null,
                 'interests' => $contactData['interests'] ?? null,
                 'work_notes' => $contactData['work_notes'] ?? null,
-                'vcard_raw_json' => json_encode($vcardJson),
+                'vcard_raw_json' => json_encode($vcardJson, JSON_THROW_ON_ERROR),
             ]);
             $result = $stmt->fetch();
 

--- a/apps/sabredav/src/VCard/Mapper.php
+++ b/apps/sabredav/src/VCard/Mapper.php
@@ -591,8 +591,12 @@ class Mapper
      * This method preserves ALL vCard properties, including ones we don't
      * specifically handle, for debugging and feature discovery purposes.
      *
+     * Property grouping behavior:
+     * - Single occurrence: stored as object {"value": "...", "params": {...}}
+     * - Multiple occurrences: stored as array [{"value": "...", "params": {...}}, ...]
+     *
      * @param string $vcard The raw vCard string
-     * @return array Complete vCard data as a JSON-serializable array
+     * @return array{raw: string, properties: array, parsed_at: string} Complete vCard data
      */
     public function vcardToJson(string $vcard): array
     {

--- a/database/migrations/1768000000000_add-vcard-raw-json.ts
+++ b/database/migrations/1768000000000_add-vcard-raw-json.ts
@@ -6,7 +6,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     {
       vcard_raw_json: {
         type: 'jsonb',
-        comment: 'Raw vCard data as JSON blob for debugging and feature discovery',
+        comment:
+          'Raw vCard data as JSON blob for debugging and feature discovery. ' +
+          'Stores complete vCard string (~1-5KB typical) plus parsed properties. ' +
+          'Only populated for contacts synced via CardDAV.',
       },
     },
   );


### PR DESCRIPTION
Store the complete vCard data as a JSONB column when contacts are
created or updated via SabreDAV. This preserves all properties,
including ones we don't specifically handle, making it easier to
discover new vCard features and investigate bugs.