### PR TITLE
Remove status message from landing page

### DIFF
--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -117,12 +117,5 @@ import { currentUser, isAuthenticated, isAuthInitialized } from '$lib/stores/aut
 				</a>
 			</div>
 		{/if}
-
-		<div class="mt-12 inline-flex items-center gap-2 px-6 py-3 bg-forest text-white rounded-lg">
-			<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-			</svg>
-			<span class="font-body">Authentication system complete - Contact management coming next!</span>
-		</div>
 	</div>
 </div>


### PR DESCRIPTION
Remove the "Authentication system complete - Contact management coming next!"
banner from the landing page as it's no longer needed.