### PR TITLE
fix(ci): resolve heredoc delimiter issue in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Load Review Prompt
         run: |
           {
-            echo 'REVIEW_PROMPT<<PROMPT_EOF'
+            echo 'REVIEW_PROMPT<<GHADELIMITER7x9k2m'
             cat .github/prompts/code-review-prompt.md
-            echo PROMPT_EOF
+            echo ''
+            echo 'GHADELIMITER7x9k2m'
           } >> $GITHUB_ENV
 
       - uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
The PROMPT_EOF delimiter was conflicting with EOF strings present
in the code-review-prompt.md file examples. Changed to a unique
delimiter and added proper newline handling before the closing
delimiter as required by GitHub Actions env file format.