### PR TITLE
feat(frontend): add terms of service page and navigation links

### DIFF
--- a/apps/frontend/src/lib/components/Footer.svelte
+++ b/apps/frontend/src/lib/components/Footer.svelte
@@ -8,6 +8,8 @@ const version = __APP_VERSION__;
       <span class="text-gray-500">Freundebuch v{version}</span>
       <span class="text-gray-300">|</span>
       <a href="/privacy" class="text-gray-500 hover:text-forest transition-colors duration-200">Privacy Policy</a>
+      <span class="text-gray-300">|</span>
+      <a href="/terms" class="text-gray-500 hover:text-forest transition-colors duration-200">Terms of Service</a>
     </div>
   </div>
 </footer>

--- a/apps/frontend/src/lib/components/NavBar.svelte
+++ b/apps/frontend/src/lib/components/NavBar.svelte
@@ -199,13 +199,23 @@ $effect(() => {
   </nav>
 
   <div class="absolute bottom-4 left-0 right-0 px-4">
-    <a
-      href="/privacy"
-      onclick={closeMobileMenu}
-      class="block text-center text-gray-400 hover:text-forest text-xs font-body mb-2 transition-colors duration-200"
-    >
-      Privacy Policy
-    </a>
+    <div class="flex justify-center gap-3 mb-2">
+      <a
+        href="/privacy"
+        onclick={closeMobileMenu}
+        class="text-gray-400 hover:text-forest text-xs font-body transition-colors duration-200"
+      >
+        Privacy Policy
+      </a>
+      <span class="text-gray-300">|</span>
+      <a
+        href="/terms"
+        onclick={closeMobileMenu}
+        class="text-gray-400 hover:text-forest text-xs font-body transition-colors duration-200"
+      >
+        Terms of Service
+      </a>
+    </div>
     <p class="text-center text-gray-400 text-xs font-body">v{version}</p>
   </div>
 </div>

--- a/apps/frontend/src/routes/terms/+page.svelte
+++ b/apps/frontend/src/routes/terms/+page.svelte
@@ -1,0 +1,240 @@
+<svelte:head>
+	<title>Terms of Service | Freundebuch</title>
+</svelte:head>
+
+<div class="bg-gray-50 min-h-screen py-12">
+	<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+		<div class="bg-white rounded-xl shadow-lg p-8">
+			<h1 class="text-4xl font-heading text-forest mb-8">Terms of Service</h1>
+
+			<div class="prose prose-gray max-w-none font-body space-y-6">
+				<p class="text-gray-600">
+					Last updated: January 2026
+				</p>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">1. Acceptance of Terms</h2>
+					<p class="text-gray-700">
+						By accessing or using Freundebuch, you agree to be bound by these Terms of Service and all applicable
+						laws and regulations. If you do not agree with any of these terms, you are prohibited from using or
+						accessing this application. The materials contained in Freundebuch are protected by applicable
+						copyright and trademark law.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">2. Description of Service</h2>
+					<p class="text-gray-700">
+						Freundebuch is a personal relationship management application designed to help you maintain and
+						nurture your personal relationships. The service allows you to:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>Store and organize contact information for friends, family, and acquaintances</li>
+						<li>Track important dates such as birthdays and anniversaries</li>
+						<li>Record notes and memories about your relationships</li>
+						<li>Sync your data with CalDAV/CardDAV compatible services</li>
+						<li>Export your data in standard formats</li>
+					</ul>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">3. User Accounts</h2>
+					<p class="text-gray-700">
+						To use Freundebuch, you must create an account. You are responsible for:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>Maintaining the confidentiality of your account credentials</li>
+						<li>All activities that occur under your account</li>
+						<li>Notifying the administrator immediately of any unauthorized use of your account</li>
+						<li>Ensuring the accuracy of your account information</li>
+					</ul>
+					<p class="text-gray-700 mt-4">
+						You must be at least 16 years of age to create an account and use this service.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">4. Acceptable Use</h2>
+					<p class="text-gray-700">
+						You agree to use Freundebuch only for lawful purposes and in accordance with these Terms. You agree not to:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>Use the service to store information about individuals without their knowledge or consent where required by law</li>
+						<li>Use the service for any commercial purpose without explicit permission</li>
+						<li>Attempt to gain unauthorized access to any portion of the service or any systems connected to it</li>
+						<li>Use the service to transmit any malicious code or interfere with the service's operation</li>
+						<li>Collect or harvest any information from the service through automated means</li>
+						<li>Use the service in any manner that could disable, damage, or impair the service</li>
+					</ul>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">5. User Content</h2>
+					<p class="text-gray-700">
+						You retain ownership of all content you create, upload, or store in Freundebuch ("User Content").
+						By using the service, you grant the service operator a limited license to process, store, and display
+						your User Content solely for the purpose of providing the service to you.
+					</p>
+					<p class="text-gray-700 mt-4">
+						You are solely responsible for:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>The accuracy and legality of the information you store</li>
+						<li>Obtaining any necessary consents from individuals whose information you store</li>
+						<li>Compliance with applicable data protection laws regarding the personal data you collect and store</li>
+						<li>Maintaining appropriate backups of your data</li>
+					</ul>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">6. Self-Hosted Instances</h2>
+					<p class="text-gray-700">
+						Freundebuch is designed to be self-hosted. For self-hosted installations:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>The individual or organization hosting the application is responsible for maintaining the infrastructure</li>
+						<li>The hosting party determines additional terms and conditions for their specific instance</li>
+						<li>Security and data protection measures are the responsibility of the hosting party</li>
+						<li>The software is provided under its respective open source license</li>
+					</ul>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">7. Third-Party Services</h2>
+					<p class="text-gray-700">
+						Freundebuch may integrate with third-party services such as:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li><strong>CalDAV/CardDAV Servers:</strong> For synchronizing contacts and calendar data</li>
+						<li><strong>Sentry:</strong> For error monitoring and performance tracking</li>
+					</ul>
+					<p class="text-gray-700 mt-4">
+						Your use of these third-party services is subject to their respective terms of service and privacy
+						policies. We are not responsible for the practices of these third-party services.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">8. Intellectual Property</h2>
+					<p class="text-gray-700">
+						The Freundebuch application, including its original content, features, and functionality, is owned
+						by its creators and is protected by international copyright, trademark, patent, trade secret, and
+						other intellectual property laws.
+					</p>
+					<p class="text-gray-700 mt-4">
+						Freundebuch is open source software. The source code is available under the terms of its license,
+						which can be found in the project's
+						<a href="https://github.com/datenknoten/freundebuch" class="text-forest hover:text-forest-light" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">9. Disclaimer of Warranties</h2>
+					<p class="text-gray-700">
+						THE SERVICE IS PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS WITHOUT ANY WARRANTIES OF ANY KIND,
+						EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE</li>
+						<li>WARRANTIES OF NON-INFRINGEMENT</li>
+						<li>WARRANTIES THAT THE SERVICE WILL BE UNINTERRUPTED, SECURE, OR ERROR-FREE</li>
+						<li>WARRANTIES REGARDING THE ACCURACY OR RELIABILITY OF ANY INFORMATION OBTAINED THROUGH THE SERVICE</li>
+					</ul>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">10. Limitation of Liability</h2>
+					<p class="text-gray-700">
+						TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL THE SERVICE OPERATORS, DEVELOPERS, OR
+						CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES,
+						INCLUDING WITHOUT LIMITATION:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>Loss of profits, data, use, goodwill, or other intangible losses</li>
+						<li>Damages resulting from unauthorized access to or alteration of your data</li>
+						<li>Damages resulting from any interruption or cessation of the service</li>
+						<li>Damages resulting from any bugs, viruses, or other harmful code transmitted through the service</li>
+					</ul>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">11. Data Portability and Export</h2>
+					<p class="text-gray-700">
+						You have the right to export your data at any time. Freundebuch supports standard data formats
+						including vCard for contacts. You can export your data through the application's settings or by
+						contacting the administrator of your Freundebuch instance.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">12. Account Termination</h2>
+					<p class="text-gray-700">
+						You may terminate your account at any time by contacting the administrator of your Freundebuch instance
+						or using the account deletion feature if available. Upon termination:
+					</p>
+					<ul class="list-disc pl-6 text-gray-700 space-y-2 mt-3">
+						<li>Your account will be deactivated</li>
+						<li>Your personal data will be deleted in accordance with our Privacy Policy</li>
+						<li>We recommend exporting your data before terminating your account</li>
+					</ul>
+					<p class="text-gray-700 mt-4">
+						The service operator reserves the right to terminate or suspend your account if you violate these
+						Terms of Service.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">13. Governing Law</h2>
+					<p class="text-gray-700">
+						These Terms shall be governed by and construed in accordance with the laws of the jurisdiction in
+						which the Freundebuch instance is hosted, without regard to its conflict of law provisions.
+						For instances hosted within the European Union, GDPR and other applicable EU regulations apply.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">14. Changes to Terms</h2>
+					<p class="text-gray-700">
+						We reserve the right to modify or replace these Terms at any time. If a revision is material, we
+						will provide at least 30 days' notice prior to any new terms taking effect. What constitutes a
+						material change will be determined at our sole discretion.
+					</p>
+					<p class="text-gray-700 mt-4">
+						By continuing to access or use our service after those revisions become effective, you agree to be
+						bound by the revised terms.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">15. Severability</h2>
+					<p class="text-gray-700">
+						If any provision of these Terms is held to be unenforceable or invalid, such provision will be
+						changed and interpreted to accomplish the objectives of such provision to the greatest extent
+						possible under applicable law, and the remaining provisions will continue in full force and effect.
+					</p>
+				</section>
+
+				<section>
+					<h2 class="text-2xl font-heading text-gray-800 mt-8 mb-4">16. Contact Us</h2>
+					<p class="text-gray-700">
+						If you have any questions about these Terms of Service, please contact the operator of this
+						Freundebuch instance or reach out through the project's
+						<a href="https://github.com/datenknoten/freundebuch" class="text-forest hover:text-forest-light" target="_blank" rel="noopener noreferrer">GitHub repository</a>.
+					</p>
+				</section>
+			</div>
+
+			<div class="mt-10 pt-6 border-t border-gray-200">
+				<a
+					href="/"
+					class="text-sm text-gray-500 hover:text-forest font-body flex items-center gap-1"
+				>
+					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+					</svg>
+					Back to Home
+				</a>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Add a comprehensive Terms of Service page following the same structure
and styling as the Privacy Policy page. The ToS covers acceptance of
terms, service description, user accounts, acceptable use, user content,
self-hosted instances, third-party services, intellectual property,
disclaimers, liability limitations, data portability, account termination,
governing law, and contact information.

Also adds navigation links to the Terms of Service in both the desktop
footer and mobile navigation menu.