### PR TITLE
fix(frontend): Redirect existing users to onboarding when required

### DIFF
--- a/apps/frontend/src/lib/api/address-lookup.ts
+++ b/apps/frontend/src/lib/api/address-lookup.ts
@@ -1,5 +1,5 @@
 import { get } from 'svelte/store';
-import type { CityInfo, CountryInfo, HouseNumberInfo, StreetInfo } from '$shared';
+import type { CityInfo, CountryInfo, ErrorResponse, HouseNumberInfo, StreetInfo } from '$shared';
 import { auth } from '../stores/auth.js';
 import { ApiError } from './auth.js';
 
@@ -37,11 +37,11 @@ async function apiRequest<T>(endpoint: string): Promise<T> {
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({
+    const errorData: ErrorResponse = await response.json().catch(() => ({
       error: 'An unknown error occurred',
     }));
 
-    throw new ApiError(response.status, errorData.error, errorData.details);
+    throw new ApiError(response.status, errorData.error, errorData.code, errorData.details);
   }
 
   return response.json();

--- a/apps/frontend/src/lib/api/app-passwords.ts
+++ b/apps/frontend/src/lib/api/app-passwords.ts
@@ -1,4 +1,5 @@
 import { get } from 'svelte/store';
+import type { ErrorResponse } from '$shared';
 import { auth } from '../stores/auth.js';
 import { ApiError } from './auth.js';
 
@@ -47,11 +48,11 @@ async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promi
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({
+    const errorData: ErrorResponse = await response.json().catch(() => ({
       error: 'An unknown error occurred',
     }));
 
-    throw new ApiError(response.status, errorData.error, errorData.details);
+    throw new ApiError(response.status, errorData.error, errorData.code, errorData.details);
   }
 
   return response.json();

--- a/apps/frontend/src/lib/api/auth.ts
+++ b/apps/frontend/src/lib/api/auth.ts
@@ -24,6 +24,7 @@ export class ApiError extends Error {
   constructor(
     public statusCode: number,
     message: string,
+    public code?: string,
     public details?: unknown,
   ) {
     super(message);
@@ -51,7 +52,7 @@ async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promi
       error: 'An unknown error occurred',
     }));
 
-    throw new ApiError(response.status, errorData.error, errorData.details);
+    throw new ApiError(response.status, errorData.error, errorData.code, errorData.details);
   }
 
   return response.json();

--- a/apps/frontend/src/lib/api/contacts.ts
+++ b/apps/frontend/src/lib/api/contacts.ts
@@ -10,6 +10,7 @@ import type {
   DateInput,
   Email,
   EmailInput,
+  ErrorResponse,
   FacetedSearchResponse,
   FacetFilters,
   GlobalSearchResult,
@@ -67,11 +68,11 @@ async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promi
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({
+    const errorData: ErrorResponse = await response.json().catch(() => ({
       error: 'An unknown error occurred',
     }));
 
-    throw new ApiError(response.status, errorData.error, errorData.details);
+    throw new ApiError(response.status, errorData.error, errorData.code, errorData.details);
   }
 
   return response.json();
@@ -330,11 +331,11 @@ export async function uploadPhoto(contactId: string, file: File): Promise<PhotoU
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({
+    const errorData: ErrorResponse = await response.json().catch(() => ({
       error: 'An unknown error occurred',
     }));
 
-    throw new ApiError(response.status, errorData.error, errorData.details);
+    throw new ApiError(response.status, errorData.error, errorData.code, errorData.details);
   }
 
   return response.json();

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -2,12 +2,13 @@
 import '../app.css';
 import type { Snippet } from 'svelte';
 import { onMount } from 'svelte';
+import { goto } from '$app/navigation';
 import { page } from '$app/stores';
 import Footer from '$lib/components/Footer.svelte';
 import GlobalSearch from '$lib/components/GlobalSearch.svelte';
 import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
 import NavBar from '$lib/components/NavBar.svelte';
-import { auth, isAuthenticated } from '$lib/stores/auth';
+import { auth, isAuthenticated, isAuthInitialized, needsOnboarding } from '$lib/stores/auth';
 
 interface Props {
   children: Snippet;
@@ -18,6 +19,20 @@ let { children }: Props = $props();
 // Initialize auth state on app load
 onMount(async () => {
   await auth.initialize();
+});
+
+// Routes exempt from onboarding redirect
+const onboardingExemptPaths = ['/onboarding', '/auth/'];
+
+// Redirect to onboarding if user needs to complete it
+$effect(() => {
+  if ($isAuthInitialized && $needsOnboarding) {
+    const currentPath = $page.url.pathname;
+    const isExempt = onboardingExemptPaths.some((path) => currentPath.startsWith(path));
+    if (!isExempt) {
+      goto('/onboarding');
+    }
+  }
 });
 
 // Hide FAB on new contact page

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -99,5 +99,6 @@ export type ResetPasswordRequest = typeof ResetPasswordRequestSchema.infer;
 // Error response
 export interface ErrorResponse {
   error: string;
+  code?: string;
   details?: unknown;
 }


### PR DESCRIPTION
Existing users who hadn't completed the self-contact onboarding were
seeing a broken app state because the frontend wasn't properly handling
the ONBOARDING_REQUIRED error from the API.

Changes:
- Add error code field to ApiError class to capture backend error codes
- Update all apiRequest functions to extract the code from error responses
- Add client-side redirect in root layout using needsOnboarding store
- Users needing onboarding are now automatically redirected to /onboarding