### PR TITLE
fix(frontend): Use requestAnimationFrame for input focus to open mobile keyboard

### DIFF
--- a/apps/frontend/src/lib/components/contacts/ContactForm.svelte
+++ b/apps/frontend/src/lib/components/contacts/ContactForm.svelte
@@ -92,8 +92,12 @@ const isLoading = $derived(externalIsLoading ?? internalIsLoading);
 let error = $state('');
 
 // Focus firstname input when form opens
+// Use requestAnimationFrame to ensure the browser has completed layout
+// before focusing, which is required for mobile keyboards to open reliably
 onMount(() => {
-  firstNameInput?.focus();
+  requestAnimationFrame(() => {
+    firstNameInput?.focus();
+  });
 });
 
 // Photo handling


### PR DESCRIPTION
Mobile browsers require focus to happen after layout completes for the
keyboard to open reliably. Wrapping the focus() call in requestAnimationFrame
ensures the browser has finished rendering before attempting to focus the
first name input field.