### PR TITLE
Debug CardDAV server returning 404 errors

### DIFF
--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -59,12 +59,13 @@ http {
         index index.html;
 
         # Well-known CardDAV/CalDAV discovery (RFC 6764)
+        # Use absolute HTTPS URLs since nginx is behind Traefik SSL termination
         location = /.well-known/carddav {
-            return 301 /carddav/;
+            return 301 https://$host/carddav/;
         }
 
         location = /.well-known/caldav {
-            return 301 /caldav/;
+            return 301 https://$host/caldav/;
         }
 
         # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)


### PR DESCRIPTION
Nginx is behind Traefik SSL termination, so relative redirects were being interpreted as HTTP by CardDAV clients, breaking discovery.

Fixes CardDAV client discovery for Thunderbird and iOS Contacts.