### PR TITLE
Fix UUID comparison error in database queries

### DIFF
--- a/apps/backend/src/utils/db.ts
+++ b/apps/backend/src/utils/db.ts
@@ -18,7 +18,7 @@ function enhanceErrorWithStack(error: unknown, callSiteStack: string): Error {
   const callSiteFrames = callSiteStack
     .split('\n')
     .slice(1) // Remove the "Error" line
-    .filter((line) => !line.includes('db.ts')) // Remove our wrapper frames
+    .filter((line) => !line.includes('/db.js') && !line.includes('/db.ts')) // Remove our wrapper frames
     .join('\n');
 
   err.stack = `${originalStack}\n    --- Query initiated from ---\n${callSiteFrames}`;


### PR DESCRIPTION
Wrap pg Pool and PoolClient to capture call site stack traces before async database operations. When errors occur, the original call stack is appended to show which route/service initiated the query, fixing the issue where only pg-pool internals appeared in error stack traces.