### PR TITLE
refactor(frontend): Extract shared autoFocus action and AlertBanner component

### DIFF
--- a/apps/frontend/src/lib/actions/autoFocus.ts
+++ b/apps/frontend/src/lib/actions/autoFocus.ts
@@ -1,0 +1,10 @@
+/**
+ * Svelte action that focuses an element on mount.
+ * Use with `use:autoFocus` on any focusable element.
+ *
+ * @example
+ * <input use:autoFocus type="text" />
+ */
+export function autoFocus(node: HTMLElement): void {
+  node.focus();
+}

--- a/apps/frontend/src/lib/components/AlertBanner.svelte
+++ b/apps/frontend/src/lib/components/AlertBanner.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+interface Props {
+  /** The variant/type of alert */
+  variant: 'error' | 'success' | 'warning' | 'info';
+  /** Content to display in the alert */
+  children: Snippet;
+}
+
+let { variant, children }: Props = $props();
+
+const variantClasses = {
+  error: 'bg-red-50 border-red-200 text-red-800',
+  success: 'bg-green-50 border-green-200 text-green-800',
+  warning: 'bg-yellow-50 border-yellow-200 text-yellow-800',
+  info: 'bg-blue-50 border-blue-200 text-blue-800',
+};
+</script>
+
+<div
+  class="border px-4 py-3 rounded-lg font-body text-sm {variantClasses[variant]}"
+  role="alert"
+>
+  {@render children()}
+</div>

--- a/apps/frontend/src/lib/components/AppPasswordManager.svelte
+++ b/apps/frontend/src/lib/components/AppPasswordManager.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import type { AppPassword, CreateAppPasswordResult } from '$lib/api/app-passwords';
 import * as appPasswordsApi from '$lib/api/app-passwords';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 
 let passwords = $state<AppPassword[]>([]);
 let isLoading = $state(true);
@@ -75,12 +76,7 @@ function formatDate(dateString: string | null): string {
 
 <div class="space-y-6">
   {#if error}
-    <div
-      class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-      role="alert"
-    >
-      {error}
-    </div>
+    <AlertBanner variant="error">{error}</AlertBanner>
   {/if}
 
   {#if createdPassword}

--- a/apps/frontend/src/lib/components/ForgotPasswordForm.svelte
+++ b/apps/frontend/src/lib/components/ForgotPasswordForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import * as authApi from '$lib/api/auth';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 
 let email = $state('');
 let isLoading = $state(false);
@@ -33,19 +34,11 @@ async function handleSubmit(e) {
 	</div>
 
 	{#if error}
-		<div
-			class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-			role="alert"
-		>
-			{error}
-		</div>
+		<AlertBanner variant="error">{error}</AlertBanner>
 	{/if}
 
 	{#if success}
-		<div
-			class="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg font-body text-sm"
-			role="alert"
-		>
+		<AlertBanner variant="success">
 			<p class="font-semibold mb-2">Password reset link sent!</p>
 			<p>If the email exists, a password reset link has been sent. Please check your inbox.</p>
 
@@ -70,7 +63,7 @@ async function handleSubmit(e) {
 					</a>
 				</div>
 			{/if}
-		</div>
+		</AlertBanner>
 	{/if}
 
 	{#if !success}

--- a/apps/frontend/src/lib/components/LoginForm.svelte
+++ b/apps/frontend/src/lib/components/LoginForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 import { auth } from '$lib/stores/auth';
 
 let email = $state('');
@@ -30,12 +31,7 @@ async function handleSubmit(e) {
 	</div>
 
 	{#if error}
-		<div
-			class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-			role="alert"
-		>
-			{error}
-		</div>
+		<AlertBanner variant="error">{error}</AlertBanner>
 	{/if}
 
 	<div>

--- a/apps/frontend/src/lib/components/RegisterForm.svelte
+++ b/apps/frontend/src/lib/components/RegisterForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 import { auth } from '$lib/stores/auth';
 
 let email = $state('');
@@ -43,12 +44,7 @@ async function handleSubmit(e) {
 	</div>
 
 	{#if error}
-		<div
-			class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-			role="alert"
-		>
-			{error}
-		</div>
+		<AlertBanner variant="error">{error}</AlertBanner>
 	{/if}
 
 	<div>

--- a/apps/frontend/src/lib/components/ResetPasswordForm.svelte
+++ b/apps/frontend/src/lib/components/ResetPasswordForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
 import * as authApi from '$lib/api/auth';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 
 let { token } = $props();
 
@@ -50,22 +51,14 @@ async function handleSubmit(e) {
 	</div>
 
 	{#if error}
-		<div
-			class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-			role="alert"
-		>
-			{error}
-		</div>
+		<AlertBanner variant="error">{error}</AlertBanner>
 	{/if}
 
 	{#if success}
-		<div
-			class="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg font-body text-sm"
-			role="alert"
-		>
+		<AlertBanner variant="success">
 			<p class="font-semibold mb-2">Password reset successful!</p>
 			<p>Your password has been reset. Redirecting to login...</p>
-		</div>
+		</AlertBanner>
 	{:else}
 		<div>
 			<label for="password" class="block text-sm font-body font-semibold text-gray-700 mb-2">

--- a/apps/frontend/src/lib/components/friends/FriendForm.svelte
+++ b/apps/frontend/src/lib/components/friends/FriendForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { goto } from '$app/navigation';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 import { friends } from '$lib/stores/friends';
 import type { Friend, FriendCreateInput } from '$shared';
 import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from '$shared';
@@ -272,12 +273,7 @@ async function handleSubmit(e: Event) {
 
 <form onsubmit={handleSubmit} class="space-y-6">
   {#if error}
-    <div
-      class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-      role="alert"
-    >
-      {error}
-    </div>
+    <AlertBanner variant="error">{error}</AlertBanner>
   {/if}
 
   <!-- Avatar with photo upload -->

--- a/apps/frontend/src/lib/components/friends/subresources/AddressEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/AddressEditForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { autoFocus } from '$lib/actions/autoFocus';
 import type { Address, AddressInput, AddressType } from '$shared';
 import HierarchicalAddressInput from '../HierarchicalAddressInput.svelte';
 
@@ -14,11 +15,6 @@ let { initialData, disabled = false, onchange }: Props = $props();
 let addressType = $state<AddressType>((() => initialData?.addressType ?? 'home')());
 let label = $state((() => initialData?.label ?? '')());
 let isPrimary = $state((() => initialData?.isPrimary ?? false)());
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Address data from HierarchicalAddressInput
 let addressData = $state<{

--- a/apps/frontend/src/lib/components/friends/subresources/CircleEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/CircleEditForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import { autoFocus } from '$lib/actions/autoFocus';
 import CircleChip from '$lib/components/circles/CircleChip.svelte';
 import { circles, circlesList } from '$lib/stores/circles';
 import type { Circle, CircleSummary } from '$shared';
@@ -15,11 +16,6 @@ let { existingCircles = [], disabled = false, onchange }: Props = $props();
 
 // Form state
 let selectedCircleId = $state('');
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Load circles on mount if not already loaded
 onMount(() => {

--- a/apps/frontend/src/lib/components/friends/subresources/DateEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/DateEditForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { autoFocus } from '$lib/actions/autoFocus';
 import type { DateInput, DateType, FriendDate } from '$shared';
 
 interface Props {
@@ -14,11 +15,6 @@ let dateValue = $state((() => initialData?.dateValue ?? '')());
 let yearKnown = $state((() => initialData?.yearKnown ?? true)());
 let dateType = $state<DateType>((() => initialData?.dateType ?? 'birthday')());
 let label = $state((() => initialData?.label ?? '')());
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Skip initial effect run
 let initialized = false;

--- a/apps/frontend/src/lib/components/friends/subresources/EmailEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/EmailEditForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { autoFocus } from '$lib/actions/autoFocus';
 import type { Email, EmailInput, EmailType } from '$shared';
 
 interface Props {
@@ -14,11 +15,6 @@ let emailAddress = $state((() => initialData?.emailAddress ?? '')());
 let emailType = $state<EmailType>((() => initialData?.emailType ?? 'personal')());
 let label = $state((() => initialData?.label ?? '')());
 let isPrimary = $state((() => initialData?.isPrimary ?? false)());
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Skip initial effect run
 let initialized = false;

--- a/apps/frontend/src/lib/components/friends/subresources/PhoneEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/PhoneEditForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { autoFocus } from '$lib/actions/autoFocus';
 import type { Phone, PhoneInput, PhoneType } from '$shared';
 
 interface Props {
@@ -14,11 +15,6 @@ let phoneNumber = $state((() => initialData?.phoneNumber ?? '')());
 let phoneType = $state<PhoneType>((() => initialData?.phoneType ?? 'mobile')());
 let label = $state((() => initialData?.label ?? '')());
 let isPrimary = $state((() => initialData?.isPrimary ?? false)());
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Skip initial effect run
 let initialized = false;

--- a/apps/frontend/src/lib/components/friends/subresources/SocialProfileEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/SocialProfileEditForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { autoFocus } from '$lib/actions/autoFocus';
 import type { SocialPlatform, SocialProfile, SocialProfileInput } from '$shared';
 
 interface Props {
@@ -13,11 +14,6 @@ let { initialData, disabled = false, onchange }: Props = $props();
 let platform = $state<SocialPlatform>((() => initialData?.platform ?? 'linkedin')());
 let profileUrl = $state((() => initialData?.profileUrl ?? '')());
 let username = $state((() => initialData?.username ?? '')());
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Skip initial effect run
 let initialized = false;

--- a/apps/frontend/src/lib/components/friends/subresources/UrlEditForm.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/UrlEditForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { autoFocus } from '$lib/actions/autoFocus';
 import type { Url, UrlInput, UrlType } from '$shared';
 
 interface Props {
@@ -13,11 +14,6 @@ let { initialData, disabled = false, onchange }: Props = $props();
 let url = $state((() => initialData?.url ?? '')());
 let urlType = $state<UrlType>((() => initialData?.urlType ?? 'personal')());
 let label = $state((() => initialData?.label ?? '')());
-
-// Auto-focus action - runs only once on mount
-function autoFocus(node: HTMLElement) {
-  node.focus();
-}
 
 // Skip initial effect run
 let initialized = false;

--- a/apps/frontend/src/routes/circles/+page.svelte
+++ b/apps/frontend/src/routes/circles/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 import CircleChip from '$lib/components/circles/CircleChip.svelte';
 import { isAuthInitialized } from '$lib/stores/auth';
 import { circles, circlesList } from '$lib/stores/circles';
@@ -199,8 +200,8 @@ let hierarchicalCircles = $derived(renderCircleTree(null, 0));
           </h2>
 
           {#if formError}
-            <div class="mb-4 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm" role="alert">
-              {formError}
+            <div class="mb-4">
+              <AlertBanner variant="error">{formError}</AlertBanner>
             </div>
           {/if}
 
@@ -310,8 +311,8 @@ let hierarchicalCircles = $derived(renderCircleTree(null, 0));
               {/if}
             </p>
             {#if formError}
-              <div class="mb-4 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm" role="alert">
-                {formError}
+              <div class="mb-4">
+                <AlertBanner variant="error">{formError}</AlertBanner>
               </div>
             {/if}
             <div class="flex gap-3">
@@ -340,9 +341,7 @@ let hierarchicalCircles = $derived(renderCircleTree(null, 0));
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-forest"></div>
         </div>
       {:else if $circles.error}
-        <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm" role="alert">
-          {$circles.error}
-        </div>
+        <AlertBanner variant="error">{$circles.error}</AlertBanner>
       {:else if $circlesList.length === 0}
         <div class="text-center py-12">
           <svg class="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/apps/frontend/src/routes/onboarding/+page.svelte
+++ b/apps/frontend/src/routes/onboarding/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
 import * as authApi from '$lib/api/auth';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 import FriendForm from '$lib/components/friends/FriendForm.svelte';
 import { auth, refreshUserData } from '$lib/stores/auth';
 import type { FriendCreateInput } from '$shared';
@@ -44,11 +45,8 @@ async function handleSubmit(data: FriendCreateInput) {
       </p>
 
       {#if error}
-        <div
-          class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg mb-6 font-body text-sm"
-          role="alert"
-        >
-          {error}
+        <div class="mb-6">
+          <AlertBanner variant="error">{error}</AlertBanner>
         </div>
       {/if}
 

--- a/apps/frontend/src/routes/profile/+page.svelte
+++ b/apps/frontend/src/routes/profile/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import * as authApi from '$lib/api/auth';
+import AlertBanner from '$lib/components/AlertBanner.svelte';
 import AppPasswordManager from '$lib/components/AppPasswordManager.svelte';
 import CardDAVSetupGuide from '$lib/components/CardDAVSetupGuide.svelte';
 import { auth, birthdayFormat, currentUser } from '$lib/stores/auth';
@@ -71,20 +72,14 @@ function handleBirthdayFormatChange(format: BirthdayFormat) {
 			</div>
 
 			{#if error}
-				<div
-					class="mb-6 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg font-body text-sm"
-					role="alert"
-				>
-					{error}
+				<div class="mb-6">
+					<AlertBanner variant="error">{error}</AlertBanner>
 				</div>
 			{/if}
 
 			{#if success}
-				<div
-					class="mb-6 bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg font-body text-sm"
-					role="alert"
-				>
-					Profile updated successfully!
+				<div class="mb-6">
+					<AlertBanner variant="success">Profile updated successfully!</AlertBanner>
 				</div>
 			{/if}
 


### PR DESCRIPTION
## Summary

- Create reusable `autoFocus` Svelte action in `src/lib/actions/autoFocus.ts`
- Create `AlertBanner` component with `error`/`success`/`warning`/`info` variants
- Update 7 edit forms to use shared autoFocus action
- Update 9 files (12 alert instances) to use AlertBanner component

## Changes

### New files
- `src/lib/actions/autoFocus.ts` - Svelte action for focusing elements on mount
- `src/lib/components/AlertBanner.svelte` - Reusable alert component with 4 variants

### Updated files
**autoFocus action (7 files):**
- DateEditForm, EmailEditForm, PhoneEditForm, AddressEditForm, UrlEditForm, SocialProfileEditForm, CircleEditForm

**AlertBanner component (9 files):**
- LoginForm, RegisterForm, ResetPasswordForm, ForgotPasswordForm, AppPasswordManager
- FriendForm, profile/+page, onboarding/+page, circles/+page

## Impact
- Removed ~70 lines of duplicated code
- Consistent styling across all alerts
- Single source of truth for both patterns

## Test plan
- [x] Type check passes (0 errors)
- [x] Build succeeds
- [x] All pre-commit and pre-push checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)