### PR TITLE
Upgrade PHP to version 8.4 in production

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -28,7 +28,7 @@ environment=NODE_ENV="production"
 priority=20
 
 [program:php-fpm]
-command=/usr/sbin/php-fpm8.2 -F
+command=/usr/sbin/php-fpm8.4 -F
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Switch base images from Bookworm to Trixie which includes PHP 8.4 natively, eliminating the need for external repositories.