### PR TITLE
ci: switch from Depot to standard GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
   test:
     name: Unit and Integration Tests
-    runs-on: depot-ubuntu-24.04-arm-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     name: Build Docker Image
     needs: release
     if: needs.release.outputs.new_release_published == 'true'
-    runs-on: depot-ubuntu-24.04-arm-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Replace depot-ubuntu-24.04-arm-8 with ubuntu-latest in CI test job
and release Docker build job.