### PR TITLE
fix(frontend): Preserve scroll position during subresource operations

### DIFF
--- a/apps/frontend/src/routes/friends/[id]/+page.svelte
+++ b/apps/frontend/src/routes/friends/[id]/+page.svelte
@@ -45,7 +45,7 @@ const backUrl = $derived.by(() => {
         Back to Friends
       </a>
 
-      {#if $isFriendsLoading}
+      {#if $isFriendsLoading && !$currentFriend}
         <div class="flex justify-center py-12">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-forest"></div>
         </div>


### PR DESCRIPTION
Show loading spinner only during initial page load, not during subresource
add/edit/delete operations. This prevents the FriendDetail component from
being unmounted and remounted, which was causing the window to scroll to top.