### PR TITLE
fix(frontend): Debounce URL updates in search to prevent pushState spam

### DIFF
--- a/apps/frontend/src/lib/components/friends/FriendList.svelte
+++ b/apps/frontend/src/lib/components/friends/FriendList.svelte
@@ -92,9 +92,6 @@ function handleSearchInput(value: string) {
   searchError = null;
   searchPage = 1; // Reset to first page on new search
 
-  // Notify parent of query change
-  onQueryChange?.(value);
-
   // Clear any pending debounce
   if (debounceTimer) {
     clearTimeout(debounceTimer);
@@ -108,12 +105,16 @@ function handleSearchInput(value: string) {
     searchTotal = 0;
     searchTotalPages = 0;
     isSearching = false;
+    // Notify parent of query change (debounced to prevent pushState spam)
+    onQueryChange?.(value);
     return;
   }
 
   isSearching = true;
 
   debounceTimer = setTimeout(async () => {
+    // Notify parent of query change (debounced to prevent pushState spam)
+    onQueryChange?.(value);
     await performSearch();
   }, 300);
 }


### PR DESCRIPTION
Move onQueryChange callback inside the debounced timeout to prevent
excessive history.pushState() calls when typing quickly in the search
input. Previously, the callback was called immediately on every
keystroke which could trigger >100 pushState calls in 10 seconds,
causing a SecurityError in browsers.

Fixes: FREUNDEBUCH-FRONTEND-M