### PR TITLE
feat(all): Add MCP server for LLM data access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,25 @@ jobs:
           # backend - amd64
           - image: backend
             dockerfile: docker/Dockerfile.backend.prod
+            target: backend
             platform: linux/amd64
             arch: amd64
           # backend - arm64
           - image: backend
             dockerfile: docker/Dockerfile.backend.prod
+            target: backend
+            platform: linux/arm64
+            arch: arm64
+          # mcp-server - amd64 (shares Dockerfile.backend.prod)
+          - image: mcp-server
+            dockerfile: docker/Dockerfile.backend.prod
+            target: mcp-server
+            platform: linux/amd64
+            arch: amd64
+          # mcp-server - arm64 (shares Dockerfile.backend.prod)
+          - image: mcp-server
+            dockerfile: docker/Dockerfile.backend.prod
+            target: mcp-server
             platform: linux/arm64
             arch: arm64
           # sabredav - amd64
@@ -167,6 +181,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target || '' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -196,6 +211,7 @@ jobs:
         image:
           - nginx
           - backend
+          - mcp-server
           - sabredav
           - osm-import
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,16 +103,14 @@ jobs:
             dockerfile: docker/Dockerfile.nginx.prod
             platform: linux/arm64
             arch: arm64
-          # backend - amd64
+          # backend - amd64 (default stage of Dockerfile.backend.prod, no --target needed)
           - image: backend
             dockerfile: docker/Dockerfile.backend.prod
-            target: backend
             platform: linux/amd64
             arch: amd64
           # backend - arm64
           - image: backend
             dockerfile: docker/Dockerfile.backend.prod
-            target: backend
             platform: linux/arm64
             arch: arm64
           # mcp-server - amd64 (shares Dockerfile.backend.prod)
@@ -181,7 +179,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          target: ${{ matrix.target || '' }}
+          target: ${{ matrix.target }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ COPY tsconfig.base.json ./
 # Copy all package.json files for dependency resolution
 COPY apps/backend/package.json ./apps/backend/
 COPY apps/frontend/package.json ./apps/frontend/
+COPY apps/mcp-server/package.json ./apps/mcp-server/
 COPY packages/shared/package.json ./packages/shared/
 
 # Install all dependencies with cache mount for pnpm store
@@ -81,6 +82,15 @@ COPY apps/backend ./apps/backend
 COPY database ./database
 RUN pnpm --filter @freundebuch/backend run build && \
     pnpm run migrate:build
+
+# ============================================
+# Stage: Build MCP server
+# Runs in parallel with backend-builder and frontend-builder
+# ============================================
+FROM backend-builder AS mcp-server-builder
+
+COPY apps/mcp-server ./apps/mcp-server
+RUN pnpm --filter @freundebuch/mcp-server run build
 
 # ============================================
 # Stage: Build frontend (static)
@@ -110,6 +120,7 @@ COPY docker/php-fpm-pool.conf /etc/php/8.2/fpm/pool.d/zz-logging.conf
 # Copy workspace configuration for production dependencies
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY apps/backend/package.json ./apps/backend/
+COPY apps/mcp-server/package.json ./apps/mcp-server/
 COPY packages/shared/package.json ./packages/shared/
 
 # Install production dependencies only with cache mount
@@ -119,6 +130,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # Copy built artifacts from parallel build stages
 COPY --from=shared-builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=backend-builder /app/apps/backend/dist ./apps/backend/dist
+COPY --from=mcp-server-builder /app/apps/mcp-server/dist ./apps/mcp-server/dist
 COPY --from=frontend-builder /app/apps/frontend/build ./apps/frontend/build
 
 # Copy compiled database migrations

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,6 +4,16 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./src/*",
+      "default": "./dist/*"
+    }
+  },
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc --project tsconfig.build.json",

--- a/apps/backend/src/services/app-passwords.service.ts
+++ b/apps/backend/src/services/app-passwords.service.ts
@@ -16,6 +16,14 @@ const SALT_ROUNDS = 10;
 const PASSWORD_LENGTH = 24; // 24 bytes = 32 chars in base64url
 const MAX_APP_PASSWORDS_PER_USER = 20;
 
+// Format: raw base64url password split into CHUNK-char chunks joined by '-'.
+// A well-formatted input has length `chunks * CHUNK + (chunks - 1)` — i.e.
+// `(length + 1) % (CHUNK + 1) === 0`. Separators sit at positions where
+// `i % (CHUNK + 1) === CHUNK`. Kept as a constant so format/unformat stay
+// in sync.
+const FORMAT_CHUNK_SIZE = 4;
+const FORMAT_STRIDE = FORMAT_CHUNK_SIZE + 1; // chunk + one separator
+
 export class MaxAppPasswordsExceededError extends AppError {
   readonly statusCode = 429;
 
@@ -55,12 +63,40 @@ export class AppPasswordsService {
    * Format raw bytes as a readable password (xxxx-xxxx-xxxx-xxxx)
    */
   private formatPassword(password: string): string {
-    // Split into chunks of 4 characters and join with dashes
     const chunks: string[] = [];
-    for (let i = 0; i < password.length; i += 4) {
-      chunks.push(password.slice(i, i + 4));
+    for (let i = 0; i < password.length; i += FORMAT_CHUNK_SIZE) {
+      chunks.push(password.slice(i, i + FORMAT_CHUNK_SIZE));
     }
     return chunks.join('-');
+  }
+
+  /**
+   * Invert formatPassword: remove only the separator dashes inserted at every
+   * FORMAT_STRIDE-th position, preserving any '-' that are part of the
+   * original base64url raw password (base64url alphabet includes '-').
+   *
+   * Fallback behavior: if the input either doesn't have a well-formatted length
+   * or has a non-dash character at a separator slot, fall back to stripping
+   * all dashes. This preserves legacy behavior for malformed input — garbage
+   * into bcrypt simply fails the compare and produces a 401.
+   */
+  private unformatPassword(input: string): string {
+    const hasWellFormattedLength =
+      input.length >= FORMAT_STRIDE && (input.length + 1) % FORMAT_STRIDE === 0;
+    if (!hasWellFormattedLength) {
+      return input.replace(/-/g, '');
+    }
+    let out = '';
+    for (let i = 0; i < input.length; i++) {
+      if (i % FORMAT_STRIDE === FORMAT_CHUNK_SIZE) {
+        if (input[i] !== '-') {
+          return input.replace(/-/g, '');
+        }
+        continue;
+      }
+      out += input[i];
+    }
+    return out;
   }
 
   /**
@@ -176,8 +212,10 @@ export class AppPasswordsService {
   async verifyAppPassword(email: string, password: string): Promise<BasicAuthContext | null> {
     this.logger.debug({ email }, 'Verifying app password');
 
-    // Remove dashes from formatted password
-    const rawPassword = password.replace(/-/g, '');
+    // Invert formatPassword to recover the raw base64url password. Must preserve
+    // '-' characters that are part of the base64url alphabet; only strip the
+    // dashes inserted as separators by formatPassword.
+    const rawPassword = this.unformatPassword(password);
     const prefix = rawPassword.substring(0, 8);
 
     // Get user by email

--- a/apps/backend/tests/services/app-passwords.service.test.ts
+++ b/apps/backend/tests/services/app-passwords.service.test.ts
@@ -294,6 +294,67 @@ describe('AppPasswordsService', () => {
       expect(result?.userId).toBe(VALID_USER_ID);
     });
 
+    it('should preserve raw dashes that are part of base64url', async () => {
+      // Regression: verifyAppPassword used to strip ALL dashes, corrupting passwords
+      // whose base64url raw contains '-' (a valid base64url char).
+      // Raw: 32-char base64url with embedded '-'. Format inserts '-' after each 4 chars:
+      // "AAAA" | "-BBB" | "CCCC" | "DDDD" | "EEEE" | "FFFF" | "GGGG" | "HHHH"
+      // → "AAAA--BBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH"
+      const rawPassword = 'AAAA-BBBCCCCDDDDEEEEFFFFGGGGHHHH';
+      const formattedPassword = 'AAAA--BBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH';
+      const passwordHash = await bcrypt.hash(rawPassword, 10);
+
+      vi.mocked(getUserByEmailWithInternalId.run).mockResolvedValue([
+        { id: 1, external_id: VALID_USER_ID, email: testEmail },
+      ]);
+      vi.mocked(getAppPasswordsByUserIdAndPrefix.run).mockResolvedValue([
+        {
+          id: 1,
+          external_id: VALID_PASSWORD_ID,
+          password_hash: passwordHash,
+        },
+      ]);
+      vi.mocked(updateAppPasswordLastUsed.run).mockResolvedValue([]);
+
+      const result = await service.verifyAppPassword(testEmail, formattedPassword);
+
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe(VALID_USER_ID);
+      expect(getAppPasswordsByUserIdAndPrefix.run).toHaveBeenCalledWith(
+        { userId: 1, prefix: 'AAAA-BBB' },
+        mockDb,
+      );
+    });
+
+    it('should fall back to strip-all-dashes when separator slots are malformed', async () => {
+      // Input has well-formatted length (39 chars) but a non-'-' sits where a
+      // format separator should be. Rather than passing the mangled string to
+      // bcrypt, the service falls back to the legacy strip-all-dashes path.
+      // The bcrypt compare still fails (input is malformed), so we get 401.
+      const malformed = 'abcdXefgh-ijkl-mnop-qrst-uvwx-yz12-3456-7890';
+      const hashOfArbitrary = await bcrypt.hash('something-unrelated', 10);
+
+      vi.mocked(getUserByEmailWithInternalId.run).mockResolvedValue([
+        { id: 1, external_id: VALID_USER_ID, email: testEmail },
+      ]);
+      vi.mocked(getAppPasswordsByUserIdAndPrefix.run).mockResolvedValue([
+        {
+          id: 1,
+          external_id: VALID_PASSWORD_ID,
+          password_hash: hashOfArbitrary,
+        },
+      ]);
+
+      const result = await service.verifyAppPassword(testEmail, malformed);
+
+      expect(result).toBeNull();
+      // Prefix derived from fallback: strip all dashes → "abcdXefghijklmnopqrstuvwxyz1234567890"
+      expect(getAppPasswordsByUserIdAndPrefix.run).toHaveBeenCalledWith(
+        expect.objectContaining({ prefix: 'abcdXefg' }),
+        mockDb,
+      );
+    });
+
     it('should update last_used_at on successful verification', async () => {
       const passwordHash = await bcrypt.hash(testPassword, 10);
 

--- a/apps/frontend/src/lib/components/mcp-setup-guide.svelte
+++ b/apps/frontend/src/lib/components/mcp-setup-guide.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+import ExclamationTriangle from 'svelte-heros-v2/ExclamationTriangle.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+import { currentUser } from '$lib/stores/auth';
+
+const i18n = createI18n();
+
+const mcpUrl = $derived(`${typeof window !== 'undefined' ? window.location.origin : ''}/mcp`);
+
+let activeTab = $state<'claude-desktop' | 'claude-code' | 'other'>('claude-desktop');
+let copied = $state(false);
+
+async function copyUrl() {
+  try {
+    await navigator.clipboard.writeText(mcpUrl);
+    copied = true;
+    setTimeout(() => {
+      copied = false;
+    }, 2000);
+  } catch {
+    const input = document.createElement('input');
+    input.value = mcpUrl;
+    document.body.appendChild(input);
+    input.select();
+    document.execCommand('copy');
+    document.body.removeChild(input);
+    copied = true;
+    setTimeout(() => {
+      copied = false;
+    }, 2000);
+  }
+}
+
+const claudeDesktopConfig = $derived(
+  JSON.stringify(
+    {
+      mcpServers: {
+        freundebuch: {
+          type: 'streamable-http',
+          url: mcpUrl,
+          headers: {
+            Authorization: `Basic <base64(${$currentUser?.email ?? 'your@email.com'}:your-app-password)>`,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  ),
+);
+</script>
+
+<div class="space-y-6">
+  <!-- MCP Endpoint URL -->
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <h4 class="font-body font-semibold text-blue-800 mb-2">{$i18n.t('profile.mcp.endpointUrl')}</h4>
+    <div class="flex items-center gap-2">
+      <code class="flex-1 bg-white border border-blue-200 rounded px-3 py-2 font-mono text-sm break-all">
+        {mcpUrl}
+      </code>
+      <button
+        onclick={copyUrl}
+        class="shrink-0 bg-blue-600 text-white px-3 py-2 rounded font-body text-sm hover:bg-blue-700 transition-colors"
+      >
+        {copied ? $i18n.t('profile.mcp.copied') : $i18n.t('profile.mcp.copy')}
+      </button>
+    </div>
+    <p class="font-body text-xs text-blue-600 mt-2">
+      {$i18n.t('profile.mcp.useCredentials', { email: $currentUser?.email })}
+    </p>
+  </div>
+
+  <!-- App Password Reminder -->
+  <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 flex items-start gap-3">
+    <ExclamationTriangle class="w-5 h-5 text-amber-600 shrink-0 mt-0.5" strokeWidth="2" />
+    <div>
+      <p class="font-body text-sm text-amber-800">
+        {$i18n.t('profile.mcp.appPasswordRequired')}
+      </p>
+      <a
+        href="/profile/app-passwords"
+        class="font-body text-sm text-amber-700 underline hover:text-amber-900 mt-1 inline-block"
+      >
+        {$i18n.t('profile.mcp.manageAppPasswords')}
+      </a>
+    </div>
+  </div>
+
+  <!-- Tabbed Setup Instructions -->
+  <div class="border border-gray-200 rounded-lg overflow-hidden">
+    <div class="flex border-b border-gray-200">
+      <button
+        onclick={() => activeTab = 'claude-desktop'}
+        class="flex-1 px-4 py-3 font-body font-medium text-sm transition-colors {activeTab === 'claude-desktop' ? 'bg-white text-forest border-b-2 border-forest' : 'bg-gray-50 text-gray-600 hover:text-gray-800'}"
+      >
+        {$i18n.t('profile.mcp.tabs.claudeDesktop')}
+      </button>
+      <button
+        onclick={() => activeTab = 'claude-code'}
+        class="flex-1 px-4 py-3 font-body font-medium text-sm transition-colors {activeTab === 'claude-code' ? 'bg-white text-forest border-b-2 border-forest' : 'bg-gray-50 text-gray-600 hover:text-gray-800'}"
+      >
+        {$i18n.t('profile.mcp.tabs.claudeCode')}
+      </button>
+      <button
+        onclick={() => activeTab = 'other'}
+        class="flex-1 px-4 py-3 font-body font-medium text-sm transition-colors {activeTab === 'other' ? 'bg-white text-forest border-b-2 border-forest' : 'bg-gray-50 text-gray-600 hover:text-gray-800'}"
+      >
+        {$i18n.t('profile.mcp.tabs.other')}
+      </button>
+    </div>
+
+    <div class="p-6 bg-white">
+      {#if activeTab === 'claude-desktop'}
+        <div class="space-y-4">
+          <p class="font-body text-sm text-gray-700">
+            {$i18n.t('profile.mcp.steps.claudeDesktop.intro')}
+          </p>
+          <ol class="list-decimal list-inside space-y-2 font-body text-sm text-gray-700">
+            <li>{$i18n.t('profile.mcp.steps.claudeDesktop.step1')}</li>
+            <li>{$i18n.t('profile.mcp.steps.claudeDesktop.step2')}</li>
+            <li>{$i18n.t('profile.mcp.steps.claudeDesktop.step3')}</li>
+          </ol>
+          <pre class="bg-gray-50 border border-gray-200 rounded-lg p-4 text-xs font-mono overflow-x-auto">{claudeDesktopConfig}</pre>
+          <p class="font-body text-xs text-gray-500">
+            {$i18n.t('profile.mcp.steps.claudeDesktop.note')}
+          </p>
+        </div>
+      {:else if activeTab === 'claude-code'}
+        <div class="space-y-4">
+          <p class="font-body text-sm text-gray-700">
+            {$i18n.t('profile.mcp.steps.claudeCode.intro')}
+          </p>
+          <pre class="bg-gray-50 border border-gray-200 rounded-lg p-4 text-xs font-mono overflow-x-auto">claude mcp add freundebuch \
+  --transport http \
+  --url {mcpUrl} \
+  --header "Authorization: Basic &lt;base64-credentials&gt;"</pre>
+          <p class="font-body text-xs text-gray-500">
+            {$i18n.t('profile.mcp.steps.claudeCode.note', { email: $currentUser?.email })}
+          </p>
+        </div>
+      {:else}
+        <div class="space-y-4">
+          <p class="font-body text-sm text-gray-700">
+            {$i18n.t('profile.mcp.steps.other.intro')}
+          </p>
+          <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-2 font-body text-sm">
+            <div><span class="font-semibold text-gray-700">{$i18n.t('profile.mcp.steps.other.transport')}:</span> <code class="text-xs">Streamable HTTP</code></div>
+            <div><span class="font-semibold text-gray-700">{$i18n.t('profile.mcp.steps.other.url')}:</span> <code class="text-xs">{mcpUrl}</code></div>
+            <div><span class="font-semibold text-gray-700">{$i18n.t('profile.mcp.steps.other.auth')}:</span> <code class="text-xs">HTTP Basic Auth</code></div>
+            <div><span class="font-semibold text-gray-700">{$i18n.t('profile.mcp.steps.other.username')}:</span> <code class="text-xs">{$currentUser?.email ?? 'your@email.com'}</code></div>
+            <div><span class="font-semibold text-gray-700">{$i18n.t('profile.mcp.steps.other.password')}:</span> <code class="text-xs">{$i18n.t('profile.mcp.steps.other.passwordValue')}</code></div>
+          </div>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/apps/frontend/src/lib/components/mcp-setup-guide.svelte
+++ b/apps/frontend/src/lib/components/mcp-setup-guide.svelte
@@ -66,7 +66,7 @@ const claudeDesktopConfig = $derived(
       </button>
     </div>
     <p class="font-body text-xs text-blue-600 mt-2">
-      {$i18n.t('profile.mcp.useCredentials', { email: $currentUser?.email })}
+      {$i18n.t('profile.mcp.useCredentials', { email: $currentUser?.email ?? 'your@email.com' })}
     </p>
   </div>
 
@@ -135,7 +135,7 @@ const claudeDesktopConfig = $derived(
   --url {mcpUrl} \
   --header "Authorization: Basic &lt;base64-credentials&gt;"</pre>
           <p class="font-body text-xs text-gray-500">
-            {$i18n.t('profile.mcp.steps.claudeCode.note', { email: $currentUser?.email })}
+            {$i18n.t('profile.mcp.steps.claudeCode.note', { email: $currentUser?.email ?? 'your@email.com' })}
           </p>
         </div>
       {:else}

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -666,6 +666,43 @@
         }
       }
     },
+    "mcp": {
+      "title": "MCP-Server-Einrichtung",
+      "subtitle": "Verbinde KI-Assistenten wie Claude mit deinen Freundebuch-Daten über das Model Context Protocol.",
+      "endpointUrl": "MCP-Server-URL",
+      "copy": "Kopieren",
+      "copied": "Kopiert!",
+      "useCredentials": "Verwende deine E-Mail {{email}} und ein App-Passwort zur Authentifizierung.",
+      "appPasswordRequired": "MCP-Zugriff erfordert ein App-Passwort. Du kannst das gleiche App-Passwort für CardDAV und MCP verwenden oder ein separates erstellen.",
+      "manageAppPasswords": "App-Passwörter verwalten",
+      "tabs": {
+        "claudeDesktop": "Claude Desktop",
+        "claudeCode": "Claude Code",
+        "other": "Andere Clients"
+      },
+      "steps": {
+        "claudeDesktop": {
+          "intro": "Füge diese Konfiguration zu deiner Claude Desktop-Konfigurationsdatei hinzu:",
+          "step1": "Öffne die Claude Desktop-Einstellungen",
+          "step2": "Navigiere zum Abschnitt MCP-Server",
+          "step3": "Füge die folgende Konfiguration hinzu (ersetze den Authorization-Header durch deine base64-codierten Zugangsdaten):",
+          "note": "Um die base64-Zugangsdaten zu erstellen, codiere \"deine@email.de:dein-app-passwort\" (ohne Anführungszeichen). Unter macOS/Linux: echo -n \"email:passwort\" | base64"
+        },
+        "claudeCode": {
+          "intro": "Führe diesen Befehl in deinem Terminal aus, um den Freundebuch-MCP-Server hinzuzufügen:",
+          "note": "Ersetze <base64-credentials> durch deine base64-codierte E-Mail und dein App-Passwort. Erstelle sie mit: echo -n \"{{email}}:dein-app-passwort\" | base64"
+        },
+        "other": {
+          "intro": "Verwende die folgenden Verbindungsdaten für jeden MCP-kompatiblen Client:",
+          "transport": "Transport",
+          "url": "URL",
+          "auth": "Authentifizierung",
+          "username": "Benutzername",
+          "password": "Passwort",
+          "passwordValue": "Dein App-Passwort"
+        }
+      }
+    },
     "danger": {
       "title": "Gefahrenzone",
       "deleteAccount": "Konto löschen",
@@ -701,6 +738,10 @@
         "carddav": {
           "title": "CardDAV-Synchronisation",
           "description": "Freunde mit mobilen und Desktop-Apps synchronisieren"
+        },
+        "mcp": {
+          "title": "MCP-Server",
+          "description": "KI-Assistenten mit deinen Freundedaten verbinden"
         }
       },
       "status": {
@@ -719,7 +760,9 @@
         "noChannels": "Keine Kanäle konfiguriert",
         "channelsEnabled": "{{count}} aktiv",
         "carddavReady": "Bereit zur Synchronisation",
-        "carddavNeedsPassword": "Erstelle zuerst ein App-Passwort"
+        "carddavNeedsPassword": "Erstelle zuerst ein App-Passwort",
+        "mcpReady": "Verbindungsbereit",
+        "mcpNeedsPassword": "Erstelle zuerst ein App-Passwort"
       },
       "backToProfile": "Zurück zum Profil"
     }

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -666,6 +666,43 @@
         }
       }
     },
+    "mcp": {
+      "title": "MCP Server Setup",
+      "subtitle": "Connect AI assistants like Claude to your Freundebuch data using the Model Context Protocol.",
+      "endpointUrl": "MCP Server URL",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "useCredentials": "Use your email {{email}} and an app password to authenticate.",
+      "appPasswordRequired": "MCP access requires an app password. You can use the same app password for CardDAV and MCP, or create a separate one.",
+      "manageAppPasswords": "Manage App Passwords",
+      "tabs": {
+        "claudeDesktop": "Claude Desktop",
+        "claudeCode": "Claude Code",
+        "other": "Other Clients"
+      },
+      "steps": {
+        "claudeDesktop": {
+          "intro": "Add this configuration to your Claude Desktop config file:",
+          "step1": "Open Claude Desktop Settings",
+          "step2": "Navigate to the MCP Servers section",
+          "step3": "Add the following configuration (replace the Authorization header with your base64-encoded credentials):",
+          "note": "To create the base64 credentials, encode \"your@email.com:your-app-password\" (without quotes). On macOS/Linux: echo -n \"email:password\" | base64"
+        },
+        "claudeCode": {
+          "intro": "Run this command in your terminal to add the Freundebuch MCP server:",
+          "note": "Replace <base64-credentials> with your base64-encoded email and app password. Create it with: echo -n \"{{email}}:your-app-password\" | base64"
+        },
+        "other": {
+          "intro": "Use the following connection details for any MCP-compatible client:",
+          "transport": "Transport",
+          "url": "URL",
+          "auth": "Authentication",
+          "username": "Username",
+          "password": "Password",
+          "passwordValue": "Your app password"
+        }
+      }
+    },
     "danger": {
       "title": "Danger Zone",
       "deleteAccount": "Delete Account",
@@ -701,6 +738,10 @@
         "carddav": {
           "title": "CardDAV Sync",
           "description": "Sync friends with mobile and desktop apps"
+        },
+        "mcp": {
+          "title": "MCP Server",
+          "description": "Connect AI assistants to your friend data"
         }
       },
       "status": {
@@ -719,7 +760,9 @@
         "noChannels": "No channels configured",
         "channelsEnabled": "{{count}} active",
         "carddavReady": "Ready to sync",
-        "carddavNeedsPassword": "Create an app password first"
+        "carddavNeedsPassword": "Create an app password first",
+        "mcpReady": "Ready to connect",
+        "mcpNeedsPassword": "Create an app password first"
       },
       "backToProfile": "Back to Profile"
     }

--- a/apps/frontend/src/routes/profile/+page.svelte
+++ b/apps/frontend/src/routes/profile/+page.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import ChatBubbleLeft from 'svelte-heros-v2/ChatBubbleLeft.svelte';
 import CloudArrowUp from 'svelte-heros-v2/CloudArrowUp.svelte';
+import CommandLine from 'svelte-heros-v2/CommandLine.svelte';
 import FingerPrint from 'svelte-heros-v2/FingerPrint.svelte';
 import LockClosed from 'svelte-heros-v2/LockClosed.svelte';
 import PaintBrush from 'svelte-heros-v2/PaintBrush.svelte';
@@ -70,6 +71,12 @@ const carddavStatus = $derived(
   appPasswordCount > 0
     ? $i18n.t('profile.hub.status.carddavReady')
     : $i18n.t('profile.hub.status.carddavNeedsPassword'),
+);
+
+const mcpStatus = $derived(
+  appPasswordCount > 0
+    ? $i18n.t('profile.hub.status.mcpReady')
+    : $i18n.t('profile.hub.status.mcpNeedsPassword'),
 );
 </script>
 
@@ -146,6 +153,15 @@ const carddavStatus = $derived(
         status={carddavStatus}
       >
         {#snippet icon()}<CloudArrowUp class="w-5 h-5" strokeWidth="2" />{/snippet}
+      </ProfileCard>
+
+      <ProfileCard
+        href="/profile/mcp"
+        title={$i18n.t('profile.hub.cards.mcp.title')}
+        description={$i18n.t('profile.hub.cards.mcp.description')}
+        status={mcpStatus}
+      >
+        {#snippet icon()}<CommandLine class="w-5 h-5" strokeWidth="2" />{/snippet}
       </ProfileCard>
     </div>
   </section>

--- a/apps/frontend/src/routes/profile/mcp/+page.svelte
+++ b/apps/frontend/src/routes/profile/mcp/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import ChevronLeft from 'svelte-heros-v2/ChevronLeft.svelte';
+import McpSetupGuide from '$lib/components/mcp-setup-guide.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+
+const i18n = createI18n();
+</script>
+
+<svelte:head>
+  <title>{$i18n.t('profile.mcp.title')} | Freundebuch</title>
+</svelte:head>
+
+<div class="bg-white rounded-xl shadow-lg p-8">
+  <div class="mb-8">
+    <a
+      href="/profile"
+      class="inline-flex items-center gap-2 text-gray-600 hover:text-forest font-body text-sm transition-colors"
+    >
+      <ChevronLeft class="w-4 h-4" strokeWidth="2" />
+      {$i18n.t('profile.hub.backToProfile')}
+    </a>
+    <h1 class="text-3xl font-heading text-forest mt-4">{$i18n.t('profile.mcp.title')}</h1>
+    <p class="text-gray-600 font-body mt-1">{$i18n.t('profile.mcp.subtitle')}</p>
+  </div>
+
+  <McpSetupGuide />
+</div>

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freundebuch/mcp-server",
-  "version": "2.68.2",
+  "version": "2.68.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@freundebuch/mcp-server",
+  "version": "2.68.2",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc --project tsconfig.build.json",
+    "start": "node --env-file=../../.env dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@freundebuch/backend": "workspace:*",
+    "@freundebuch/shared": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@pgtyped/runtime": "2.4.2",
+    "arktype": "2.1.29",
+    "bcrypt": "6.0.0",
+    "pg": "8.16.3",
+    "pino": "10.1.0",
+    "pino-pretty": "13.1.3",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@testcontainers/postgresql": "11.10.0",
+    "@types/bcrypt": "6.0.0",
+    "@types/node": "25.0.3",
+    "@types/pg": "8.16.0",
+    "node-pg-migrate": "8.0.4",
+    "testcontainers": "11.10.0",
+    "tsx": "4.21.0",
+    "typescript": "5.9.3",
+    "vite-tsconfig-paths": "6.0.3",
+    "vitest": "4.0.16"
+  }
+}

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -1,0 +1,32 @@
+import { type } from 'arktype';
+
+const ConfigSchema = type({
+  DATABASE_URL: 'string',
+  DATABASE_POOL_MIN: 'string.integer.parse = "1"',
+  DATABASE_POOL_MAX: 'string.integer.parse = "5"',
+  MCP_PORT: 'string.integer.parse = "3100"',
+  LOG_LEVEL: '"trace" | "debug" | "info" | "warn" | "error" | "fatal" | "silent" = "info"',
+  // No default: deploying to production without explicitly setting ENV would
+  // silently use development defaults (e.g. pino-pretty transport). Fail closed.
+  ENV: '"development" | "production" | "test"',
+  '+': 'delete',
+});
+
+export type Config = typeof ConfigSchema.infer;
+
+let cachedConfig: Config | null = null;
+
+export function getConfig(): Config {
+  if (cachedConfig !== null) {
+    return cachedConfig;
+  }
+
+  const result = ConfigSchema(process.env);
+
+  if (result instanceof type.errors) {
+    throw new Error(`MCP Server configuration validation failed:\n${result.summary}`);
+  }
+
+  cachedConfig = result;
+  return result;
+}

--- a/apps/mcp-server/src/http-handler.ts
+++ b/apps/mcp-server/src/http-handler.ts
@@ -25,15 +25,26 @@ interface HandlerDeps {
 
 const DEFAULT_MAX_BODY_BYTES = 1_048_576; // 1 MiB; MCP JSON-RPC bodies are small.
 
-function getClientIp(req: IncomingMessage): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string' && forwarded.length > 0) {
-    return forwarded.split(',')[0].trim();
-  }
+export function getClientIp(req: IncomingMessage): string {
+  // Trust order matters: nginx sets `X-Real-IP` to `$remote_addr` (the trusted
+  // upstream hop), and `X-Forwarded-For` via `$proxy_add_x_forwarded_for` which
+  // *appends* the trusted source to whatever the client sent. So the first XFF
+  // entry is client-supplied and spoofable; the trustworthy hop is the last one.
   const realIp = req.headers['x-real-ip'];
-  if (typeof realIp === 'string' && realIp.length > 0) {
-    return realIp;
+  if (typeof realIp === 'string') {
+    const trimmed = realIp.trim();
+    if (trimmed.length > 0) return trimmed;
   }
+
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') {
+    const hops = forwarded
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    if (hops.length > 0) return hops[hops.length - 1];
+  }
+
   return req.socket.remoteAddress ?? 'unknown';
 }
 

--- a/apps/mcp-server/src/http-handler.ts
+++ b/apps/mcp-server/src/http-handler.ts
@@ -71,6 +71,9 @@ type ReadResult = { ok: true; body: string } | { ok: false; reason: 'too-large' 
 async function readBody(req: IncomingMessage, maxBytes: number): Promise<ReadResult> {
   const declared = Number.parseInt(req.headers['content-length'] ?? '', 10);
   if (Number.isFinite(declared) && declared > maxBytes) {
+    // Swallow drain-time errors (client abort, socket reset). Without a listener,
+    // an `'error'` event would crash the process via Node's default handler.
+    req.on('error', () => undefined);
     req.resume();
     return { ok: false, reason: 'too-large' };
   }
@@ -97,6 +100,9 @@ async function readBody(req: IncomingMessage, maxBytes: number): Promise<ReadRes
       if (total > maxBytes) {
         chunks.length = 0;
         settle({ ok: false, reason: 'too-large' });
+        // settle() ran cleanup() and detached the original `'error'` listener.
+        // Reattach a no-op so a drain-time abort doesn't crash the process.
+        req.on('error', () => undefined);
         req.resume(); // drain remaining bytes in background
         return;
       }

--- a/apps/mcp-server/src/http-handler.ts
+++ b/apps/mcp-server/src/http-handler.ts
@@ -1,0 +1,269 @@
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Logger } from 'pino';
+import { createMcpServer } from './server.js';
+import type { Services } from './utils/service-factory.js';
+
+// Brute-force / rate limiting is intentionally handled at the infrastructure
+// layer (nginx `limit_req_zone`, WAF, or load balancer) — same design as
+// `apps/sabredav/src/Auth/AppPasswordBackend.php`. An in-process limiter would
+// not survive restarts or span replicas. Failed auth attempts are logged via
+// `logger.warn` so infrastructure alerting can trigger.
+
+export interface Session {
+  transport: StreamableHTTPServerTransport;
+  userId: string;
+}
+
+interface HandlerDeps {
+  services: Services;
+  logger: Logger;
+  sessions: Map<string, Session>;
+  maxBodyBytes?: number;
+}
+
+const DEFAULT_MAX_BODY_BYTES = 1_048_576; // 1 MiB; MCP JSON-RPC bodies are small.
+
+function getClientIp(req: IncomingMessage): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  const realIp = req.headers['x-real-ip'];
+  if (typeof realIp === 'string' && realIp.length > 0) {
+    return realIp;
+  }
+  return req.socket.remoteAddress ?? 'unknown';
+}
+
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  extra?: Record<string, string>,
+) {
+  res.writeHead(status, { 'Content-Type': 'application/json', ...(extra ?? {}) });
+  res.end(JSON.stringify(body));
+}
+
+function sendUnauthorized(res: ServerResponse) {
+  sendJson(
+    res,
+    401,
+    { error: 'Unauthorized' },
+    { 'WWW-Authenticate': 'Basic realm="Freundebuch MCP"' },
+  );
+}
+
+type ReadResult = { ok: true; body: string } | { ok: false; reason: 'too-large' | 'stream-error' };
+
+/**
+ * Read request body with a byte cap. Uses Buffer.concat + utf-8 decode at end
+ * so multi-byte characters split across TCP chunks are handled correctly.
+ *
+ * If `Content-Length` is present and exceeds the cap, short-circuit before
+ * reading any body. Otherwise, stream the body and once the cap is reached
+ * stop buffering (keep draining data events so the client finishes sending
+ * and reads the 413 response cleanly instead of hitting ECONNRESET).
+ */
+async function readBody(req: IncomingMessage, maxBytes: number): Promise<ReadResult> {
+  const declared = Number.parseInt(req.headers['content-length'] ?? '', 10);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    return { ok: false, reason: 'too-large' };
+  }
+
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let tooLarge = false;
+    let settled = false;
+    const settle = (value: ReadResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        tooLarge = true;
+        chunks.length = 0;
+        return; // keep draining; client will finish and we respond after 'end'
+      }
+      if (!tooLarge) chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (tooLarge) {
+        settle({ ok: false, reason: 'too-large' });
+        return;
+      }
+      settle({ ok: true, body: Buffer.concat(chunks).toString('utf-8') });
+    });
+    req.on('error', () => {
+      settle({ ok: false, reason: 'stream-error' });
+    });
+  });
+}
+
+/**
+ * Extract mcp-session-id from headers. Rejects duplicate headers.
+ *
+ * Node's http parser merges duplicate instances of non-listed headers into a
+ * comma-joined string (only certain headers surface as arrays), so a naive
+ * `Array.isArray` check would miss duplicates. Walk `req.rawHeaders` directly
+ * to count occurrences.
+ */
+function readSessionIdHeader(
+  req: IncomingMessage,
+  res: ServerResponse,
+): { ok: true; sessionId: string | undefined } | { ok: false } {
+  let count = 0;
+  let value: string | undefined;
+  for (let i = 0; i < req.rawHeaders.length; i += 2) {
+    if (req.rawHeaders[i].toLowerCase() === 'mcp-session-id') {
+      count++;
+      if (count === 1) value = req.rawHeaders[i + 1];
+      if (count > 1) {
+        sendJson(res, 400, { error: 'Duplicate mcp-session-id header' });
+        return { ok: false };
+      }
+    }
+  }
+  return { ok: true, sessionId: value };
+}
+
+export function createMcpRequestHandler(
+  deps: HandlerDeps,
+): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+  const { services, logger, sessions } = deps;
+  const maxBodyBytes = deps.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+
+  return async function handleRequest(req, res) {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+
+    if (url.pathname === '/health') {
+      sendJson(res, 200, { status: 'ok' });
+      return;
+    }
+    if (url.pathname !== '/mcp') {
+      sendJson(res, 404, { error: 'Not Found' });
+      return;
+    }
+
+    // Authenticate every request
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Basic ')) {
+      sendUnauthorized(res);
+      return;
+    }
+
+    const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
+    const colonIndex = decoded.indexOf(':');
+    if (colonIndex === -1) {
+      sendUnauthorized(res);
+      return;
+    }
+
+    const email = decoded.slice(0, colonIndex);
+    const password = decoded.slice(colonIndex + 1);
+
+    const authResult = await services.appPasswords.verifyAppPassword(email, password);
+    if (!authResult) {
+      logger.warn(
+        { ip: getClientIp(req), email },
+        'MCP basic-auth failure (infrastructure rate limiting should throttle repeats)',
+      );
+      sendUnauthorized(res);
+      return;
+    }
+
+    const sessionHeader = readSessionIdHeader(req, res);
+    if (!sessionHeader.ok) return;
+    const sessionId = sessionHeader.sessionId;
+
+    if (req.method === 'POST') {
+      const read = await readBody(req, maxBodyBytes);
+      if (!read.ok) {
+        if (read.reason === 'too-large') {
+          sendJson(res, 413, { error: 'Payload Too Large', maxBytes: maxBodyBytes });
+        } else {
+          sendJson(res, 400, { error: 'Request stream error' });
+        }
+        return;
+      }
+
+      let parsedBody: unknown;
+      try {
+        parsedBody = JSON.parse(read.body);
+      } catch {
+        sendJson(res, 400, { error: 'Invalid JSON' });
+        return;
+      }
+
+      const existingSession = sessionId ? sessions.get(sessionId) : undefined;
+      if (existingSession) {
+        if (existingSession.userId !== authResult.userId) {
+          sendUnauthorized(res);
+          return;
+        }
+        await existingSession.transport.handleRequest(req, res, parsedBody);
+        return;
+      }
+
+      // New session
+      const newSessionId = randomUUID();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => newSessionId,
+      });
+
+      const userId = authResult.userId;
+      const server = createMcpServer(services, () => userId);
+      sessions.set(newSessionId, { transport, userId });
+
+      transport.onclose = () => {
+        sessions.delete(newSessionId);
+        logger.debug({ sessionId: newSessionId }, 'MCP session closed');
+      };
+
+      await server.connect(transport);
+      logger.info(
+        { sessionId: newSessionId, email: authResult.email },
+        'New MCP session established',
+      );
+      await transport.handleRequest(req, res, parsedBody);
+      return;
+    }
+
+    if (req.method === 'GET') {
+      const getSession = sessionId ? sessions.get(sessionId) : undefined;
+      if (!getSession) {
+        sendJson(res, 400, { error: 'Missing or invalid session ID' });
+        return;
+      }
+      if (getSession.userId !== authResult.userId) {
+        sendUnauthorized(res);
+        return;
+      }
+      await getSession.transport.handleRequest(req, res);
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      const deleteSession = sessionId ? sessions.get(sessionId) : undefined;
+      if (!deleteSession) {
+        sendJson(res, 404, { error: 'Session not found' });
+        return;
+      }
+      if (deleteSession.userId !== authResult.userId) {
+        sendUnauthorized(res);
+        return;
+      }
+      await deleteSession.transport.handleRequest(req, res);
+      sessions.delete(sessionId as string);
+      logger.info({ sessionId }, 'MCP session terminated');
+      return;
+    }
+
+    sendJson(res, 405, { error: 'Method not allowed' });
+  };
+}

--- a/apps/mcp-server/src/http-handler.ts
+++ b/apps/mcp-server/src/http-handler.ts
@@ -63,45 +63,55 @@ type ReadResult = { ok: true; body: string } | { ok: false; reason: 'too-large' 
  * so multi-byte characters split across TCP chunks are handled correctly.
  *
  * If `Content-Length` is present and exceeds the cap, short-circuit before
- * reading any body. Otherwise, stream the body and once the cap is reached
- * stop buffering (keep draining data events so the client finishes sending
- * and reads the 413 response cleanly instead of hitting ECONNRESET).
+ * reading any body. Otherwise stream the body, and as soon as the cap is
+ * exceeded resolve with `too-large` immediately (so the caller can send 413
+ * without waiting for the client to finish uploading). The remaining body is
+ * drained in the background to keep the connection healthy.
  */
 async function readBody(req: IncomingMessage, maxBytes: number): Promise<ReadResult> {
   const declared = Number.parseInt(req.headers['content-length'] ?? '', 10);
   if (Number.isFinite(declared) && declared > maxBytes) {
+    req.resume();
     return { ok: false, reason: 'too-large' };
   }
 
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     let total = 0;
-    let tooLarge = false;
     let settled = false;
+
+    const cleanup = () => {
+      req.off('data', onData);
+      req.off('end', onEnd);
+      req.off('error', onError);
+    };
     const settle = (value: ReadResult) => {
       if (settled) return;
       settled = true;
+      cleanup();
       resolve(value);
     };
-    req.on('data', (chunk: Buffer) => {
+
+    const onData = (chunk: Buffer) => {
       total += chunk.length;
       if (total > maxBytes) {
-        tooLarge = true;
         chunks.length = 0;
-        return; // keep draining; client will finish and we respond after 'end'
-      }
-      if (!tooLarge) chunks.push(chunk);
-    });
-    req.on('end', () => {
-      if (tooLarge) {
         settle({ ok: false, reason: 'too-large' });
+        req.resume(); // drain remaining bytes in background
         return;
       }
+      chunks.push(chunk);
+    };
+    const onEnd = () => {
       settle({ ok: true, body: Buffer.concat(chunks).toString('utf-8') });
-    });
-    req.on('error', () => {
+    };
+    const onError = () => {
       settle({ ok: false, reason: 'stream-error' });
-    });
+    };
+
+    req.on('data', onData);
+    req.on('end', onEnd);
+    req.on('error', onError);
   });
 }
 

--- a/apps/mcp-server/src/http-handler.ts
+++ b/apps/mcp-server/src/http-handler.ts
@@ -5,11 +5,11 @@ import type { Logger } from 'pino';
 import { createMcpServer } from './server.js';
 import type { Services } from './utils/service-factory.js';
 
-// Brute-force / rate limiting is intentionally handled at the infrastructure
-// layer (nginx `limit_req_zone`, WAF, or load balancer) — same design as
-// `apps/sabredav/src/Auth/AppPasswordBackend.php`. An in-process limiter would
-// not survive restarts or span replicas. Failed auth attempts are logged via
-// `logger.warn` so infrastructure alerting can trigger.
+// Brute-force / rate limiting is handled at the infrastructure layer — see
+// the `limit_req_zone zone=mcp_auth` directives in `docker/nginx*.conf*`.
+// Same design as `apps/sabredav/src/Auth/AppPasswordBackend.php`: an in-process
+// limiter would not survive restarts or span replicas. Failed auth attempts
+// are still logged via `logger.warn` so infrastructure alerting can trigger.
 
 export interface Session {
   transport: StreamableHTTPServerTransport;
@@ -139,13 +139,16 @@ export function createMcpRequestHandler(
   const maxBodyBytes = deps.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
 
   return async function handleRequest(req, res) {
-    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    // `Host` is optional in HTTP/1.0 and can be missing behind some proxies, so
+    // use a fixed base — we only care about pathname here, not the host.
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const pathname = url.pathname.replace(/\/+$/, '') || '/';
 
-    if (url.pathname === '/health') {
+    if (pathname === '/health') {
       sendJson(res, 200, { status: 'ok' });
       return;
     }
-    if (url.pathname !== '/mcp') {
+    if (pathname !== '/mcp') {
       sendJson(res, 404, { error: 'Not Found' });
       return;
     }

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,9 +1,7 @@
-import { randomUUID } from 'node:crypto';
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createServer } from 'node:http';
 import pg from 'pg';
 import { getConfig } from './config.js';
-import { createMcpServer } from './server.js';
+import { createMcpRequestHandler, type Session } from './http-handler.js';
 import { createLogger } from './utils/logger.js';
 import { createServices } from './utils/service-factory.js';
 
@@ -18,161 +16,14 @@ const pool = new pg.Pool({
 
 const services = createServices(pool, logger);
 
-interface Session {
-  transport: StreamableHTTPServerTransport;
-  userId: string;
-}
-
 const sessions = new Map<string, Session>();
 
-async function authenticate(
-  req: IncomingMessage,
-): Promise<{ userId: string; email: string } | null> {
-  const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith('Basic ')) {
-    return null;
-  }
-
-  const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
-  const colonIndex = decoded.indexOf(':');
-  if (colonIndex === -1) {
-    return null;
-  }
-
-  const email = decoded.slice(0, colonIndex);
-  const password = decoded.slice(colonIndex + 1);
-
-  const result = await services.appPasswords.verifyAppPassword(email, password);
-  if (!result) {
-    return null;
-  }
-
-  return { userId: result.userId, email: result.email };
-}
-
-function sendUnauthorized(res: ServerResponse) {
-  res.writeHead(401, {
-    'WWW-Authenticate': 'Basic realm="Freundebuch MCP"',
-    'Content-Type': 'application/json',
-  });
-  res.end(JSON.stringify({ error: 'Unauthorized' }));
-}
-
-async function handleRequest(req: IncomingMessage, res: ServerResponse) {
-  const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
-
-  // Only handle /mcp endpoint
-  if (url.pathname !== '/mcp') {
-    if (url.pathname === '/health') {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok' }));
-      return;
-    }
-    res.writeHead(404, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Not Found' }));
-    return;
-  }
-
-  // Authenticate every request
-  const auth = await authenticate(req);
-  if (!auth) {
-    sendUnauthorized(res);
-    return;
-  }
-
-  const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-  if (req.method === 'POST') {
-    // Read request body
-    const body = await new Promise<string>((resolve, reject) => {
-      let data = '';
-      req.on('data', (chunk: Buffer) => {
-        data += chunk.toString();
-      });
-      req.on('end', () => resolve(data));
-      req.on('error', reject);
-    });
-
-    let parsedBody: unknown;
-    try {
-      parsedBody = JSON.parse(body);
-    } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
-
-    const existingSession = sessionId ? sessions.get(sessionId) : undefined;
-    if (existingSession) {
-      // Existing session — verify same user
-      if (existingSession.userId !== auth.userId) {
-        sendUnauthorized(res);
-        return;
-      }
-      await existingSession.transport.handleRequest(req, res, parsedBody);
-    } else {
-      // New session — create transport and McpServer
-      const newSessionId = randomUUID();
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => newSessionId,
-      });
-
-      const userId = auth.userId;
-      const server = createMcpServer(services, () => userId);
-
-      sessions.set(newSessionId, { transport, userId });
-
-      transport.onclose = () => {
-        sessions.delete(newSessionId);
-        logger.debug({ sessionId: newSessionId }, 'MCP session closed');
-      };
-
-      await server.connect(transport);
-      logger.info({ sessionId: newSessionId, email: auth.email }, 'New MCP session established');
-
-      await transport.handleRequest(req, res, parsedBody);
-    }
-  } else if (req.method === 'GET') {
-    // SSE stream for existing session
-    const getSession = sessionId ? sessions.get(sessionId) : undefined;
-    if (!getSession) {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Missing or invalid session ID' }));
-      return;
-    }
-    if (getSession.userId !== auth.userId) {
-      sendUnauthorized(res);
-      return;
-    }
-    await getSession.transport.handleRequest(req, res);
-  } else if (req.method === 'DELETE') {
-    // Session termination
-    const deleteSession = sessionId ? sessions.get(sessionId) : undefined;
-    if (!deleteSession) {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Session not found' }));
-      return;
-    }
-    if (deleteSession.userId !== auth.userId) {
-      sendUnauthorized(res);
-      return;
-    }
-    await deleteSession.transport.handleRequest(req, res);
-    sessions.delete(sessionId as string);
-    logger.info({ sessionId }, 'MCP session terminated');
-  } else {
-    res.writeHead(405, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Method not allowed' }));
-  }
-}
-
-const httpServer = createServer(handleRequest);
+const httpServer = createServer(createMcpRequestHandler({ services, logger, sessions }));
 
 httpServer.listen(config.MCP_PORT, () => {
   logger.info({ port: config.MCP_PORT }, 'Freundebuch MCP server started');
 });
 
-// Graceful shutdown
 let isShuttingDown = false;
 
 function shutdown(signal: string) {
@@ -182,15 +33,8 @@ function shutdown(signal: string) {
   logger.info(`${signal} received, shutting down MCP server`);
 
   httpServer.close(async () => {
-    // Close all active sessions
-    for (const [id, session] of sessions) {
-      try {
-        await session.transport.close();
-      } catch {
-        // Ignore close errors during shutdown
-      }
-      sessions.delete(id);
-    }
+    await Promise.allSettled([...sessions.values()].map((session) => session.transport.close()));
+    sessions.clear();
 
     await pool.end();
     logger.info('MCP server shutdown complete');

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from 'node:crypto';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import pg from 'pg';
+import { getConfig } from './config.js';
+import { createMcpServer } from './server.js';
+import { createLogger } from './utils/logger.js';
+import { createServices } from './utils/service-factory.js';
+
+const config = getConfig();
+const logger = createLogger(config);
+
+const pool = new pg.Pool({
+  connectionString: config.DATABASE_URL,
+  min: config.DATABASE_POOL_MIN,
+  max: config.DATABASE_POOL_MAX,
+});
+
+const services = createServices(pool, logger);
+
+interface Session {
+  transport: StreamableHTTPServerTransport;
+  userId: string;
+}
+
+const sessions = new Map<string, Session>();
+
+async function authenticate(
+  req: IncomingMessage,
+): Promise<{ userId: string; email: string } | null> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Basic ')) {
+    return null;
+  }
+
+  const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
+  const colonIndex = decoded.indexOf(':');
+  if (colonIndex === -1) {
+    return null;
+  }
+
+  const email = decoded.slice(0, colonIndex);
+  const password = decoded.slice(colonIndex + 1);
+
+  const result = await services.appPasswords.verifyAppPassword(email, password);
+  if (!result) {
+    return null;
+  }
+
+  return { userId: result.userId, email: result.email };
+}
+
+function sendUnauthorized(res: ServerResponse) {
+  res.writeHead(401, {
+    'WWW-Authenticate': 'Basic realm="Freundebuch MCP"',
+    'Content-Type': 'application/json',
+  });
+  res.end(JSON.stringify({ error: 'Unauthorized' }));
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+
+  // Only handle /mcp endpoint
+  if (url.pathname !== '/mcp') {
+    if (url.pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not Found' }));
+    return;
+  }
+
+  // Authenticate every request
+  const auth = await authenticate(req);
+  if (!auth) {
+    sendUnauthorized(res);
+    return;
+  }
+
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  if (req.method === 'POST') {
+    // Read request body
+    const body = await new Promise<string>((resolve, reject) => {
+      let data = '';
+      req.on('data', (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+      req.on('end', () => resolve(data));
+      req.on('error', reject);
+    });
+
+    let parsedBody: unknown;
+    try {
+      parsedBody = JSON.parse(body);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      return;
+    }
+
+    const existingSession = sessionId ? sessions.get(sessionId) : undefined;
+    if (existingSession) {
+      // Existing session — verify same user
+      if (existingSession.userId !== auth.userId) {
+        sendUnauthorized(res);
+        return;
+      }
+      await existingSession.transport.handleRequest(req, res, parsedBody);
+    } else {
+      // New session — create transport and McpServer
+      const newSessionId = randomUUID();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => newSessionId,
+      });
+
+      const userId = auth.userId;
+      const server = createMcpServer(services, () => userId);
+
+      sessions.set(newSessionId, { transport, userId });
+
+      transport.onclose = () => {
+        sessions.delete(newSessionId);
+        logger.debug({ sessionId: newSessionId }, 'MCP session closed');
+      };
+
+      await server.connect(transport);
+      logger.info({ sessionId: newSessionId, email: auth.email }, 'New MCP session established');
+
+      await transport.handleRequest(req, res, parsedBody);
+    }
+  } else if (req.method === 'GET') {
+    // SSE stream for existing session
+    const getSession = sessionId ? sessions.get(sessionId) : undefined;
+    if (!getSession) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Missing or invalid session ID' }));
+      return;
+    }
+    if (getSession.userId !== auth.userId) {
+      sendUnauthorized(res);
+      return;
+    }
+    await getSession.transport.handleRequest(req, res);
+  } else if (req.method === 'DELETE') {
+    // Session termination
+    const deleteSession = sessionId ? sessions.get(sessionId) : undefined;
+    if (!deleteSession) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Session not found' }));
+      return;
+    }
+    if (deleteSession.userId !== auth.userId) {
+      sendUnauthorized(res);
+      return;
+    }
+    await deleteSession.transport.handleRequest(req, res);
+    sessions.delete(sessionId as string);
+    logger.info({ sessionId }, 'MCP session terminated');
+  } else {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+  }
+}
+
+const httpServer = createServer(handleRequest);
+
+httpServer.listen(config.MCP_PORT, () => {
+  logger.info({ port: config.MCP_PORT }, 'Freundebuch MCP server started');
+});
+
+// Graceful shutdown
+let isShuttingDown = false;
+
+function shutdown(signal: string) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  logger.info(`${signal} received, shutting down MCP server`);
+
+  httpServer.close(async () => {
+    // Close all active sessions
+    for (const [id, session] of sessions) {
+      try {
+        await session.transport.close();
+      } catch {
+        // Ignore close errors during shutdown
+      }
+      sessions.delete(id);
+    }
+
+    await pool.end();
+    logger.info('MCP server shutdown complete');
+    process.exit(0);
+  });
+
+  // Force shutdown after 10 seconds
+  setTimeout(() => {
+    logger.error('Forced shutdown after timeout');
+    process.exit(1);
+  }, 10000);
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerCirclesTools } from './tools/circles.js';
 import { registerCollectivesTools } from './tools/collectives.js';
@@ -5,10 +6,15 @@ import { registerEncountersTools } from './tools/encounters.js';
 import { registerFriendsTools } from './tools/friends.js';
 import type { Services } from './utils/service-factory.js';
 
+const require = createRequire(import.meta.url);
+// biome-ignore lint/correctness/useImportExtensions: package.json is correct, not package.js
+const pkg: Record<string, unknown> = require('../package.json');
+const serverVersion = typeof pkg.version === 'string' ? pkg.version : 'unknown';
+
 export function createMcpServer(services: Services, getUserId: () => string): McpServer {
   const server = new McpServer({
     name: 'freundebuch',
-    version: '2.68.2',
+    version: serverVersion,
   });
 
   registerFriendsTools(server, services, getUserId);

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,0 +1,20 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerCirclesTools } from './tools/circles.js';
+import { registerCollectivesTools } from './tools/collectives.js';
+import { registerEncountersTools } from './tools/encounters.js';
+import { registerFriendsTools } from './tools/friends.js';
+import type { Services } from './utils/service-factory.js';
+
+export function createMcpServer(services: Services, getUserId: () => string): McpServer {
+  const server = new McpServer({
+    name: 'freundebuch',
+    version: '2.68.2',
+  });
+
+  registerFriendsTools(server, services, getUserId);
+  registerCirclesTools(server, services, getUserId);
+  registerCollectivesTools(server, services, getUserId);
+  registerEncountersTools(server, services, getUserId);
+
+  return server;
+}

--- a/apps/mcp-server/src/tools/circles.ts
+++ b/apps/mcp-server/src/tools/circles.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Services } from '../utils/service-factory.js';
+
+export function registerCirclesTools(
+  server: McpServer,
+  services: Services,
+  getUserId: () => string,
+) {
+  server.tool(
+    'list_circles',
+    'List all circles (categorization groups) for the user. Each circle has a name, color, and friend count. Circles are used to organize friends into groups.',
+    {},
+    async () => {
+      const circles = await services.circles.listCircles(getUserId());
+      return { content: [{ type: 'text' as const, text: JSON.stringify(circles, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_circle',
+    'Get details for a single circle including its name, color, description, and friend count.',
+    {
+      circleId: z.string().uuid().describe('The circle ID (UUID)'),
+    },
+    async ({ circleId }) => {
+      const circle = await services.circles.getCircleById(getUserId(), circleId);
+      if (!circle) {
+        return { content: [{ type: 'text' as const, text: 'Circle not found.' }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(circle, null, 2) }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/collectives.ts
+++ b/apps/mcp-server/src/tools/collectives.ts
@@ -1,0 +1,52 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Services } from '../utils/service-factory.js';
+
+export function registerCollectivesTools(
+  server: McpServer,
+  services: Services,
+  getUserId: () => string,
+) {
+  server.tool(
+    'list_collectives',
+    'List all collectives (families, companies, clubs, friend groups) with pagination. Each collective includes a member preview showing the first few members.',
+    {
+      page: z.number().int().min(1).default(1).describe('Page number (1-based)'),
+      pageSize: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe('Number of collectives per page'),
+      typeId: z.string().uuid().optional().describe('Filter by collective type ID (UUID)'),
+      search: z.string().optional().describe('Search by collective name'),
+    },
+    async ({ page, pageSize, typeId, search }) => {
+      const result = await services.collectives.listCollectives(getUserId(), {
+        page,
+        pageSize,
+        typeId,
+        search,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_collective',
+    'Get complete details for a single collective including all members with their roles, addresses, phones, emails, URLs, and circle memberships.',
+    {
+      collectiveId: z.string().uuid().describe('The collective ID (UUID)'),
+    },
+    async ({ collectiveId }) => {
+      const collective = await services.collectives.getCollectiveById(getUserId(), collectiveId);
+      if (!collective) {
+        return { content: [{ type: 'text' as const, text: 'Collective not found.' }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(collective, null, 2) }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/encounters.ts
+++ b/apps/mcp-server/src/tools/encounters.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Services } from '../utils/service-factory.js';
+
+export function registerEncountersTools(
+  server: McpServer,
+  services: Services,
+  getUserId: () => string,
+) {
+  server.tool(
+    'list_encounters',
+    'List encounters (meetings, events, interactions) with pagination and filtering. Can filter by friend, date range, or search text. Each encounter shows the title, date, location, and a preview of associated friends.',
+    {
+      page: z.number().int().min(1).default(1).describe('Page number (1-based)'),
+      pageSize: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe('Number of encounters per page'),
+      friendId: z
+        .string()
+        .uuid()
+        .optional()
+        .describe('Filter to encounters with a specific friend'),
+      fromDate: z
+        .string()
+        .optional()
+        .describe('Filter encounters from this date (ISO 8601 format, e.g. "2024-01-01")'),
+      toDate: z
+        .string()
+        .optional()
+        .describe('Filter encounters up to this date (ISO 8601 format, e.g. "2024-12-31")'),
+      search: z.string().optional().describe('Search by encounter title, description, or location'),
+    },
+    async ({ page, pageSize, friendId, fromDate, toDate, search }) => {
+      const result = await services.encounters.listEncounters(getUserId(), {
+        page,
+        pageSize,
+        friendId,
+        fromDate,
+        toDate,
+        search,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_encounter',
+    'Get complete details for a single encounter including its title, date, location, description, and all associated friends.',
+    {
+      encounterId: z.string().uuid().describe('The encounter ID (UUID)'),
+    },
+    async ({ encounterId }) => {
+      const encounter = await services.encounters.getEncounterById(getUserId(), encounterId);
+      if (!encounter) {
+        return { content: [{ type: 'text' as const, text: 'Encounter not found.' }] };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(encounter, null, 2) }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/friends.ts
+++ b/apps/mcp-server/src/tools/friends.ts
@@ -1,0 +1,142 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Services } from '../utils/service-factory.js';
+
+export function registerFriendsTools(
+  server: McpServer,
+  services: Services,
+  getUserId: () => string,
+) {
+  server.tool(
+    'list_friends',
+    'List friends with pagination, sorting, and filtering. Returns a paginated list of friend summaries with basic info like name, primary email/phone, city, and circle memberships.',
+    {
+      page: z.number().int().min(1).default(1).describe('Page number (1-based)'),
+      pageSize: z.number().int().min(1).max(100).default(25).describe('Number of friends per page'),
+      sortBy: z
+        .enum(['display_name', 'created_at', 'updated_at'])
+        .default('display_name')
+        .describe('Field to sort by'),
+      sortOrder: z.enum(['asc', 'desc']).default('asc').describe('Sort direction'),
+      favorites: z.boolean().optional().describe('Filter to only favorites'),
+      archived: z
+        .union([z.boolean(), z.literal('only')])
+        .optional()
+        .describe('true = include archived, "only" = only archived, omit = exclude archived'),
+    },
+    async ({ page, pageSize, sortBy, sortOrder, favorites, archived }) => {
+      const result = await services.friends.listFriends(getUserId(), {
+        page,
+        pageSize,
+        sortBy,
+        sortOrder,
+        favorites,
+        archived,
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_friend',
+    'Get complete details for a single friend including all sub-resources: phones, emails, addresses, URLs, dates, relationships, professional history, social profiles, met info, and circle memberships.',
+    {
+      friendId: z.string().uuid().describe('The friend ID (UUID)'),
+    },
+    async ({ friendId }) => {
+      const friend = await services.friends.getFriendById(getUserId(), friendId);
+      if (!friend) {
+        return { content: [{ type: 'text' as const, text: 'Friend not found.' }] };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(friend, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'search_friends',
+    'Full-text search across all friend data. Searches names, nicknames, organization, job title, emails, phones, notes, addresses, and met context. Returns results ranked by relevance with highlighted matches.',
+    {
+      query: z.string().min(1).describe('Search query text'),
+      limit: z.number().int().min(1).max(50).default(10).describe('Maximum number of results'),
+    },
+    async ({ query, limit }) => {
+      const results = await services.friends.fullTextSearch(getUserId(), query, limit);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(results, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'faceted_search',
+    'Advanced search with filtering by location, profession, relationship category, and circles. Optionally includes facet counts for understanding data distribution.',
+    {
+      query: z.string().optional().describe('Optional search query text'),
+      page: z.number().int().min(1).default(1).describe('Page number'),
+      pageSize: z.number().int().min(1).max(100).default(25).describe('Number of results per page'),
+      sortBy: z
+        .enum(['relevance', 'display_name', 'created_at', 'updated_at'])
+        .default('display_name')
+        .describe('Sort field (relevance only works with a query)'),
+      sortOrder: z.enum(['asc', 'desc']).default('asc').describe('Sort direction'),
+      filters: z
+        .object({
+          country: z.array(z.string()).optional().describe('Filter by country names'),
+          city: z.array(z.string()).optional().describe('Filter by city names'),
+          organization: z.array(z.string()).optional().describe('Filter by organization names'),
+          job_title: z.array(z.string()).optional().describe('Filter by job titles'),
+          department: z.array(z.string()).optional().describe('Filter by departments'),
+          relationship_category: z
+            .array(z.enum(['family', 'professional', 'social']))
+            .optional()
+            .describe('Filter by relationship categories: family, professional, or social'),
+          circles: z.array(z.string().uuid()).optional().describe('Filter by circle IDs'),
+          favorites: z.boolean().optional().describe('Filter to favorites only'),
+          archived: z.enum(['include', 'exclude', 'only']).optional().describe('Archived filter'),
+        })
+        .default({})
+        .describe('Filter criteria'),
+      includeFacets: z
+        .boolean()
+        .default(false)
+        .describe('Include facet counts in response for understanding data distribution'),
+    },
+    async ({ query, page, pageSize, sortBy, sortOrder, filters, includeFacets }) => {
+      const options = {
+        query,
+        page,
+        pageSize,
+        sortBy: sortBy as 'relevance' | 'display_name' | 'created_at' | 'updated_at',
+        sortOrder,
+        filters,
+        includeFacets,
+      };
+
+      const results = query
+        ? await services.friends.facetedSearch(getUserId(), options)
+        : await services.friends.filterOnlyList(getUserId(), options);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(results, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_upcoming_dates',
+    'Get upcoming birthdays, anniversaries, and other important dates across all friends. Useful for reminders and planning.',
+    {
+      days: z.number().int().min(1).max(365).default(30).describe('Number of days ahead to look'),
+      limit: z.number().int().min(1).max(100).default(20).describe('Maximum number of dates'),
+    },
+    async ({ days, limit }) => {
+      const dates = await services.friends.getUpcomingDates(getUserId(), { days, limit });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(dates, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_network_graph',
+    'Get the relationship network graph showing how friends are connected to each other. Returns nodes (friends) and links (relationships between them). Useful for understanding social connections.',
+    {},
+    async () => {
+      const data = await services.friends.getNetworkGraphData(getUserId());
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/utils/logger.ts
+++ b/apps/mcp-server/src/utils/logger.ts
@@ -1,0 +1,12 @@
+import pino from 'pino';
+import type { Config } from '../config.js';
+
+export function createLogger(config: Config) {
+  return pino({
+    level: config.LOG_LEVEL,
+    transport:
+      config.ENV === 'development'
+        ? { target: 'pino-pretty', options: { colorize: true } }
+        : undefined,
+  });
+}

--- a/apps/mcp-server/src/utils/service-factory.ts
+++ b/apps/mcp-server/src/utils/service-factory.ts
@@ -1,0 +1,19 @@
+import { AppPasswordsService } from '@freundebuch/backend/services/app-passwords.service.js';
+import { CirclesService } from '@freundebuch/backend/services/circles.service.js';
+import { CollectivesService } from '@freundebuch/backend/services/collectives/collectives.service.js';
+import { EncountersService } from '@freundebuch/backend/services/encounters.service.js';
+import { FriendsService } from '@freundebuch/backend/services/friends/friends.service.js';
+import type pg from 'pg';
+import type { Logger } from 'pino';
+
+export function createServices(pool: pg.Pool, logger: Logger) {
+  return {
+    friends: new FriendsService(pool, logger),
+    circles: new CirclesService(pool),
+    collectives: new CollectivesService(pool),
+    encounters: new EncountersService(pool),
+    appPasswords: new AppPasswordsService(pool, logger),
+  };
+}
+
+export type Services = ReturnType<typeof createServices>;

--- a/apps/mcp-server/tests/get-client-ip.test.ts
+++ b/apps/mcp-server/tests/get-client-ip.test.ts
@@ -1,0 +1,79 @@
+import type { IncomingMessage } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { getClientIp } from '../src/http-handler.js';
+
+function makeReq(opts: {
+  headers?: Record<string, string | string[]>;
+  remoteAddress?: string;
+}): IncomingMessage {
+  return {
+    headers: opts.headers ?? {},
+    socket: { remoteAddress: opts.remoteAddress },
+  } as unknown as IncomingMessage;
+}
+
+describe('getClientIp', () => {
+  it('prefers X-Real-IP over X-Forwarded-For', () => {
+    const req = makeReq({
+      headers: {
+        'x-real-ip': '10.0.0.1',
+        'x-forwarded-for': '1.2.3.4, 10.0.0.1',
+      },
+      remoteAddress: '127.0.0.1',
+    });
+    expect(getClientIp(req)).toBe('10.0.0.1');
+  });
+
+  it('returns the last X-Forwarded-For hop when X-Real-IP is absent', () => {
+    // nginx appends $remote_addr via $proxy_add_x_forwarded_for, so the
+    // trustworthy hop is the rightmost entry. The first entry is whatever
+    // the client sent — spoofable.
+    const req = makeReq({
+      headers: { 'x-forwarded-for': '1.2.3.4, 10.0.0.1' },
+      remoteAddress: '127.0.0.1',
+    });
+    expect(getClientIp(req)).toBe('10.0.0.1');
+  });
+
+  it('does not return a spoofed first X-Forwarded-For entry', () => {
+    const req = makeReq({
+      headers: { 'x-forwarded-for': '6.6.6.6' },
+      remoteAddress: '127.0.0.1',
+    });
+    // Only one hop present — that hop *is* the trusted one (nginx-appended).
+    expect(getClientIp(req)).toBe('6.6.6.6');
+  });
+
+  it('trims whitespace around X-Real-IP and XFF entries', () => {
+    expect(
+      getClientIp(
+        makeReq({ headers: { 'x-real-ip': '  10.0.0.5  ' }, remoteAddress: '127.0.0.1' }),
+      ),
+    ).toBe('10.0.0.5');
+
+    expect(
+      getClientIp(
+        makeReq({
+          headers: { 'x-forwarded-for': ' 1.2.3.4 ,  10.0.0.5 ' },
+          remoteAddress: '127.0.0.1',
+        }),
+      ),
+    ).toBe('10.0.0.5');
+  });
+
+  it('falls back to socket.remoteAddress when no headers are set', () => {
+    expect(getClientIp(makeReq({ remoteAddress: '127.0.0.1' }))).toBe('127.0.0.1');
+  });
+
+  it('returns "unknown" when nothing is available', () => {
+    expect(getClientIp(makeReq({}))).toBe('unknown');
+  });
+
+  it('skips empty X-Real-IP and empty XFF entries', () => {
+    const req = makeReq({
+      headers: { 'x-real-ip': '   ', 'x-forwarded-for': ', , ,' },
+      remoteAddress: '127.0.0.1',
+    });
+    expect(getClientIp(req)).toBe('127.0.0.1');
+  });
+});

--- a/apps/mcp-server/tests/helpers.ts
+++ b/apps/mcp-server/tests/helpers.ts
@@ -1,0 +1,423 @@
+import crypto from 'node:crypto';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import bcrypt from 'bcrypt';
+import { runner } from 'node-pg-migrate';
+import pg from 'pg';
+import type { Logger } from 'pino';
+import pino from 'pino';
+import { Wait } from 'testcontainers';
+import { afterAll, beforeAll } from 'vitest';
+import { createMcpServer } from '../src/server.js';
+import { createServices, type Services } from '../src/utils/service-factory.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface TestContext {
+  container: StartedPostgreSqlContainer;
+  pool: pg.Pool;
+  services: Services;
+  logger: Logger;
+  baseUrl: string;
+  httpServer: http.Server;
+  testUser: {
+    externalId: string;
+    email: string;
+    appPassword: string; // raw password in xxxx-xxxx-xxxx-xxxx format
+  };
+  otherUser: {
+    externalId: string;
+    email: string;
+    appPassword: string;
+  };
+}
+
+const silentLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+};
+
+async function runMigrations(pool: pg.Pool): Promise<void> {
+  const migrationsDir = path.resolve(__dirname, '../../../database/migrations');
+  const client = await pool.connect();
+  try {
+    await runner({
+      dbClient: client,
+      migrationsTable: 'pgmigrations',
+      dir: migrationsDir,
+      direction: 'up',
+      count: Infinity,
+      decamelize: true,
+      logger: silentLogger,
+    });
+  } finally {
+    client.release();
+  }
+}
+
+async function createTestUserWithAppPassword(
+  pool: pg.Pool,
+  email: string,
+): Promise<{ externalId: string; email: string; appPassword: string }> {
+  const userPasswordHash = await bcrypt.hash('not-used-for-mcp', 10);
+
+  // Create user in legacy table
+  const userResult = await pool.query(
+    'INSERT INTO auth.users (email, password_hash) VALUES ($1, $2) RETURNING id, external_id, email',
+    [email, userPasswordHash],
+  );
+  const userId = userResult.rows[0].id;
+  const externalId = userResult.rows[0].external_id;
+
+  // Create user in Better Auth tables
+  await pool.query(
+    `INSERT INTO auth."user" (id, name, email, email_verified, created_at, updated_at)
+     VALUES ($1, $2, $3, false, NOW(), NOW())`,
+    [externalId, email.split('@')[0], email],
+  );
+
+  // Create self-profile (required for services to work)
+  const profileResult = await pool.query(
+    `INSERT INTO friends.friends (user_id, display_name)
+     VALUES ($1, $2)
+     RETURNING id, external_id`,
+    [userId, `${email.split('@')[0]} (Self)`],
+  );
+  await pool.query('UPDATE auth.users SET self_profile_id = $1 WHERE id = $2', [
+    profileResult.rows[0].id,
+    userId,
+  ]);
+  await pool.query('UPDATE auth."user" SET self_profile_id = $1 WHERE id = $2', [
+    profileResult.rows[0].id,
+    externalId,
+  ]);
+
+  // Create app password via direct SQL (matching the service's create logic exactly)
+  const rawPassword = crypto.randomBytes(24).toString('base64url');
+  const passwordPrefix = rawPassword.substring(0, 8);
+  const passwordHash = await bcrypt.hash(rawPassword, 10);
+
+  await pool.query(
+    `INSERT INTO auth.app_passwords (user_id, name, password_hash, password_prefix)
+     VALUES ($1, 'Test MCP', $2, $3)`,
+    [userId, passwordHash, passwordPrefix],
+  );
+
+  // Format as xxxx-xxxx-xxxx-xxxx (same as AppPasswordsService.formatPassword)
+  const chunks: string[] = [];
+  for (let i = 0; i < rawPassword.length; i += 4) {
+    chunks.push(rawPassword.slice(i, i + 4));
+  }
+  const formattedPassword = chunks.join('-');
+
+  return { externalId, email, appPassword: formattedPassword };
+}
+
+function startMcpHttpServer(
+  services: Services,
+  _logger: Logger,
+): Promise<{ server: http.Server; baseUrl: string }> {
+  // Import the handler setup inline to avoid circular deps
+  return new Promise((resolve) => {
+    const { randomUUID } = crypto;
+
+    interface Session {
+      transport: import('@modelcontextprotocol/sdk/server/streamableHttp.js').StreamableHTTPServerTransport;
+      userId: string;
+    }
+    const sessions = new Map<string, Session>();
+
+    const httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+
+      if (url.pathname === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      if (url.pathname !== '/mcp') {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Not Found' }));
+        return;
+      }
+
+      // Authenticate
+      const authHeader = req.headers.authorization;
+      if (!authHeader?.startsWith('Basic ')) {
+        res.writeHead(401, {
+          'WWW-Authenticate': 'Basic realm="Freundebuch MCP"',
+          'Content-Type': 'application/json',
+        });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
+
+      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
+      const colonIndex = decoded.indexOf(':');
+      if (colonIndex === -1) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
+
+      const email = decoded.slice(0, colonIndex);
+      const password = decoded.slice(colonIndex + 1);
+
+      const authResult = await services.appPasswords.verifyAppPassword(email, password);
+      if (!authResult) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
+
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      if (req.method === 'POST') {
+        const body = await new Promise<string>((resolveBody, reject) => {
+          let data = '';
+          req.on('data', (chunk: Buffer) => {
+            data += chunk.toString();
+          });
+          req.on('end', () => resolveBody(data));
+          req.on('error', reject);
+        });
+
+        let parsedBody: unknown;
+        try {
+          parsedBody = JSON.parse(body);
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid JSON' }));
+          return;
+        }
+
+        const existingSession = sessionId ? sessions.get(sessionId) : undefined;
+        if (existingSession) {
+          if (existingSession.userId !== authResult.userId) {
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Unauthorized' }));
+            return;
+          }
+          await existingSession.transport.handleRequest(req, res, parsedBody);
+        } else {
+          const { StreamableHTTPServerTransport } = await import(
+            '@modelcontextprotocol/sdk/server/streamableHttp.js'
+          );
+          const newSessionId = randomUUID();
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => newSessionId,
+          });
+
+          const userId = authResult.userId;
+          const server = createMcpServer(services, () => userId);
+          sessions.set(newSessionId, { transport, userId });
+          transport.onclose = () => sessions.delete(newSessionId);
+          await server.connect(transport);
+          await transport.handleRequest(req, res, parsedBody);
+        }
+      } else if (req.method === 'DELETE') {
+        const deleteSession = sessionId ? sessions.get(sessionId) : undefined;
+        if (!deleteSession) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Session not found' }));
+          return;
+        }
+        if (deleteSession.userId !== authResult.userId) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Unauthorized' }));
+          return;
+        }
+        await deleteSession.transport.handleRequest(req, res);
+        sessions.delete(sessionId as string);
+      } else {
+        res.writeHead(405, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Method not allowed' }));
+      }
+    });
+
+    httpServer.listen(0, () => {
+      const addr = httpServer.address() as { port: number };
+      resolve({ server: httpServer, baseUrl: `http://localhost:${addr.port}` });
+    });
+  });
+}
+
+export function basicAuthHeader(email: string, password: string): string {
+  return `Basic ${Buffer.from(`${email}:${password}`).toString('base64')}`;
+}
+
+/**
+ * Send an MCP JSON-RPC request and return the parsed response
+ */
+export async function mcpRequest(
+  baseUrl: string,
+  body: unknown,
+  options: { email: string; password: string; sessionId?: string },
+): Promise<{ status: number; headers: Headers; body: unknown }> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    Authorization: basicAuthHeader(options.email, options.password),
+  };
+  if (options.sessionId) {
+    headers['mcp-session-id'] = options.sessionId;
+  }
+
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  let responseBody: unknown;
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    responseBody = await response.json();
+  } else if (contentType.includes('text/event-stream')) {
+    // Parse SSE response to extract JSON-RPC result
+    const text = await response.text();
+    const lines = text.split('\n');
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        try {
+          responseBody = JSON.parse(line.slice(6));
+        } catch {
+          // keep trying subsequent data lines
+        }
+      }
+    }
+  } else {
+    responseBody = await response.text();
+  }
+
+  return { status: response.status, headers: response.headers, body: responseBody };
+}
+
+/**
+ * Initialize an MCP session and return the session ID.
+ *
+ * Uses raw fetch (not mcpRequest) to ensure the SSE response body
+ * is fully consumed before returning. This prevents connection pool
+ * issues with Node.js fetch/undici on SSE streams.
+ */
+export async function initMcpSession(
+  baseUrl: string,
+  email: string,
+  password: string,
+): Promise<string> {
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: basicAuthHeader(email, password),
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    }),
+  });
+
+  // Fully consume the response body to drain the SSE stream
+  await response.text();
+
+  const sessionId = response.headers.get('mcp-session-id');
+  if (!sessionId) {
+    throw new Error(`No session ID returned from initialize (status: ${response.status})`);
+  }
+  return sessionId;
+}
+
+/**
+ * Call an MCP tool and return the result
+ */
+export async function callTool(
+  baseUrl: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  options: { email: string; password: string; sessionId: string },
+): Promise<{ status: number; body: unknown }> {
+  const { status, body } = await mcpRequest(
+    baseUrl,
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: toolName, arguments: args },
+    },
+    options,
+  );
+  return { status, body };
+}
+
+export function setupMcpTestSuite() {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    const container = await new PostgreSqlContainer('imresamu/postgis:18-3.6.1-trixie')
+      .withDatabase('test')
+      .withUsername('test')
+      .withPassword('test')
+      .withStartupTimeout(120000)
+      .withWaitStrategy(Wait.forHealthCheck())
+      .start();
+
+    const pool = new pg.Pool({
+      connectionString: container.getConnectionUri(),
+      min: 1,
+      max: 5,
+    });
+
+    pool.on('error', () => {
+      // Ignore — expected during test teardown
+    });
+
+    await runMigrations(pool);
+
+    const logger: Logger = pino({ level: 'silent' });
+    const services = createServices(pool, logger);
+
+    const testUser = await createTestUserWithAppPassword(pool, 'mcp-test@example.com');
+    const otherUser = await createTestUserWithAppPassword(pool, 'mcp-other@example.com');
+
+    const { server: httpServer, baseUrl } = await startMcpHttpServer(services, logger);
+
+    context = {
+      container,
+      pool,
+      services,
+      logger,
+      baseUrl,
+      httpServer,
+      testUser,
+      otherUser,
+    };
+  }, 120000);
+
+  afterAll(async () => {
+    if (context?.httpServer) {
+      await new Promise<void>((resolve) => context.httpServer.close(() => resolve()));
+    }
+    if (context?.pool) {
+      await context.pool.end();
+    }
+    if (context?.container) {
+      await context.container.stop();
+    }
+  }, 120000);
+
+  return { getContext: () => context };
+}

--- a/apps/mcp-server/tests/helpers.ts
+++ b/apps/mcp-server/tests/helpers.ts
@@ -249,6 +249,62 @@ export async function callTool(
   return { status, body };
 }
 
+/**
+ * Revoke all app passwords for a user. Used in tests that need to simulate a
+ * revoked credential; paired with `restoreAppPasswordsForUser` in a try/finally.
+ */
+export async function revokeAppPasswordsForUser(
+  pool: pg.Pool,
+  userExternalId: string,
+): Promise<void> {
+  await pool.query(
+    `UPDATE auth.app_passwords ap
+       SET revoked_at = NOW()
+       FROM auth.users u
+       WHERE ap.user_id = u.id AND u.external_id = $1`,
+    [userExternalId],
+  );
+}
+
+export async function restoreAppPasswordsForUser(
+  pool: pg.Pool,
+  userExternalId: string,
+): Promise<void> {
+  await pool.query(
+    `UPDATE auth.app_passwords ap
+       SET revoked_at = NULL
+       FROM auth.users u
+       WHERE ap.user_id = u.id AND u.external_id = $1`,
+    [userExternalId],
+  );
+}
+
+/**
+ * Delete seeded encounters, circles, and friends for a set of users while
+ * preserving their self-profiles. Junction tables (encounter_friends,
+ * friend_circles) cascade with their parents so we don't need to clean them
+ * explicitly.
+ */
+export async function cleanupUserData(pool: pg.Pool, userExternalIds: string[]): Promise<void> {
+  if (userExternalIds.length === 0) return;
+  await pool.query(
+    `DELETE FROM encounters.encounters
+       WHERE user_id IN (SELECT id FROM auth.users WHERE external_id = ANY($1::uuid[]))`,
+    [userExternalIds],
+  );
+  await pool.query(
+    `DELETE FROM friends.circles
+       WHERE user_id IN (SELECT id FROM auth.users WHERE external_id = ANY($1::uuid[]))`,
+    [userExternalIds],
+  );
+  await pool.query(
+    `DELETE FROM friends.friends f
+       WHERE f.user_id IN (SELECT id FROM auth.users WHERE external_id = ANY($1::uuid[]))
+         AND f.id NOT IN (SELECT self_profile_id FROM auth.users WHERE self_profile_id IS NOT NULL)`,
+    [userExternalIds],
+  );
+}
+
 export function setupMcpTestSuite() {
   let context: TestContext;
 
@@ -267,8 +323,9 @@ export function setupMcpTestSuite() {
       max: 5,
     });
 
-    pool.on('error', () => {
-      // Ignore — expected during test teardown
+    const poolLogger = pino({ level: 'silent' });
+    pool.on('error', (err) => {
+      poolLogger.error({ err }, 'pg pool error during MCP integration test');
     });
 
     await runMigrations(pool);

--- a/apps/mcp-server/tests/helpers.ts
+++ b/apps/mcp-server/tests/helpers.ts
@@ -11,7 +11,7 @@ import type { Logger } from 'pino';
 import pino from 'pino';
 import { Wait } from 'testcontainers';
 import { afterAll, beforeAll } from 'vitest';
-import { createMcpServer } from '../src/server.js';
+import { createMcpRequestHandler, type Session } from '../src/http-handler.js';
 import { createServices, type Services } from '../src/utils/service-factory.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -121,130 +121,16 @@ async function createTestUserWithAppPassword(
 
 function startMcpHttpServer(
   services: Services,
-  _logger: Logger,
-): Promise<{ server: http.Server; baseUrl: string }> {
-  // Import the handler setup inline to avoid circular deps
+  logger: Logger,
+): Promise<{ server: http.Server; baseUrl: string; sessions: Map<string, Session> }> {
   return new Promise((resolve) => {
-    const { randomUUID } = crypto;
-
-    interface Session {
-      transport: import('@modelcontextprotocol/sdk/server/streamableHttp.js').StreamableHTTPServerTransport;
-      userId: string;
-    }
     const sessions = new Map<string, Session>();
-
-    const httpServer = http.createServer(async (req, res) => {
-      const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
-
-      if (url.pathname === '/health') {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok' }));
-        return;
-      }
-
-      if (url.pathname !== '/mcp') {
-        res.writeHead(404, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Not Found' }));
-        return;
-      }
-
-      // Authenticate
-      const authHeader = req.headers.authorization;
-      if (!authHeader?.startsWith('Basic ')) {
-        res.writeHead(401, {
-          'WWW-Authenticate': 'Basic realm="Freundebuch MCP"',
-          'Content-Type': 'application/json',
-        });
-        res.end(JSON.stringify({ error: 'Unauthorized' }));
-        return;
-      }
-
-      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
-      const colonIndex = decoded.indexOf(':');
-      if (colonIndex === -1) {
-        res.writeHead(401, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Unauthorized' }));
-        return;
-      }
-
-      const email = decoded.slice(0, colonIndex);
-      const password = decoded.slice(colonIndex + 1);
-
-      const authResult = await services.appPasswords.verifyAppPassword(email, password);
-      if (!authResult) {
-        res.writeHead(401, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Unauthorized' }));
-        return;
-      }
-
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-      if (req.method === 'POST') {
-        const body = await new Promise<string>((resolveBody, reject) => {
-          let data = '';
-          req.on('data', (chunk: Buffer) => {
-            data += chunk.toString();
-          });
-          req.on('end', () => resolveBody(data));
-          req.on('error', reject);
-        });
-
-        let parsedBody: unknown;
-        try {
-          parsedBody = JSON.parse(body);
-        } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
-
-        const existingSession = sessionId ? sessions.get(sessionId) : undefined;
-        if (existingSession) {
-          if (existingSession.userId !== authResult.userId) {
-            res.writeHead(401, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'Unauthorized' }));
-            return;
-          }
-          await existingSession.transport.handleRequest(req, res, parsedBody);
-        } else {
-          const { StreamableHTTPServerTransport } = await import(
-            '@modelcontextprotocol/sdk/server/streamableHttp.js'
-          );
-          const newSessionId = randomUUID();
-          const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: () => newSessionId,
-          });
-
-          const userId = authResult.userId;
-          const server = createMcpServer(services, () => userId);
-          sessions.set(newSessionId, { transport, userId });
-          transport.onclose = () => sessions.delete(newSessionId);
-          await server.connect(transport);
-          await transport.handleRequest(req, res, parsedBody);
-        }
-      } else if (req.method === 'DELETE') {
-        const deleteSession = sessionId ? sessions.get(sessionId) : undefined;
-        if (!deleteSession) {
-          res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Session not found' }));
-          return;
-        }
-        if (deleteSession.userId !== authResult.userId) {
-          res.writeHead(401, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Unauthorized' }));
-          return;
-        }
-        await deleteSession.transport.handleRequest(req, res);
-        sessions.delete(sessionId as string);
-      } else {
-        res.writeHead(405, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Method not allowed' }));
-      }
-    });
+    const handler = createMcpRequestHandler({ services, logger, sessions });
+    const httpServer = http.createServer(handler);
 
     httpServer.listen(0, () => {
       const addr = httpServer.address() as { port: number };
-      resolve({ server: httpServer, baseUrl: `http://localhost:${addr.port}` });
+      resolve({ server: httpServer, baseUrl: `http://localhost:${addr.port}`, sessions });
     });
   });
 }

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, it } from 'vitest';
+import {
+  basicAuthHeader,
+  callTool,
+  initMcpSession,
+  mcpRequest,
+  setupMcpTestSuite,
+} from './helpers.js';
+
+describe('MCP Server', { timeout: 60000 }, () => {
+  const { getContext } = setupMcpTestSuite();
+
+  // =========================================================================
+  // HTTP Routing
+  // =========================================================================
+
+  describe('HTTP Routing', () => {
+    it('should return 200 for /health', async () => {
+      const { baseUrl } = getContext();
+      const response = await fetch(`${baseUrl}/health`);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({ status: 'ok' });
+    });
+
+    it('should return 404 for unknown paths', async () => {
+      const { baseUrl } = getContext();
+      const response = await fetch(`${baseUrl}/unknown`);
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 405 for unsupported methods on /mcp', async () => {
+      const { baseUrl, testUser } = getContext();
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'PUT',
+        headers: {
+          Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+        },
+      });
+      expect(response.status).toBe(405);
+    });
+
+    it('should return 401 for /mcp without auth', async () => {
+      const { baseUrl } = getContext();
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      });
+      expect(response.status).toBe(401);
+      expect(response.headers.get('www-authenticate')).toContain('Basic');
+    });
+  });
+
+  // =========================================================================
+  // Authentication
+  // =========================================================================
+
+  describe('Authentication', () => {
+    it('should authenticate with valid app password', async () => {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+      expect(sessionId).toBeTruthy();
+    });
+
+    it('should reject invalid password', async () => {
+      const { baseUrl, testUser } = getContext();
+      const { status } = await mcpRequest(
+        baseUrl,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+          },
+        },
+        { email: testUser.email, password: 'wrong-password' },
+      );
+      expect(status).toBe(401);
+    });
+
+    it('should reject non-existent user', async () => {
+      const { baseUrl } = getContext();
+      const { status } = await mcpRequest(
+        baseUrl,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+          },
+        },
+        { email: 'nobody@example.com', password: 'xxxx-xxxx-xxxx-xxxx' },
+      );
+      expect(status).toBe(401);
+    });
+
+    it('should reject malformed Basic auth (no colon)', async () => {
+      const { baseUrl } = getContext();
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from('no-colon-here').toString('base64')}`,
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      });
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject Bearer auth (only Basic is supported)', async () => {
+      const { baseUrl } = getContext();
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer some-token',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      });
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject revoked app password', async () => {
+      const { baseUrl, pool, testUser } = getContext();
+
+      await pool.query(
+        `UPDATE auth.app_passwords ap
+         SET revoked_at = NOW()
+         FROM auth.users u
+         WHERE ap.user_id = u.id AND u.external_id = $1`,
+        [testUser.externalId],
+      );
+
+      const { status } = await mcpRequest(
+        baseUrl,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+          },
+        },
+        { email: testUser.email, password: testUser.appPassword },
+      );
+      expect(status).toBe(401);
+
+      // Restore for subsequent tests
+      await pool.query(
+        `UPDATE auth.app_passwords ap
+         SET revoked_at = NULL
+         FROM auth.users u
+         WHERE ap.user_id = u.id AND u.external_id = $1`,
+        [testUser.externalId],
+      );
+    });
+  });
+
+  // =========================================================================
+  // Session Management
+  // =========================================================================
+
+  describe('Session Management', () => {
+    it('should return a session ID on initialize', async () => {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+      expect(sessionId).toBeTruthy();
+      expect(typeof sessionId).toBe('string');
+    });
+
+    it('should reuse an existing session with the same session ID', async () => {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+
+      const { status, body } = await mcpRequest(
+        baseUrl,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        { email: testUser.email, password: testUser.appPassword, sessionId },
+      );
+
+      expect(status).toBe(200);
+      const result = body as { result?: { tools?: unknown[] } };
+      expect(result.result?.tools).toBeDefined();
+    });
+
+    it('should reject session hijacking — different user with existing session ID', async () => {
+      const { baseUrl, testUser, otherUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+
+      const { status } = await mcpRequest(
+        baseUrl,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        { email: otherUser.email, password: otherUser.appPassword, sessionId },
+      );
+
+      expect(status).toBe(401);
+    });
+
+    it('should terminate a session via DELETE', async () => {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+
+      const deleteResponse = await fetch(`${baseUrl}/mcp`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+          'mcp-session-id': sessionId,
+        },
+      });
+      expect(deleteResponse.status).toBe(200);
+    });
+
+    it('should return 404 when deleting a non-existent session', async () => {
+      const { baseUrl, testUser } = getContext();
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+          'mcp-session-id': 'non-existent-session-id',
+        },
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it('should isolate data between users', async () => {
+      const { baseUrl, pool, testUser, otherUser } = getContext();
+
+      await pool.query(
+        `INSERT INTO friends.friends (user_id, display_name)
+         SELECT u.id, 'TestUser Only Friend'
+         FROM auth.users u WHERE u.external_id = $1`,
+        [testUser.externalId],
+      );
+      await pool.query(
+        `INSERT INTO friends.friends (user_id, display_name)
+         SELECT u.id, 'OtherUser Only Friend'
+         FROM auth.users u WHERE u.external_id = $1`,
+        [otherUser.externalId],
+      );
+
+      const session1 = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+      const session2 = await initMcpSession(baseUrl, otherUser.email, otherUser.appPassword);
+
+      const { body: body1 } = await callTool(
+        baseUrl,
+        'list_friends',
+        {},
+        { email: testUser.email, password: testUser.appPassword, sessionId: session1 },
+      );
+      const { body: body2 } = await callTool(
+        baseUrl,
+        'list_friends',
+        {},
+        { email: otherUser.email, password: otherUser.appPassword, sessionId: session2 },
+      );
+
+      const r1 = body1 as { result?: { content?: Array<{ text?: string }> } };
+      const r2 = body2 as { result?: { content?: Array<{ text?: string }> } };
+      const friends1 = JSON.parse(r1.result?.content?.[0]?.text ?? '{}');
+      const friends2 = JSON.parse(r2.result?.content?.[0]?.text ?? '{}');
+
+      const names1 = friends1.friends?.map((f: { displayName: string }) => f.displayName) ?? [];
+      const names2 = friends2.friends?.map((f: { displayName: string }) => f.displayName) ?? [];
+
+      expect(names1).toContain('TestUser Only Friend');
+      expect(names1).not.toContain('OtherUser Only Friend');
+      expect(names2).toContain('OtherUser Only Friend');
+      expect(names2).not.toContain('TestUser Only Friend');
+    });
+  });
+
+  // =========================================================================
+  // Tool Execution
+  // =========================================================================
+
+  describe('Tool Execution', () => {
+    async function getSessionAndAuth() {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+      return { baseUrl, sessionId, email: testUser.email, password: testUser.appPassword };
+    }
+
+    it('should list all 12 tools', async () => {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+
+      const { body } = await mcpRequest(
+        baseUrl,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        { email: testUser.email, password: testUser.appPassword, sessionId },
+      );
+
+      const result = body as { result?: { tools?: Array<{ name: string }> } };
+      const toolNames = result.result?.tools?.map((t) => t.name) ?? [];
+
+      expect(toolNames).toHaveLength(12);
+      expect(toolNames).toContain('list_friends');
+      expect(toolNames).toContain('get_friend');
+      expect(toolNames).toContain('search_friends');
+      expect(toolNames).toContain('faceted_search');
+      expect(toolNames).toContain('get_upcoming_dates');
+      expect(toolNames).toContain('get_network_graph');
+      expect(toolNames).toContain('list_circles');
+      expect(toolNames).toContain('get_circle');
+      expect(toolNames).toContain('list_collectives');
+      expect(toolNames).toContain('get_collective');
+      expect(toolNames).toContain('list_encounters');
+      expect(toolNames).toContain('get_encounter');
+    });
+
+    it('list_friends should return a paginated list', async () => {
+      const { pool, testUser } = getContext();
+      for (const name of ['Alice', 'Bob', 'Charlie']) {
+        await pool.query(
+          `INSERT INTO friends.friends (user_id, display_name)
+           SELECT u.id, $2 FROM auth.users u WHERE u.external_id = $1`,
+          [testUser.externalId, name],
+        );
+      }
+
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'list_friends',
+        { pageSize: 10 },
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const data = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
+      expect(data.friends.length).toBeGreaterThanOrEqual(3);
+      expect(data.total).toBeGreaterThanOrEqual(3);
+    });
+
+    it('get_friend should return friend details', async () => {
+      const { pool, testUser } = getContext();
+      const friendResult = await pool.query(
+        `INSERT INTO friends.friends (user_id, display_name, nickname)
+         SELECT u.id, 'Detail Friend', 'Detaily'
+         FROM auth.users u WHERE u.external_id = $1
+         RETURNING external_id`,
+        [testUser.externalId],
+      );
+      const friendId = friendResult.rows[0].external_id;
+
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'get_friend',
+        { friendId },
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const friend = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
+      expect(friend.displayName).toBe('Detail Friend');
+      expect(friend.nickname).toBe('Detaily');
+    });
+
+    it('get_friend should return not found for non-existent friend', async () => {
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'get_friend',
+        { friendId: '00000000-0000-0000-0000-000000000000' },
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      expect(result.result?.content?.[0]?.text).toBe('Friend not found.');
+    });
+
+    it('search_friends should return results', async () => {
+      const { pool, testUser } = getContext();
+      await pool.query(
+        `INSERT INTO friends.friends (user_id, display_name)
+         SELECT u.id, 'Searchable Uniquename'
+         FROM auth.users u WHERE u.external_id = $1`,
+        [testUser.externalId],
+      );
+
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'search_friends',
+        { query: 'Uniquename', limit: 5 },
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const results = JSON.parse(result.result?.content?.[0]?.text ?? '[]');
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('list_circles should return circles', async () => {
+      const { pool, testUser } = getContext();
+      await pool.query(
+        `INSERT INTO friends.circles (user_id, name, color)
+         SELECT u.id, 'Close Friends', '#FF0000'
+         FROM auth.users u WHERE u.external_id = $1`,
+        [testUser.externalId],
+      );
+
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(baseUrl, 'list_circles', {}, { email, password, sessionId });
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const circles = JSON.parse(result.result?.content?.[0]?.text ?? '[]');
+      expect(circles.some((c: { name: string }) => c.name === 'Close Friends')).toBe(true);
+    });
+
+    it('list_encounters should return encounters', async () => {
+      const { pool, testUser } = getContext();
+      await pool.query(
+        `INSERT INTO encounters.encounters (user_id, title, encounter_date)
+         SELECT u.id, 'Coffee meetup', '2024-06-15'
+         FROM auth.users u WHERE u.external_id = $1`,
+        [testUser.externalId],
+      );
+
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'list_encounters',
+        {},
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const data = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
+      expect(data.encounters.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('get_upcoming_dates should return dates array', async () => {
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'get_upcoming_dates',
+        { days: 365, limit: 50 },
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const dates = JSON.parse(result.result?.content?.[0]?.text ?? '[]');
+      expect(Array.isArray(dates)).toBe(true);
+    });
+
+    it('get_network_graph should return nodes and links', async () => {
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'get_network_graph',
+        {},
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const data = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
+      expect(data.nodes).toBeDefined();
+      expect(data.links).toBeDefined();
+    });
+  });
+});

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -1,14 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   basicAuthHeader,
   callTool,
+  cleanupUserData,
   initMcpSession,
   mcpRequest,
+  restoreAppPasswordsForUser,
+  revokeAppPasswordsForUser,
   setupMcpTestSuite,
 } from './helpers.js';
 
 describe('MCP Server', { timeout: 60000 }, () => {
   const { getContext } = setupMcpTestSuite();
+
+  afterEach(async () => {
+    const { pool, testUser, otherUser } = getContext();
+    await cleanupUserData(pool, [testUser.externalId, otherUser.externalId]);
+  });
 
   // =========================================================================
   // HTTP Routing
@@ -210,38 +218,26 @@ describe('MCP Server', { timeout: 60000 }, () => {
     it('should reject revoked app password', async () => {
       const { baseUrl, pool, testUser } = getContext();
 
-      await pool.query(
-        `UPDATE auth.app_passwords ap
-         SET revoked_at = NOW()
-         FROM auth.users u
-         WHERE ap.user_id = u.id AND u.external_id = $1`,
-        [testUser.externalId],
-      );
-
-      const { status } = await mcpRequest(
-        baseUrl,
-        {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'initialize',
-          params: {
-            protocolVersion: '2025-03-26',
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
+      await revokeAppPasswordsForUser(pool, testUser.externalId);
+      try {
+        const { status } = await mcpRequest(
+          baseUrl,
+          {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: '2025-03-26',
+              capabilities: {},
+              clientInfo: { name: 'test-client', version: '1.0.0' },
+            },
           },
-        },
-        { email: testUser.email, password: testUser.appPassword },
-      );
-      expect(status).toBe(401);
-
-      // Restore for subsequent tests
-      await pool.query(
-        `UPDATE auth.app_passwords ap
-         SET revoked_at = NULL
-         FROM auth.users u
-         WHERE ap.user_id = u.id AND u.external_id = $1`,
-        [testUser.externalId],
-      );
+          { email: testUser.email, password: testUser.appPassword },
+        );
+        expect(status).toBe(401);
+      } finally {
+        await restoreAppPasswordsForUser(pool, testUser.externalId);
+      }
     });
   });
 
@@ -382,7 +378,7 @@ describe('MCP Server', { timeout: 60000 }, () => {
       const result = body as { result?: { tools?: Array<{ name: string }> } };
       const toolNames = result.result?.tools?.map((t) => t.name) ?? [];
 
-      expect(toolNames).toHaveLength(12);
+      expect(toolNames.length).toBeGreaterThanOrEqual(12);
       expect(toolNames).toContain('list_friends');
       expect(toolNames).toContain('get_friend');
       expect(toolNames).toContain('search_friends');

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -48,6 +48,19 @@ describe('MCP Server', { timeout: 60000 }, () => {
       expect(response.status).toBe(405);
     });
 
+    it('should accept /mcp/ with a trailing slash', async () => {
+      // Some reverse proxies normalize requests to add a trailing slash; the
+      // MCP path matcher must treat `/mcp/` as equivalent to `/mcp`.
+      const { baseUrl, testUser } = getContext();
+      const response = await fetch(`${baseUrl}/mcp/`, {
+        method: 'PUT',
+        headers: {
+          Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+        },
+      });
+      expect(response.status).toBe(405);
+    });
+
     it('should return 401 for /mcp without auth', async () => {
       const { baseUrl } = getContext();
       const response = await fetch(`${baseUrl}/mcp`, {

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -50,6 +50,86 @@ describe('MCP Server', { timeout: 60000 }, () => {
       expect(response.status).toBe(401);
       expect(response.headers.get('www-authenticate')).toContain('Basic');
     });
+
+    it('should return 413 for bodies exceeding the size cap', async () => {
+      const { baseUrl, testUser } = getContext();
+      // Payload > 1 MiB default cap. Use a single big string value to keep JSON legal.
+      const bigValue = 'x'.repeat(2 * 1024 * 1024);
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { filler: bigValue },
+      });
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+        },
+        body,
+      });
+      expect(response.status).toBe(413);
+    });
+
+    it('should return 400 for duplicate mcp-session-id headers', async () => {
+      const { baseUrl, testUser } = getContext();
+      // `undici` fetch collapses duplicate headers into a comma-joined string,
+      // so use raw http.request with an array-valued header to emit two
+      // separate header lines (Node surfaces both in `req.rawHeaders`).
+      const http = await import('node:http');
+      const url = new URL(`${baseUrl}/mcp`);
+      const { status, body } = await new Promise<{ status: number; body: string }>(
+        (resolve, reject) => {
+          const req = http.request(
+            {
+              method: 'POST',
+              hostname: url.hostname,
+              port: url.port,
+              path: url.pathname,
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+                'mcp-session-id': ['session-one', 'session-two'],
+              },
+            },
+            (res) => {
+              const chunks: Buffer[] = [];
+              res.on('data', (c: Buffer) => chunks.push(c));
+              res.on('end', () =>
+                resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }),
+              );
+            },
+          );
+          req.on('error', reject);
+          req.end(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }));
+        },
+      );
+      expect(status).toBe(400);
+      expect(body).toContain('Duplicate');
+    });
+
+    it('should handle multi-byte utf-8 characters correctly', async () => {
+      const { baseUrl, testUser } = getContext();
+      const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
+
+      // Request payload carrying emoji + non-ASCII — guards against naive
+      // per-chunk `Buffer.toString()` that would mangle split code points.
+      const { status } = await mcpRequest(
+        baseUrl,
+        {
+          jsonrpc: '2.0',
+          id: 42,
+          method: 'tools/call',
+          params: {
+            name: 'search_friends',
+            arguments: { query: '🌮 café 日本語 €', limit: 1 },
+          },
+        },
+        { email: testUser.email, password: testUser.appPassword, sessionId },
+      );
+      expect(status).toBe(200);
+    });
   });
 
   // =========================================================================

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -93,6 +93,44 @@ describe('MCP Server', { timeout: 60000 }, () => {
       expect(response.status).toBe(413);
     });
 
+    it('should not crash when client aborts during oversized body drain', async () => {
+      // Repro: client declares Content-Length > 1 MiB cap, writes a partial body,
+      // then destroys the socket. readBody() short-circuits on Content-Length and
+      // starts draining via req.resume(). The aborted socket surfaces an 'error'
+      // event on the server-side IncomingMessage. Without a no-op error listener
+      // attached before resume(), Node would throw an uncaught error and crash
+      // this test process. Server liveness is verified via /health afterward.
+      const { baseUrl, testUser } = getContext();
+      const http = await import('node:http');
+      const url = new URL(`${baseUrl}/mcp`);
+
+      await new Promise<void>((resolve) => {
+        const req = http.request({
+          method: 'POST',
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': String(2 * 1024 * 1024),
+            Authorization: basicAuthHeader(testUser.email, testUser.appPassword),
+          },
+        });
+        // Expected after destroy(); swallow so the test runner doesn't see it.
+        req.on('error', () => undefined);
+        req.on('close', () => resolve());
+        req.write(Buffer.alloc(64));
+        setTimeout(() => req.destroy(), 10);
+      });
+
+      // Give the server a tick to process the aborted stream + any background drain.
+      await new Promise((r) => setTimeout(r, 100));
+
+      // If the server crashed on an unhandled 'error' event, this would fail.
+      const health = await fetch(`${baseUrl}/health`);
+      expect(health.status).toBe(200);
+    });
+
     it('should return 400 for duplicate mcp-session-id headers', async () => {
       const { baseUrl, testUser } = getContext();
       // `undici` fetch collapses duplicate headers into a comma-joined string,

--- a/apps/mcp-server/tsconfig.build.json
+++ b/apps/mcp-server/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "./src",
+    "paths": {}
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "types": ["node", "vitest/globals"],
+    "noEmit": true,
+    "paths": {
+      "@freundebuch/shared": ["../../packages/shared/src/index.ts"],
+      "@freundebuch/shared/index.js": ["../../packages/shared/src/index.ts"],
+      "@freundebuch/backend/*": ["../backend/src/*"]
+    }
+  },
+  "include": ["src/**/*", "tests/**/*", "../backend/src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/mcp-server/vitest.config.ts
+++ b/apps/mcp-server/vitest.config.ts
@@ -1,0 +1,12 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: 'node',
+    fileParallelism: false,
+    exclude: ['node_modules', 'dist', '.git', '.cache'],
+  },
+});

--- a/apps/sabredav/src/Auth/AppPasswordBackend.php
+++ b/apps/sabredav/src/Auth/AppPasswordBackend.php
@@ -23,11 +23,43 @@ use Sabre\DAV\Auth\Backend\AbstractBasic;
  */
 class AppPasswordBackend extends AbstractBasic
 {
+    private const FORMAT_CHUNK_SIZE = 4;
+    private const FORMAT_STRIDE = self::FORMAT_CHUNK_SIZE + 1;
+
     private PDO $pdo;
 
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
+    }
+
+    /**
+     * Invert the server-side formatPassword (4-char chunks joined with '-').
+     *
+     * Base64url — the alphabet used for raw passwords — includes '-' as a
+     * valid character, so naive `str_replace('-', '', ...)` corrupts passwords
+     * whose raw contains '-'. Walk the input and strip only the dashes that
+     * sit at separator positions. Fall back to full strip for malformed input
+     * so bcrypt still gets a deterministic value (and fails the compare).
+     */
+    private function unformatPassword(string $input): string
+    {
+        $len = strlen($input);
+        $wellFormatted = $len >= self::FORMAT_STRIDE && ($len + 1) % self::FORMAT_STRIDE === 0;
+        if (!$wellFormatted) {
+            return str_replace('-', '', $input);
+        }
+        $out = '';
+        for ($i = 0; $i < $len; $i++) {
+            if ($i % self::FORMAT_STRIDE === self::FORMAT_CHUNK_SIZE) {
+                if ($input[$i] !== '-') {
+                    return str_replace('-', '', $input);
+                }
+                continue;
+            }
+            $out .= $input[$i];
+        }
+        return $out;
     }
 
     /**
@@ -39,8 +71,7 @@ class AppPasswordBackend extends AbstractBasic
      */
     protected function validateUserPass($username, $password): bool
     {
-        // Remove dashes from formatted password (xxxx-xxxx-xxxx-xxxx -> xxxxxxxxxxxxxxxx)
-        $rawPassword = str_replace('-', '', $password);
+        $rawPassword = $this->unformatPassword($password);
         $prefix = substr($rawPassword, 0, 8);
 
         // Find user by email

--- a/apps/sabredav/tests/Auth/AppPasswordBackendTest.php
+++ b/apps/sabredav/tests/Auth/AppPasswordBackendTest.php
@@ -161,6 +161,45 @@ class AppPasswordBackendTest extends TestCase
     }
 
     #[Test]
+    public function validateUserPassPreservesRawDashesThatArePartOfBase64Url(): void
+    {
+        // Regression: previous implementation stripped every '-' from the input,
+        // corrupting ~42% of generated passwords whose base64url raw contains
+        // '-'. Now only format-separator dashes are removed.
+        // Raw: "AAAA-BBBCCCCDDDDEEEEFFFFGGGGHHHH" (32 chars, '-' at index 4).
+        // Formatted: "AAAA--BBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH".
+        $rawPassword = 'AAAA-BBBCCCCDDDDEEEEFFFFGGGGHHHH';
+        $formattedPassword = 'AAAA--BBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH';
+        $passwordHash = password_hash($rawPassword, PASSWORD_BCRYPT);
+
+        $userStmt = $this->createMock(PDOStatement::class);
+        $userStmt->method('execute')->willReturn(true);
+        $userStmt->method('fetch')->willReturn([
+            'id' => 1,
+            'external_id' => 'user-uuid',
+            'email' => 'user@example.com',
+        ]);
+
+        $passwordStmt = $this->createMock(PDOStatement::class);
+        $passwordStmt->method('execute')->willReturn(true);
+        $passwordStmt->method('fetch')
+            ->willReturnOnConsecutiveCalls(
+                ['id' => 1, 'password_hash' => $passwordHash],
+                false
+            );
+
+        $updateStmt = $this->createMock(PDOStatement::class);
+        $updateStmt->method('execute')->willReturn(true);
+
+        $this->pdo->method('prepare')
+            ->willReturnOnConsecutiveCalls($userStmt, $passwordStmt, $updateStmt);
+
+        $result = $this->callValidateUserPass('user@example.com', $formattedPassword);
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
     public function validateUserPassHandlesNodeJsBcryptPrefix(): void
     {
         $rawPassword = 'abcd1234efgh5678';

--- a/apps/sabredav/tests/Integration/Auth/AppPasswordBackendIntegrationTest.php
+++ b/apps/sabredav/tests/Integration/Auth/AppPasswordBackendIntegrationTest.php
@@ -90,6 +90,25 @@ class AppPasswordBackendIntegrationTest extends IntegrationTestCase
     }
 
     #[Test]
+    public function validateUserPassPreservesRawDashesThatArePartOfBase64Url(): void
+    {
+        // Regression: previous implementation ran str_replace('-', '', $password)
+        // which corrupted ~42% of generated passwords whose base64url raw
+        // contains '-' (a valid base64url char), yielding intermittent 401s.
+        $user = $this->createTestUser('user@example.com');
+        // Raw: 32-char base64url with embedded '-' at index 4.
+        // "AAAA" | "-BBB" | "CCCC" | "DDDD" | "EEEE" | "FFFF" | "GGGG" | "HHHH"
+        // → formatted "AAAA--BBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH"
+        $rawPassword = 'AAAA-BBBCCCCDDDDEEEEFFFFGGGGHHHH';
+        $formattedPassword = 'AAAA--BBB-CCCC-DDDD-EEEE-FFFF-GGGG-HHHH';
+        $this->createAppPassword((int) $user['id'], 'Test Device', $rawPassword);
+
+        $result = $this->callValidateUserPass('user@example.com', $formattedPassword);
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
     public function validateUserPassUpdatesLastUsedAt(): void
     {
         $user = $this->createTestUser('user@example.com');

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,27 @@
 services:
+  mcp-server:
+    image: ghcr.io/enko/freundebuch2-mcp-server:${VERSION:-latest}
+    container_name: freundebuch-mcp-server
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_POOL_MIN: ${DATABASE_POOL_MIN:-1}
+      DATABASE_POOL_MAX: ${DATABASE_POOL_MAX:-5}
+      MCP_PORT: 3100
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      ENV: production
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3100/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   nginx:
     image: ghcr.io/enko/freundebuch2-nginx:${VERSION:-latest}
     container_name: freundebuch-nginx
@@ -8,6 +31,8 @@ services:
       BACKEND_PORT: 3000
       SABREDAV_HOST: sabredav
       SABREDAV_PORT: 9000
+      MCP_HOST: mcp-server
+      MCP_PORT: 3100
       NGINX_ACCESS_LOG: ${NGINX_ACCESS_LOG:-off}
       NGINX_ERROR_LOG_LEVEL: ${NGINX_ERROR_LOG_LEVEL:-warn}
     networks:
@@ -34,6 +59,8 @@ services:
       start_period: 40s
     depends_on:
       backend:
+        condition: service_healthy
+      mcp-server:
         condition: service_healthy
       sabredav:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,33 @@ services:
       - /app/node_modules
     command: pnpm --filter frontend run dev
 
+  mcp:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.backend
+    container_name: freundebuch-mcp
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://freundebuch:dev_password@postgres:5432/freundebuch_dev
+      DATABASE_POOL_MIN: 1
+      DATABASE_POOL_MAX: 5
+      MCP_PORT: 3100
+      LOG_LEVEL: debug
+      ENV: development
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./apps/mcp-server:/app/apps/mcp-server
+      - /app/apps/mcp-server/node_modules
+      - ./apps/backend:/app/apps/backend
+      - /app/apps/backend/node_modules
+      - ./packages:/app/packages
+      - /app/packages/shared/node_modules
+      - /app/node_modules
+    command: pnpm --filter @freundebuch/mcp-server run dev
+
   sabredav:
     build:
       context: .
@@ -97,6 +124,8 @@ services:
       backend:
         condition: service_started
       frontend:
+        condition: service_started
+      mcp:
         condition: service_started
       sabredav:
         condition: service_healthy

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -13,6 +13,7 @@ COPY tsconfig.base.json ./
 # Copy all workspace package.json files (needed for pnpm lockfile resolution)
 COPY apps/backend/package.json ./apps/backend/
 COPY apps/frontend/package.json ./apps/frontend/
+COPY apps/mcp-server/package.json ./apps/mcp-server/
 COPY packages/shared/package.json ./packages/shared/
 
 # Install dependencies
@@ -20,6 +21,7 @@ RUN pnpm install --frozen-lockfile
 
 # Copy source code
 COPY apps/backend ./apps/backend
+COPY apps/mcp-server ./apps/mcp-server
 COPY packages/shared ./packages/shared
 COPY database ./database
 

--- a/docker/Dockerfile.backend.prod
+++ b/docker/Dockerfile.backend.prod
@@ -1,8 +1,11 @@
 # syntax=docker/dockerfile:1.4
-# Production Dockerfile for Backend
+# Production Dockerfile for Node-based services (backend + mcp-server).
+# Two production targets share the workspace install + shared/backend build:
+#   --target backend     → ghcr.io/.../backend
+#   --target mcp-server  → ghcr.io/.../mcp-server
 # ============================================
 
-# Stage 1: Build dependencies and compile TypeScript
+# Stage 1: Build dependencies and compile TypeScript (shared by both targets)
 FROM node:24-bookworm-slim AS builder
 
 # Get target architecture for cache isolation
@@ -22,8 +25,11 @@ WORKDIR /app
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 
-# Copy package.json files for dependency resolution
+# Copy package.json files for all workspaces that participate in either prod image.
+# mcp-server depends on @freundebuch/backend (workspace dep), so backend's
+# package.json is required even for the mcp-server target.
 COPY apps/backend/package.json ./apps/backend/
+COPY apps/mcp-server/package.json ./apps/mcp-server/
 COPY packages/shared/package.json ./packages/shared/
 
 # Install all dependencies with architecture-specific cache mount
@@ -33,17 +39,19 @@ RUN --mount=type=cache,id=pnpm-${TARGETARCH},target=/root/.local/share/pnpm/stor
 # Copy source code
 COPY packages/shared ./packages/shared
 COPY apps/backend ./apps/backend
+COPY apps/mcp-server ./apps/mcp-server
 COPY database ./database
 
-# Build shared package and backend
+# Build shared package, backend, mcp-server, and migrations
 RUN pnpm --filter @freundebuch/shared run build && \
     pnpm --filter @freundebuch/backend run build && \
+    pnpm --filter @freundebuch/mcp-server run build && \
     pnpm run migrate:build
 
-# Stage 2: Production runtime
-FROM node:24-bookworm-slim AS production
+# ============================================
+# Stage 2: backend production runtime
+FROM node:24-bookworm-slim AS backend
 
-# Get target architecture for cache isolation
 ARG TARGETARCH
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -79,3 +87,48 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
 
 CMD ["node", "/app/apps/backend/dist/index.js"]
+
+# ============================================
+# Stage 3: mcp-server production runtime
+FROM node:24-bookworm-slim AS mcp-server
+
+ARG TARGETARCH
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+
+# Copy workspace configuration for production dependencies. mcp-server imports
+# @freundebuch/backend/services/*.js at runtime (workspace dep), so backend's
+# package.json must be present for pnpm to wire up the workspace symlink.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY apps/mcp-server/package.json ./apps/mcp-server/
+COPY apps/backend/package.json ./apps/backend/
+COPY packages/shared/package.json ./packages/shared/
+
+# Install production dependencies only with architecture-specific cache mount
+RUN --mount=type=cache,id=pnpm-${TARGETARCH},target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod --ignore-scripts
+
+# Copy built artifacts. backend dist is included because mcp-server resolves
+# `@freundebuch/backend/services/*.js` to backend's compiled JS via the
+# workspace package's `exports` field.
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder /app/apps/backend/dist ./apps/backend/dist
+COPY --from=builder /app/apps/mcp-server/dist ./apps/mcp-server/dist
+
+RUN chown -R node:node /app
+
+# config.ts requires ENV; default it so the all-in-one supervisord image and
+# any compose deploy that forgets to set ENV still boot in production mode.
+ENV ENV=production
+ENV MCP_PORT=3100
+
+EXPOSE 3100
+
+# Drop to non-root user
+USER node
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3100/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
+
+CMD ["node", "/app/apps/mcp-server/dist/index.js"]

--- a/docker/Dockerfile.backend.prod
+++ b/docker/Dockerfile.backend.prod
@@ -1,8 +1,11 @@
 # syntax=docker/dockerfile:1.4
 # Production Dockerfile for Node-based services (backend + mcp-server).
-# Two production targets share the workspace install + shared/backend build:
-#   --target backend     → ghcr.io/.../backend
-#   --target mcp-server  → ghcr.io/.../mcp-server
+# Two production targets share the workspace install + shared/backend build.
+# `backend` is the *last* stage so a plain `docker build` (no `--target`)
+# produces the backend image — matches the historical default.
+#   docker build -f docker/Dockerfile.backend.prod .                 → backend
+#   docker build -f docker/Dockerfile.backend.prod --target backend .→ backend
+#   docker build -f docker/Dockerfile.backend.prod --target mcp-server . → mcp-server
 # ============================================
 
 # Stage 1: Build dependencies and compile TypeScript (shared by both targets)
@@ -49,47 +52,7 @@ RUN pnpm --filter @freundebuch/shared run build && \
     pnpm run migrate:build
 
 # ============================================
-# Stage 2: backend production runtime
-FROM node:24-bookworm-slim AS backend
-
-ARG TARGETARCH
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-WORKDIR /app
-
-# Copy workspace configuration for production dependencies
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
-COPY apps/backend/package.json ./apps/backend/
-COPY packages/shared/package.json ./packages/shared/
-
-# Install production dependencies only with architecture-specific cache mount
-RUN --mount=type=cache,id=pnpm-${TARGETARCH},target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod --ignore-scripts
-
-# Copy built artifacts
-COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
-COPY --from=builder /app/apps/backend/dist ./apps/backend/dist
-COPY --from=builder /app/database/dist ./database/dist
-
-# Create uploads directory and set ownership for non-root execution
-RUN mkdir -p /app/uploads && \
-    chown -R node:node /app
-
-ENV NODE_ENV=production
-ENV PORT=3000
-
-EXPOSE 3000
-
-# Drop to non-root user
-USER node
-
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
-
-CMD ["node", "/app/apps/backend/dist/index.js"]
-
-# ============================================
-# Stage 3: mcp-server production runtime
+# Stage 2: mcp-server production runtime
 FROM node:24-bookworm-slim AS mcp-server
 
 ARG TARGETARCH
@@ -132,3 +95,43 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3100/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
 
 CMD ["node", "/app/apps/mcp-server/dist/index.js"]
+
+# ============================================
+# Stage 3: backend production runtime (default target)
+FROM node:24-bookworm-slim AS backend
+
+ARG TARGETARCH
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+
+# Copy workspace configuration for production dependencies
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY apps/backend/package.json ./apps/backend/
+COPY packages/shared/package.json ./packages/shared/
+
+# Install production dependencies only with architecture-specific cache mount
+RUN --mount=type=cache,id=pnpm-${TARGETARCH},target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod --ignore-scripts
+
+# Copy built artifacts
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder /app/apps/backend/dist ./apps/backend/dist
+COPY --from=builder /app/database/dist ./database/dist
+
+# Create uploads directory and set ownership for non-root execution
+RUN mkdir -p /app/uploads && \
+    chown -R node:node /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+EXPOSE 3000
+
+# Drop to non-root user
+USER node
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
+
+CMD ["node", "/app/apps/backend/dist/index.js"]

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -44,6 +44,11 @@ http {
         server 127.0.0.1:9000;
     }
 
+    # Upstream for MCP server
+    upstream mcp-server {
+        server 127.0.0.1:3100;
+    }
+
     server {
         listen 80;
         listen [::]:80;
@@ -99,6 +104,22 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # MCP Server - Model Context Protocol endpoint for LLM access
+        location ^~ /mcp {
+            proxy_pass http://mcp-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+
+            # SSE/streaming support
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
         }
 
         # API routes - proxy to Node.js backend

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -49,6 +49,10 @@ http {
         server 127.0.0.1:3100;
     }
 
+    # Brute-force throttle for the MCP Basic Auth endpoint.
+    # 30 req/min per source IP, with a small burst window.
+    limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;
+
     server {
         listen 80;
         listen [::]:80;
@@ -108,12 +112,13 @@ http {
 
         # MCP Server - Model Context Protocol endpoint for LLM access
         #
-        # TODO: brute-force protection for Basic Auth is intended to live here.
-        # Add a `limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;`
-        # directive at the http{} level and `limit_req zone=mcp_auth burst=10 nodelay;`
-        # inside this location. MCP server itself does not rate-limit on purpose
-        # — see apps/mcp-server/src/http-handler.ts comment.
+        # Brute-force protection for Basic Auth lives at this layer (see the
+        # `limit_req_zone` directive in the surrounding http{} block); the MCP
+        # server intentionally does not rate-limit in-process — see
+        # apps/mcp-server/src/http-handler.ts comment.
         location ^~ /mcp {
+            limit_req zone=mcp_auth burst=10 nodelay;
+
             proxy_pass http://mcp-server;
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -107,6 +107,12 @@ http {
         }
 
         # MCP Server - Model Context Protocol endpoint for LLM access
+        #
+        # TODO: brute-force protection for Basic Auth is intended to live here.
+        # Add a `limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;`
+        # directive at the http{} level and `limit_req zone=mcp_auth burst=10 nodelay;`
+        # inside this location. MCP server itself does not rate-limit on purpose
+        # — see apps/mcp-server/src/http-handler.ts comment.
         location ^~ /mcp {
             proxy_pass http://mcp-server;
             proxy_http_version 1.1;

--- a/docker/nginx.dev.conf
+++ b/docker/nginx.dev.conf
@@ -37,6 +37,11 @@ http {
         server sabredav:9000;
     }
 
+    # Upstream for MCP server
+    upstream mcp-server {
+        server mcp:3100;
+    }
+
     server {
         listen 80;
         listen [::]:80;
@@ -72,6 +77,22 @@ http {
 
             # Pass through authentication headers
             fastcgi_param HTTP_AUTHORIZATION $http_authorization;
+        }
+
+        # MCP Server - Model Context Protocol endpoint for LLM access
+        location ^~ /mcp {
+            proxy_pass http://mcp-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+
+            # SSE/streaming support
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
         }
 
         # API routes - proxy to Node.js backend

--- a/docker/nginx.multiservice.conf.template
+++ b/docker/nginx.multiservice.conf.template
@@ -48,6 +48,9 @@ http {
         server ${MCP_HOST}:${MCP_PORT};
     }
 
+    # Brute-force throttle for the MCP Basic Auth endpoint.
+    limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;
+
     server {
         listen 80;
         listen [::]:80;
@@ -107,12 +110,13 @@ http {
 
         # MCP Server - Model Context Protocol endpoint for LLM access
         #
-        # TODO: brute-force protection for Basic Auth is intended to live here.
-        # Add a `limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;`
-        # directive at the http{} level and `limit_req zone=mcp_auth burst=10 nodelay;`
-        # inside this location. MCP server itself does not rate-limit on purpose
-        # — see apps/mcp-server/src/http-handler.ts comment.
+        # Brute-force protection for Basic Auth lives at this layer (see the
+        # `limit_req_zone` directive in the surrounding http{} block); the MCP
+        # server intentionally does not rate-limit in-process — see
+        # apps/mcp-server/src/http-handler.ts comment.
         location ^~ /mcp {
+            limit_req zone=mcp_auth burst=10 nodelay;
+
             proxy_pass http://mcp-server;
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/docker/nginx.multiservice.conf.template
+++ b/docker/nginx.multiservice.conf.template
@@ -106,6 +106,12 @@ http {
         }
 
         # MCP Server - Model Context Protocol endpoint for LLM access
+        #
+        # TODO: brute-force protection for Basic Auth is intended to live here.
+        # Add a `limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;`
+        # directive at the http{} level and `limit_req zone=mcp_auth burst=10 nodelay;`
+        # inside this location. MCP server itself does not rate-limit on purpose
+        # — see apps/mcp-server/src/http-handler.ts comment.
         location ^~ /mcp {
             proxy_pass http://mcp-server;
             proxy_http_version 1.1;

--- a/docker/nginx.multiservice.conf.template
+++ b/docker/nginx.multiservice.conf.template
@@ -43,6 +43,11 @@ http {
         server ${SABREDAV_HOST}:${SABREDAV_PORT};
     }
 
+    # Upstream for MCP server (separate container)
+    upstream mcp-server {
+        server ${MCP_HOST}:${MCP_PORT};
+    }
+
     server {
         listen 80;
         listen [::]:80;
@@ -98,6 +103,22 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # MCP Server - Model Context Protocol endpoint for LLM access
+        location ^~ /mcp {
+            proxy_pass http://mcp-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+
+            # SSE/streaming support
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
         }
 
         # API routes - proxy to Node.js backend

--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -47,6 +47,9 @@ http {
         server 127.0.0.1:3100;
     }
 
+    # Brute-force throttle for the MCP Basic Auth endpoint.
+    limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;
+
     server {
         listen 80;
         listen [::]:80;
@@ -107,12 +110,13 @@ http {
 
         # MCP Server - Model Context Protocol endpoint for LLM access
         #
-        # TODO: brute-force protection for Basic Auth is intended to live here.
-        # Add a `limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;`
-        # directive at the http{} level and `limit_req zone=mcp_auth burst=10 nodelay;`
-        # inside this location. MCP server itself does not rate-limit on purpose
-        # — see apps/mcp-server/src/http-handler.ts comment.
+        # Brute-force protection for Basic Auth lives at this layer (see the
+        # `limit_req_zone` directive in the surrounding http{} block); the MCP
+        # server intentionally does not rate-limit in-process — see
+        # apps/mcp-server/src/http-handler.ts comment.
         location ^~ /mcp {
+            limit_req zone=mcp_auth burst=10 nodelay;
+
             proxy_pass http://mcp-server;
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -42,6 +42,11 @@ http {
         server 127.0.0.1:9000;
     }
 
+    # Upstream for MCP server
+    upstream mcp-server {
+        server 127.0.0.1:3100;
+    }
+
     server {
         listen 80;
         listen [::]:80;
@@ -98,6 +103,22 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # MCP Server - Model Context Protocol endpoint for LLM access
+        location ^~ /mcp {
+            proxy_pass http://mcp-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+
+            # SSE/streaming support
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
         }
 
         # API routes - proxy to Node.js backend

--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -106,6 +106,12 @@ http {
         }
 
         # MCP Server - Model Context Protocol endpoint for LLM access
+        #
+        # TODO: brute-force protection for Basic Auth is intended to live here.
+        # Add a `limit_req_zone $binary_remote_addr zone=mcp_auth:10m rate=30r/m;`
+        # directive at the http{} level and `limit_req zone=mcp_auth burst=10 nodelay;`
+        # inside this location. MCP server itself does not rate-limit on purpose
+        # — see apps/mcp-server/src/http-handler.ts comment.
         location ^~ /mcp {
             proxy_pass http://mcp-server;
             proxy_http_version 1.1;

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -31,13 +31,14 @@ priority=20
 [program:mcp-server]
 command=node /app/apps/mcp-server/dist/index.js
 directory=/app/apps/mcp-server
+user=node
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=NODE_ENV="production"
+environment=NODE_ENV="production",ENV="production"
 priority=25
 
 [program:php-fpm]

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -28,6 +28,18 @@ stderr_logfile_maxbytes=0
 environment=NODE_ENV="production"
 priority=20
 
+[program:mcp-server]
+command=node /app/apps/mcp-server/dist/index.js
+directory=/app/apps/mcp-server
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+environment=NODE_ENV="production"
+priority=25
+
 [program:php-fpm]
 command=/usr/sbin/php-fpm8.2 -F
 user=www-data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,70 @@ importers:
         specifier: 4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
 
+  apps/mcp-server:
+    dependencies:
+      '@freundebuch/backend':
+        specifier: workspace:*
+        version: link:../backend
+      '@freundebuch/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@3.25.76)
+      '@pgtyped/runtime':
+        specifier: 2.4.2
+        version: 2.4.2
+      arktype:
+        specifier: 2.1.29
+        version: 2.1.29
+      bcrypt:
+        specifier: 6.0.0
+        version: 6.0.0
+      pg:
+        specifier: 8.16.3
+        version: 8.16.3
+      pino:
+        specifier: 10.1.0
+        version: 10.1.0
+      pino-pretty:
+        specifier: 13.1.3
+        version: 13.1.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@testcontainers/postgresql':
+        specifier: 11.10.0
+        version: 11.10.0
+      '@types/bcrypt':
+        specifier: 6.0.0
+        version: 6.0.0
+      '@types/node':
+        specifier: 25.0.3
+        version: 25.0.3
+      '@types/pg':
+        specifier: 8.16.0
+        version: 8.16.0
+      node-pg-migrate:
+        specifier: 8.0.4
+        version: 8.0.4(@types/pg@8.16.0)(pg@8.16.3)
+      testcontainers:
+        specifier: 11.10.0
+        version: 11.10.0
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite-tsconfig-paths:
+        specifier: 6.0.3
+        version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: 4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/danger:
     dependencies:
       '@commitlint/lint':
@@ -831,6 +895,12 @@ packages:
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/node-server@1.19.7':
     resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
     engines: {node: '>=18.14.1'}
@@ -1023,6 +1093,16 @@ packages:
 
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
@@ -2283,6 +2363,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2308,6 +2392,14 @@ packages:
   aggregate-error@5.0.0:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
@@ -2574,6 +2666,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
@@ -2613,6 +2709,10 @@ packages:
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2755,6 +2855,14 @@ packages:
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
     engines: {node: '>=16'}
@@ -2797,8 +2905,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cookiejar@2.1.4:
@@ -2809,6 +2925,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.1.0:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
@@ -3029,6 +3149,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
@@ -3092,6 +3216,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -3106,6 +3233,10 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3161,6 +3292,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -3183,6 +3317,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -3196,6 +3334,14 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -3216,6 +3362,16 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -3263,6 +3419,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -3298,11 +3458,19 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fp-ts@2.16.11:
     resolution: {integrity: sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
@@ -3399,11 +3567,6 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -3484,6 +3647,10 @@ packages:
     resolution: {integrity: sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
+
   hook-std@3.0.0:
     resolution: {integrity: sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3503,6 +3670,10 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -3554,6 +3725,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -3614,6 +3789,14 @@ packages:
     peerDependencies:
       fp-ts: ^2.5.0
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -3659,6 +3842,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -3757,6 +3943,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -4033,6 +4222,10 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs-or-file-map-to-github-branch@1.3.0:
     resolution: {integrity: sha512-AzgIEodmt51dgwB3TmihTf1Fh2SmszdZskC6trFHy4v71R5shLmdjJSYI7ocVfFa7C/TE6ncb0OZ9eBg2rmkBQ==}
 
@@ -4045,6 +4238,10 @@ packages:
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -4062,9 +4259,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -4186,6 +4391,10 @@ packages:
   nanostores@1.1.1:
     resolution: {integrity: sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -4362,6 +4571,10 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4502,6 +4715,10 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   pascal-case@4.0.0:
     resolution: {integrity: sha512-DPrSBfN1ivlJ5WwTdcBfCfmOHZXjaeW+b8DMHXcUWiR8wmO92T6N8elBsJj/v3g+INObw8Zx/q6eFAjA1w071Q==}
     deprecated: Use `change-case`
@@ -4533,6 +4750,9 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4621,6 +4841,10 @@ packages:
   piscina@4.9.2:
     resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
@@ -4698,6 +4922,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -4719,11 +4947,23 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
   rate-limiter-flexible@9.0.1:
     resolution: {integrity: sha512-sO+QdoGPCxroi4VkO2FIVjfUGuexhRkBc9ROHqu5eVEEz+oPHzQqvCc25ajFfMUBosbNGb6qpNa8xmxH9YNZsg==}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4829,6 +5069,10 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -4878,11 +5122,22 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4990,6 +5245,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -5215,6 +5474,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -5281,6 +5544,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -5327,6 +5594,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
 
@@ -5349,6 +5620,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-tsconfig-paths@6.0.3:
     resolution: {integrity: sha512-7bL7FPX/DSviaZGYUKowWF1AiDVWjMjxNbE8lyaVGDezkedWqfGhlnQ4BZXre0ZN5P4kAgIJfAlgFDVyjrCIyg==}
@@ -5585,6 +5860,14 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -6069,12 +6352,12 @@ snapshots:
   '@gitbeaker/core@38.12.1':
     dependencies:
       '@gitbeaker/requester-utils': 38.12.1
-      qs: 6.14.0
+      qs: 6.15.1
       xcase: 2.0.1
 
   '@gitbeaker/requester-utils@38.12.1':
     dependencies:
-      qs: 6.14.0
+      qs: 6.15.1
       xcase: 2.0.1
 
   '@gitbeaker/rest@38.12.1':
@@ -6102,6 +6385,10 @@ snapshots:
       yargs: 17.7.2
 
   '@hexagon/base64@1.1.28': {}
+
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
 
   '@hono/node-server@1.19.7(hono@4.11.1)':
     dependencies:
@@ -6240,6 +6527,28 @@ snapshots:
   '@js-sdsl/ordered-map@4.4.2': {}
 
   '@levischuck/tiny-cbor@0.2.11': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
@@ -7738,6 +8047,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -7761,6 +8075,10 @@ snapshots:
     dependencies:
       clean-stack: 5.3.0
       indent-string: 5.0.0
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv@8.17.1:
     dependencies:
@@ -7800,7 +8118,7 @@ snapshots:
 
   archiver-utils@5.0.2:
     dependencies:
-      glob: 10.4.5
+      glob: 10.5.0
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
@@ -8019,6 +8337,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   bottleneck@2.19.5: {}
 
   brace-expansion@2.0.2:
@@ -8057,6 +8389,8 @@ snapshots:
     optional: true
 
   byline@5.0.0: {}
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -8205,6 +8539,10 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   conventional-changelog-angular@7.0.0:
     dependencies:
       compare-func: 2.0.0
@@ -8245,13 +8583,22 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
 
   cookiejar@2.1.4: {}
 
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.1.0(@types/node@25.0.3)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -8525,6 +8872,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
@@ -8597,6 +8946,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.267: {}
 
   emoji-regex@10.6.0: {}
@@ -8606,6 +8957,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   emojilib@2.4.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -8679,6 +9032,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@5.0.0: {}
@@ -8695,6 +9050,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.1: {}
@@ -8706,6 +9063,12 @@ snapshots:
       - bare-abort-controller
 
   events@3.3.0: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
 
   execa@5.1.1:
     dependencies:
@@ -8752,6 +9115,44 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -8785,6 +9186,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up-simple@1.0.1: {}
 
@@ -8829,9 +9241,13 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  forwarded@0.2.0: {}
+
   fp-ts@2.16.11: {}
 
   fraction.js@5.3.4: {}
+
+  fresh@2.0.0: {}
 
   from2@2.3.0:
     dependencies:
@@ -8926,15 +9342,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -8948,7 +9355,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.0.3
+      minimatch: 10.1.1
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -9011,6 +9418,8 @@ snapshots:
 
   hono@4.11.1: {}
 
+  hono@4.12.14: {}
+
   hook-std@3.0.0: {}
 
   hosted-git-info@7.0.2:
@@ -9030,6 +9439,14 @@ snapshots:
       '@exodus/bytes': 1.8.0
     transitivePeerDependencies:
       - '@exodus/crypto'
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -9081,6 +9498,10 @@ snapshots:
       typescript: 5.9.3
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -9136,6 +9557,10 @@ snapshots:
     dependencies:
       fp-ts: 2.16.11
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
@@ -9165,6 +9590,8 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -9291,6 +9718,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -9535,6 +9964,8 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
+  media-typer@1.1.0: {}
+
   memfs-or-file-map-to-github-branch@1.3.0:
     dependencies:
       '@octokit/rest': 18.12.0
@@ -9547,6 +9978,8 @@ snapshots:
 
   meow@13.2.0: {}
 
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   methods@1.1.2: {}
@@ -9558,9 +9991,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -9631,6 +10070,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.1.1: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -9707,6 +10148,10 @@ snapshots:
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -9832,6 +10277,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   pascal-case@4.0.0:
     dependencies:
       no-case: 4.0.0
@@ -9855,6 +10302,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.4
       minipass: 7.1.2
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -9958,6 +10407,8 @@ snapshots:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
+  pkce-challenge@5.0.1: {}
+
   pkg-conf@2.1.0:
     dependencies:
       find-up: 2.1.0
@@ -10039,6 +10490,11 @@ snapshots:
       '@types/node': 25.0.3
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pump@3.0.3:
@@ -10058,9 +10514,22 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-format-unescaped@4.0.4: {}
 
+  range-parser@1.2.1: {}
+
   rate-limiter-flexible@9.0.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -10197,6 +10666,16 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rw@1.3.3: {}
 
   sade@1.8.1:
@@ -10262,9 +10741,36 @@ snapshots:
 
   semver@7.7.3: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.1: {}
 
   set-cookie-parser@3.0.1: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -10414,6 +10920,8 @@ snapshots:
       nan: 2.23.0
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -10709,6 +11217,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.0:
@@ -10758,6 +11268,12 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   uglify-js@3.19.3:
@@ -10785,6 +11301,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unplugin@1.0.1:
     dependencies:
       acorn: 8.15.0
@@ -10808,6 +11326,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
@@ -11039,5 +11559,11 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -18,6 +18,7 @@ const packagePaths = [
   'package.json',
   'apps/backend/package.json',
   'apps/frontend/package.json',
+  'apps/mcp-server/package.json',
   'packages/shared/package.json',
 ];
 


### PR DESCRIPTION
Add a new MCP (Model Context Protocol) server that exposes Freundebuch
data to AI assistants via Streamable HTTP transport. The server provides
12 read-only tools for querying friends, circles, collectives, and
encounters, authenticated via existing app passwords (HTTP Basic Auth).

- New `apps/mcp-server/` workspace package with direct DB access,
  reusing backend service layer via workspace dependency
- Nginx routing at `/mcp` across all deployment configs
- Docker integration (compose, all-in-one Dockerfile, supervisord)
- Frontend setup guide at `/profile/mcp` with instructions for
  Claude Desktop, Claude Code, and other MCP clients
- i18n translations (en + de) for the setup page

https://claude.ai/code/session_018RWkgff8oVYZfs8yxgNwE2