### PR TITLE
fix(deploy): Align image registry with current repository path

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   mcp-server:
-    image: ghcr.io/enko/freundebuch2-mcp-server:${VERSION:-latest}
+    image: ghcr.io/datenknoten/freundebuch-mcp-server:${VERSION:-latest}
     container_name: freundebuch-mcp-server
     restart: unless-stopped
     environment:
@@ -23,7 +23,7 @@ services:
         condition: service_healthy
 
   nginx:
-    image: ghcr.io/enko/freundebuch2-nginx:${VERSION:-latest}
+    image: ghcr.io/datenknoten/freundebuch-nginx:${VERSION:-latest}
     container_name: freundebuch-nginx
     restart: unless-stopped
     environment:
@@ -66,7 +66,7 @@ services:
         condition: service_healthy
 
   backend:
-    image: ghcr.io/enko/freundebuch2-backend:${VERSION:-latest}
+    image: ghcr.io/datenknoten/freundebuch-backend:${VERSION:-latest}
     container_name: freundebuch-backend
     restart: unless-stopped
     environment:
@@ -109,7 +109,7 @@ services:
         condition: service_healthy
 
   sabredav:
-    image: ghcr.io/enko/freundebuch2-sabredav:${VERSION:-latest}
+    image: ghcr.io/datenknoten/freundebuch-sabredav:${VERSION:-latest}
     container_name: freundebuch-sabredav
     restart: unless-stopped
     environment:
@@ -146,7 +146,7 @@ services:
 
   # OSM address data import (run manually with --profile import)
   osm-import:
-    image: ghcr.io/enko/freundebuch2-osm-import:${VERSION:-latest}
+    image: ghcr.io/datenknoten/freundebuch-osm-import:${VERSION:-latest}
     container_name: freundebuch-osm-import
     profiles:
       - import  # Only runs when explicitly requested

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,17 +24,18 @@ VERSION="$1"
 # Configuration
 COMPOSE_DIR="/srv/freundebuch.schumacher.im"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
-IMAGE_BASE="ghcr.io/enko/freundebuch2"
+IMAGE_BASE="ghcr.io/datenknoten/freundebuch"
 
 # Service images (multi-service architecture)
 IMAGES=(
     "${IMAGE_BASE}-nginx:${VERSION}"
     "${IMAGE_BASE}-backend:${VERSION}"
+    "${IMAGE_BASE}-mcp-server:${VERSION}"
     "${IMAGE_BASE}-sabredav:${VERSION}"
 )
 
 # Services to manage
-SERVICES=("nginx" "backend" "sabredav")
+SERVICES=("nginx" "backend" "mcp-server" "sabredav")
 
 # Retry configuration
 MAX_PULL_RETRIES=5


### PR DESCRIPTION
The release workflow publishes images to ghcr.io/${{ github.repository }}-*,
which resolves to ghcr.io/datenknoten/freundebuch-*. The production deploy
script and compose file still pointed at the old ghcr.io/enko/freundebuch2-*
namespace from before the repo migration, so `docker pull` (and the implicit
pull triggered by `docker compose up` for nginx's mcp-server dependency)
returned `manifest unknown` and aborted the deploy.

- scripts/deploy.sh: update IMAGE_BASE; add mcp-server to IMAGES and
  SERVICES so it benefits from the parallel-pull retry/rollback logic
  instead of being lazily pulled by docker compose at startup.
- docker-compose.prod.yml: rewrite all ghcr.io image references to the
  new namespace.

https://claude.ai/code/session_016DTWqU3VXf9o2z4j7Z1HPG