### PR TITLE
fix(docker): Substitute MCP_HOST/MCP_PORT in nginx config

### DIFF
--- a/docker/nginx-entrypoint.sh
+++ b/docker/nginx-entrypoint.sh
@@ -7,6 +7,8 @@ export BACKEND_HOST="${BACKEND_HOST:-backend}"
 export BACKEND_PORT="${BACKEND_PORT:-3000}"
 export SABREDAV_HOST="${SABREDAV_HOST:-sabredav}"
 export SABREDAV_PORT="${SABREDAV_PORT:-9000}"
+export MCP_HOST="${MCP_HOST:-mcp-server}"
+export MCP_PORT="${MCP_PORT:-3100}"
 
 # Handle access log configuration
 if [ "${NGINX_ACCESS_LOG:-off}" = "off" ]; then
@@ -16,7 +18,7 @@ else
 fi
 
 # Generate nginx config from template
-envsubst '${NGINX_ACCESS_LOG_LINE} ${NGINX_ERROR_LOG_LEVEL} ${BACKEND_HOST} ${BACKEND_PORT} ${SABREDAV_HOST} ${SABREDAV_PORT}' \
+envsubst '${NGINX_ACCESS_LOG_LINE} ${NGINX_ERROR_LOG_LEVEL} ${BACKEND_HOST} ${BACKEND_PORT} ${SABREDAV_HOST} ${SABREDAV_PORT} ${MCP_HOST} ${MCP_PORT}' \
     < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 echo "Nginx configuration generated successfully"


### PR DESCRIPTION
The MCP server feature added an `mcp-server` upstream to
docker/nginx.multiservice.conf.template that references ${MCP_HOST}
and ${MCP_PORT}, but the nginx entrypoint's envsubst whitelist was not
updated. envsubst left those tokens literal in the generated
nginx.conf, so nginx failed to parse the upstream block, the container
never became healthy, and deploy.sh rolled the release back.

Add MCP_HOST/MCP_PORT defaults and include them in the envsubst
whitelist so the template renders correctly.