### PR TITLE
feat(frontend): add long-press create menu to mobile FAB

### DIFF
--- a/apps/frontend/src/lib/actions/long-press.ts
+++ b/apps/frontend/src/lib/actions/long-press.ts
@@ -1,0 +1,120 @@
+interface LongPressParams {
+  onShort: () => void;
+  onLong: () => void;
+  duration?: number;
+}
+
+const DEFAULT_DURATION = 500;
+const MOVE_CANCEL_PX = 10;
+
+/**
+ * Svelte action distinguishing a short tap from a long press on a single element.
+ * Long-press detection uses pointer events; the short action is driven by `click`
+ * so keyboard activation (Enter/Space) and assistive tech work as expected. A
+ * long press opens the secondary action and the synthesized click is suppressed,
+ * so the gesture never double-triggers. The OS callout/context menu is suppressed
+ * only while a touch/pen press is active, leaving desktop right-click intact.
+ *
+ * @example
+ * <button use:longPress={{ onShort: () => goto('/x'), onLong: () => (menuOpen = true) }}>
+ */
+export function longPress(node: HTMLElement, params: LongPressParams) {
+  let current = params;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let longPressFired = false;
+  let activePointerId: number | null = null;
+  let activePointerType = '';
+  let startX = 0;
+  let startY = 0;
+
+  function clearTimer() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function endPress() {
+    clearTimer();
+    activePointerId = null;
+  }
+
+  function handlePointerDown(e: PointerEvent) {
+    // Ignore secondary buttons (e.g. right-click) and additional pointers while
+    // one is already being tracked (multi-touch / re-entrancy).
+    if (e.button !== 0 || activePointerId !== null) return;
+    clearTimer();
+    activePointerId = e.pointerId;
+    activePointerType = e.pointerType;
+    longPressFired = false;
+    startX = e.clientX;
+    startY = e.clientY;
+    timer = setTimeout(() => {
+      timer = null;
+      longPressFired = true;
+      current.onLong();
+    }, current.duration ?? DEFAULT_DURATION);
+  }
+
+  function handlePointerMove(e: PointerEvent) {
+    if (e.pointerId !== activePointerId || !timer) return;
+    if (
+      Math.abs(e.clientX - startX) > MOVE_CANCEL_PX ||
+      Math.abs(e.clientY - startY) > MOVE_CANCEL_PX
+    ) {
+      clearTimer();
+    }
+  }
+
+  function handlePointerEnd(e: PointerEvent) {
+    if (e.pointerId !== activePointerId) return;
+    endPress();
+  }
+
+  function handleClick(e: MouseEvent) {
+    // Suppress the click synthesized after a long press so it doesn't also fire onShort.
+    if (longPressFired) {
+      e.preventDefault();
+      e.stopPropagation();
+      longPressFired = false;
+      return;
+    }
+    // Covers pointer taps (mouse/touch) and keyboard activation (Enter/Space).
+    current.onShort();
+  }
+
+  function handleContextMenu(e: Event) {
+    // Only block the OS long-press menu/callout during a touch/pen press;
+    // leave desktop right-click and assistive tools untouched.
+    if (
+      activePointerId !== null &&
+      (activePointerType === 'touch' || activePointerType === 'pen')
+    ) {
+      e.preventDefault();
+    }
+  }
+
+  node.addEventListener('pointerdown', handlePointerDown);
+  node.addEventListener('pointermove', handlePointerMove);
+  node.addEventListener('pointerup', handlePointerEnd);
+  node.addEventListener('pointercancel', handlePointerEnd);
+  node.addEventListener('pointerleave', handlePointerEnd);
+  node.addEventListener('click', handleClick);
+  node.addEventListener('contextmenu', handleContextMenu);
+
+  return {
+    update(next: LongPressParams) {
+      current = next;
+    },
+    destroy() {
+      clearTimer();
+      node.removeEventListener('pointerdown', handlePointerDown);
+      node.removeEventListener('pointermove', handlePointerMove);
+      node.removeEventListener('pointerup', handlePointerEnd);
+      node.removeEventListener('pointercancel', handlePointerEnd);
+      node.removeEventListener('pointerleave', handlePointerEnd);
+      node.removeEventListener('click', handleClick);
+      node.removeEventListener('contextmenu', handleContextMenu);
+    },
+  };
+}

--- a/apps/frontend/src/lib/actions/long-press.ts
+++ b/apps/frontend/src/lib/actions/long-press.ts
@@ -22,6 +22,7 @@ export function longPress(node: HTMLElement, params: LongPressParams) {
   let current = params;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let longPressFired = false;
+  let cancelled = false;
   let activePointerId: number | null = null;
   let activePointerType = '';
   let startX = 0;
@@ -47,6 +48,7 @@ export function longPress(node: HTMLElement, params: LongPressParams) {
     activePointerId = e.pointerId;
     activePointerType = e.pointerType;
     longPressFired = false;
+    cancelled = false;
     startX = e.clientX;
     startY = e.clientY;
     timer = setTimeout(() => {
@@ -62,7 +64,10 @@ export function longPress(node: HTMLElement, params: LongPressParams) {
       Math.abs(e.clientX - startX) > MOVE_CANCEL_PX ||
       Math.abs(e.clientY - startY) > MOVE_CANCEL_PX
     ) {
+      // Treat a drag/scroll as a cancelled gesture: stop the long press and
+      // suppress the click that follows so it isn't mistaken for a short tap.
       clearTimer();
+      cancelled = true;
     }
   }
 
@@ -72,11 +77,13 @@ export function longPress(node: HTMLElement, params: LongPressParams) {
   }
 
   function handleClick(e: MouseEvent) {
-    // Suppress the click synthesized after a long press so it doesn't also fire onShort.
-    if (longPressFired) {
+    // Suppress the click that follows a long press or a cancelled drag so it
+    // doesn't also fire onShort.
+    if (longPressFired || cancelled) {
       e.preventDefault();
       e.stopPropagation();
       longPressFired = false;
+      cancelled = false;
       return;
     }
     // Covers pointer taps (mouse/touch) and keyboard activation (Enter/Space).

--- a/apps/frontend/src/lib/components/fab-create-menu.svelte
+++ b/apps/frontend/src/lib/components/fab-create-menu.svelte
@@ -18,12 +18,12 @@ export function navigateForCreateChoice(choice: FabCreateChoice): void {
       goto('/collectives/new');
       break;
     case 'circle':
-      // Mirror the keyboard shortcut (shortcuts/handlers/creation.ts): circles are
-      // created via a modal, so open it in place when already on /circles, else navigate.
+      // Circles are created via a modal. Open it in place when already on /circles,
+      // otherwise navigate there with a flag the circles page uses to auto-open it.
       if (get(page).url.pathname === '/circles') {
         window.dispatchEvent(new CustomEvent('shortcut:new-circle'));
       } else {
-        goto('/circles');
+        goto('/circles?new=1');
       }
       break;
   }

--- a/apps/frontend/src/lib/components/fab-create-menu.svelte
+++ b/apps/frontend/src/lib/components/fab-create-menu.svelte
@@ -1,0 +1,154 @@
+<script lang="ts" module>
+import { get } from 'svelte/store';
+import { goto } from '$app/navigation';
+import { page } from '$app/stores';
+
+export type FabCreateChoice = 'friend' | 'encounter' | 'circle' | 'collective';
+
+/** Routes the user to the creation flow for the chosen entity. */
+export function navigateForCreateChoice(choice: FabCreateChoice): void {
+  switch (choice) {
+    case 'friend':
+      goto('/friends/new');
+      break;
+    case 'encounter':
+      goto('/encounters/new');
+      break;
+    case 'collective':
+      goto('/collectives/new');
+      break;
+    case 'circle':
+      // Mirror the keyboard shortcut (shortcuts/handlers/creation.ts): circles are
+      // created via a modal, so open it in place when already on /circles, else navigate.
+      if (get(page).url.pathname === '/circles') {
+        window.dispatchEvent(new CustomEvent('shortcut:new-circle'));
+      } else {
+        goto('/circles');
+      }
+      break;
+  }
+}
+</script>
+
+<script lang="ts">
+import { onMount } from 'svelte';
+import BuildingOffice from 'svelte-heros-v2/BuildingOffice.svelte';
+import Calendar from 'svelte-heros-v2/Calendar.svelte';
+import Swatch from 'svelte-heros-v2/Swatch.svelte';
+import UserPlus from 'svelte-heros-v2/UserPlus.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+import { isModalOpen } from '$lib/stores/ui';
+
+const i18n = createI18n();
+
+interface Props {
+  onSelect: (choice: FabCreateChoice) => void;
+  onClose: () => void;
+}
+
+let { onSelect, onClose }: Props = $props();
+
+const options: { choice: FabCreateChoice; icon: typeof UserPlus; labelKey: string }[] = [
+  { choice: 'friend', icon: UserPlus, labelKey: 'shortcuts.newFriend' },
+  { choice: 'encounter', icon: Calendar, labelKey: 'shortcuts.newEncounter' },
+  { choice: 'circle', icon: Swatch, labelKey: 'shortcuts.newCircle' },
+  { choice: 'collective', icon: BuildingOffice, labelKey: 'shortcuts.newCollective' },
+];
+
+let modalRef = $state<HTMLDivElement | null>(null);
+let optionButtons = $state<HTMLButtonElement[]>([]);
+let cancelButton = $state<HTMLButtonElement | null>(null);
+
+function handleBackdropClick(e: MouseEvent) {
+  if (e.target === e.currentTarget) {
+    onClose();
+  }
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    onClose();
+  }
+
+  // Focus trapping
+  if (e.key === 'Tab' && modalRef) {
+    const firstButton = optionButtons[0];
+    if (!firstButton || !cancelButton) return;
+
+    if (e.shiftKey && document.activeElement === firstButton) {
+      e.preventDefault();
+      cancelButton.focus();
+    } else if (!e.shiftKey && document.activeElement === cancelButton) {
+      e.preventDefault();
+      firstButton.focus();
+    }
+  }
+}
+
+onMount(() => {
+  isModalOpen.set(true);
+  optionButtons[0]?.focus();
+
+  return () => {
+    isModalOpen.set(false);
+  };
+});
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div
+  class="fixed inset-0 bg-black/50 z-50 flex items-end justify-center sm:hidden"
+  onclick={handleBackdropClick}
+  role="presentation"
+>
+  <div
+    bind:this={modalRef}
+    class="w-full bg-white rounded-t-2xl shadow-xl animate-slide-up max-h-[80vh] overflow-y-auto"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="fab-create-menu-title"
+  >
+    <div class="p-4">
+      <h2 id="fab-create-menu-title" class="text-xl font-heading text-gray-900 mb-4 text-center">
+        {$i18n.t('common.createNew')}
+      </h2>
+
+      <div class="space-y-3">
+        {#each options as option, index (option.choice)}
+          {@const Icon = option.icon}
+          <button
+            bind:this={optionButtons[index]}
+            type="button"
+            onclick={() => onSelect(option.choice)}
+            class="w-full flex items-center gap-4 p-4 rounded-xl
+                   bg-gray-50 hover:bg-forest/10 transition-colors
+                   focus:outline-none focus:ring-2 focus:ring-forest focus:ring-offset-2"
+          >
+            <div class="w-12 h-12 rounded-full bg-forest/10 flex items-center justify-center flex-shrink-0">
+              <Icon class="w-6 h-6 text-forest" strokeWidth="2" />
+            </div>
+            <span class="text-base font-body font-semibold text-gray-900">
+              {$i18n.t(option.labelKey)}
+            </span>
+          </button>
+        {/each}
+      </div>
+
+      <button
+        bind:this={cancelButton}
+        type="button"
+        onclick={onClose}
+        class="w-full mt-4 py-3 text-center font-body font-semibold text-gray-600
+               hover:bg-gray-100 rounded-xl transition-colors
+               focus:outline-none focus:ring-2 focus:ring-forest focus:ring-offset-2"
+      >
+        {$i18n.t('common.cancel')}
+      </button>
+    </div>
+
+    <!-- Safe area padding for iOS -->
+    <div class="h-safe-area-inset-bottom"></div>
+  </div>
+</div>

--- a/apps/frontend/src/lib/components/friends/friend-detail.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-detail.svelte
@@ -4,7 +4,12 @@ import Heart from 'svelte-heros-v2/Heart.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { goto } from '$app/navigation';
+import { longPress } from '$lib/actions/long-press';
 import { getCollectivesForFriend } from '$lib/api/friends';
+import FabCreateMenu, {
+  type FabCreateChoice,
+  navigateForCreateChoice,
+} from '$lib/components/fab-create-menu.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
 import {
@@ -135,6 +140,7 @@ let showDeleteConfirm = $state(false);
 // Mobile add modal state
 let showMobileAddChoiceModal = $state(false);
 let showMobileAddModal = $state(false);
+let showFabCreateMenu = $state(false);
 
 // Friend delete handler
 async function handleDelete() {
@@ -361,13 +367,16 @@ onMount(() => {
   </section>
 </div>
 
-<!-- Mobile FAB for adding -->
+<!-- Mobile FAB: tap = add friend/detail choice, long-press = create menu -->
 <button
   type="button"
-  onclick={() => showMobileAddChoiceModal = true}
+  use:longPress={{
+    onShort: () => (showMobileAddChoiceModal = true),
+    onLong: () => (showFabCreateMenu = true),
+  }}
   class="fixed bottom-6 right-6 sm:hidden w-14 h-14 bg-forest text-white
          rounded-full shadow-lg hover:bg-forest-light transition-colors
-         flex items-center justify-center z-40"
+         flex items-center justify-center z-40 select-none touch-none [-webkit-touch-callout:none]"
   aria-label={$i18n.t('subresources.common.add')}
 >
   <Plus class="w-6 h-6" strokeWidth="2" />
@@ -396,6 +405,17 @@ onMount(() => {
       dispatchAddEvent(type);
     }}
     onClose={() => showMobileAddModal = false}
+  />
+{/if}
+
+<!-- Mobile long-press create menu -->
+{#if showFabCreateMenu}
+  <FabCreateMenu
+    onSelect={(choice: FabCreateChoice) => {
+      showFabCreateMenu = false;
+      navigateForCreateChoice(choice);
+    }}
+    onClose={() => (showFabCreateMenu = false)}
   />
 {/if}
 

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -10,6 +10,7 @@
     "back": "Zurück",
     "next": "Weiter",
     "new": "Neu",
+    "createNew": "Neu erstellen",
     "submit": "Absenden",
     "search": "Suchen",
     "filter": "Filtern",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -10,6 +10,7 @@
     "back": "Back",
     "next": "Next",
     "new": "New",
+    "createNew": "Create new",
     "submit": "Submit",
     "search": "Search",
     "filter": "Filter",

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -85,12 +85,13 @@ const showFab = $derived(
 
 let createMenuOpen = $state(false);
 
-// Close the create menu on navigation (incl. browser back/forward) so the
-// bottom-sheet overlay can never linger on a route where the FAB is hidden.
-let lastPath = $page.url.pathname;
+// Close the create menu on any navigation (incl. browser back/forward and
+// query-param-only updates) so the bottom-sheet overlay can never linger on a
+// route where the FAB is hidden.
+let lastHref = $page.url.href;
 $effect(() => {
-  if ($page.url.pathname !== lastPath) {
-    lastPath = $page.url.pathname;
+  if ($page.url.href !== lastHref) {
+    lastHref = $page.url.href;
     createMenuOpen = false;
   }
 });

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -85,6 +85,16 @@ const showFab = $derived(
 
 let createMenuOpen = $state(false);
 
+// Close the create menu on navigation (incl. browser back/forward) so the
+// bottom-sheet overlay can never linger on a route where the FAB is hidden.
+let lastPath = $page.url.pathname;
+$effect(() => {
+  if ($page.url.pathname !== lastPath) {
+    lastPath = $page.url.pathname;
+    createMenuOpen = false;
+  }
+});
+
 function handleCreateSelect(choice: FabCreateChoice) {
   createMenuOpen = false;
   navigateForCreateChoice(choice);
@@ -117,7 +127,7 @@ function handleCreateSelect(choice: FabCreateChoice) {
 		</button>
 	{/if}
 
-	{#if createMenuOpen}
+	{#if showFab && createMenuOpen}
 		<FabCreateMenu onSelect={handleCreateSelect} onClose={() => (createMenuOpen = false)} />
 	{/if}
 </div>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -5,6 +5,11 @@ import type { Snippet } from 'svelte';
 import { onMount } from 'svelte';
 import { goto } from '$app/navigation';
 import { page } from '$app/stores';
+import { longPress } from '$lib/actions/long-press';
+import FabCreateMenu, {
+  type FabCreateChoice,
+  navigateForCreateChoice,
+} from '$lib/components/fab-create-menu.svelte';
 import Footer from '$lib/components/footer.svelte';
 import GlobalSearch from '$lib/components/global-search.svelte';
 import NavBar from '$lib/components/nav-bar.svelte';
@@ -77,6 +82,13 @@ const showFab = $derived(
     !$page.url.pathname.includes('/friends/new') &&
     !$page.url.pathname.match(/^\/friends\/[^/]+$/),
 );
+
+let createMenuOpen = $state(false);
+
+function handleCreateSelect(choice: FabCreateChoice) {
+  createMenuOpen = false;
+  navigateForCreateChoice(choice);
+}
 </script>
 
 <KeyboardShortcuts />
@@ -89,16 +101,23 @@ const showFab = $derived(
 	</main>
 	<Footer />
 
-	<!-- Floating Action Button for mobile -->
+	<!-- Floating Action Button for mobile: tap = new friend, long-press = create menu -->
 	{#if showFab}
-		<a
-			href="/friends/new"
-			data-sveltekit-preload-data="tap"
-			class="fixed bottom-6 right-6 sm:hidden w-14 h-14 bg-forest text-white rounded-full shadow-lg hover:bg-forest-light transition-colors flex items-center justify-center z-50"
+		<button
+			type="button"
+			use:longPress={{
+				onShort: () => goto('/friends/new'),
+				onLong: () => (createMenuOpen = true),
+			}}
+			class="fixed bottom-6 right-6 sm:hidden w-14 h-14 bg-forest text-white rounded-full shadow-lg hover:bg-forest-light transition-colors flex items-center justify-center z-50 select-none touch-none [-webkit-touch-callout:none]"
 			title={$i18n.t('friends.addNew')}
 			aria-label={$i18n.t('friends.addNew')}
 		>
 			<Plus class="w-6 h-6" strokeWidth="2" />
-		</a>
+		</button>
+	{/if}
+
+	{#if createMenuOpen}
+		<FabCreateMenu onSelect={handleCreateSelect} onClose={() => (createMenuOpen = false)} />
 	{/if}
 </div>

--- a/apps/frontend/src/routes/circles/+page.svelte
+++ b/apps/frontend/src/routes/circles/+page.svelte
@@ -2,6 +2,8 @@
 import { onMount } from 'svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
+import { replaceState } from '$app/navigation';
+import { page } from '$app/stores';
 import AlertBanner from '$lib/components/alert-banner.svelte';
 import CircleEditModal from '$lib/components/circles/circle-edit-modal.svelte';
 import DeleteConfirmModal from '$lib/components/friends/subresources/delete-confirm-modal.svelte';
@@ -59,6 +61,15 @@ onMount(() => {
   window.addEventListener('shortcut:new-circle', handleNewCircle);
   window.addEventListener('shortcut:edit-circle', handleEditCircle as EventListener);
   window.addEventListener('shortcut:delete-circle', handleDeleteCircle as EventListener);
+
+  // Auto-open the create modal when navigated here with ?new=1 (e.g. from the
+  // mobile FAB long-press menu), then strip the flag so reloads don't reopen it.
+  if ($page.url.searchParams.get('new') === '1') {
+    openCreateModal();
+    const cleaned = new URL($page.url);
+    cleaned.searchParams.delete('new');
+    replaceState(cleaned.pathname + cleaned.search, {});
+  }
 
   return () => {
     window.removeEventListener('shortcut:new-circle', handleNewCircle);


### PR DESCRIPTION
Short tap keeps the existing behavior (new friend / add-detail choice on
friend pages); a long press opens a bottom-sheet menu to create any entity
type (friend, encounter, circle, collective). Long-press detection lives in
a reusable Svelte action so both the layout FAB and the friend-detail FAB
share one code path.

https://claude.ai/code/session_01QSMd9uTSM2uZKF8qDpS2Bo