### PR TITLE
feat(encounters): Add interaction type to encounters

### DIFF
--- a/apps/backend/src/models/queries/encounters.queries.ts
+++ b/apps/backend/src/models/queries/encounters.queries.ts
@@ -7,6 +7,7 @@ export type NumberOrString = number | string;
 
 /** 'GetEncountersByUserId' parameters type */
 export interface IGetEncountersByUserIdParams {
+  encounterType?: string | null | void;
   friendExternalId?: string | null | void;
   fromDate?: DateOrString | null | void;
   offset?: NumberOrString | null | void;
@@ -23,13 +24,15 @@ export interface IGetEncountersByUserIdResult {
   description: string | null;
   /** Date when the encounter occurred */
   encounter_date: Date;
+  /** Kind of contact: 'in_person', 'phone_call', 'video_call' or 'message' */
+  encounter_type: string;
   /** Public UUID for API exposure (always use this in APIs) */
   external_id: string;
   friend_count: number | null;
   /** Free-text location description */
   location_text: string | null;
   /** Title/name of the encounter (e.g., "Coffee at Starbucks", "Birthday Party") */
-  title: string;
+  title: string | null;
   updated_at: Date;
 }
 
@@ -39,7 +42,7 @@ export interface IGetEncountersByUserIdQuery {
   result: IGetEncountersByUserIdResult;
 }
 
-const getEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"friendExternalId":true,"fromDate":true,"toDate":true,"search":true,"pageSize":true,"offset":true},"params":[{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":347,"b":361}]},{"name":"friendExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":381,"b":397},{"a":605,"b":621}]},{"name":"fromDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":651,"b":659},{"a":702,"b":710}]},{"name":"toDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":734,"b":740},{"a":783,"b":789}]},{"name":"search","required":false,"transform":{"type":"scalar"},"locs":[{"a":813,"b":819},{"a":863,"b":869},{"a":912,"b":918}]},{"name":"pageSize","required":false,"transform":{"type":"scalar"},"locs":[{"a":1103,"b":1111}]},{"name":"offset","required":false,"transform":{"type":"scalar"},"locs":[{"a":1120,"b":1126}]}],"statement":"SELECT\n    e.external_id,\n    e.title,\n    e.encounter_date,\n    e.location_text,\n    e.description,\n    e.created_at,\n    e.updated_at,\n    COUNT(DISTINCT ef.id)::int AS friend_count\nFROM encounters.encounters e\nINNER JOIN auth.users u ON e.user_id = u.id\nLEFT JOIN encounters.encounter_friends ef ON ef.encounter_id = e.id\nWHERE u.external_id = :userExternalId::uuid\n  AND (\n    :friendExternalId::uuid IS NULL\n    OR EXISTS (\n      SELECT 1 FROM encounters.encounter_friends ef2\n      INNER JOIN friends.friends f ON ef2.friend_id = f.id\n      WHERE ef2.encounter_id = e.id\n        AND f.external_id = :friendExternalId::uuid\n    )\n  )\n  AND (\n    :fromDate::date IS NULL\n    OR e.encounter_date >= :fromDate::date\n  )\n  AND (\n    :toDate::date IS NULL\n    OR e.encounter_date <= :toDate::date\n  )\n  AND (\n    :search::text IS NULL\n    OR e.title ILIKE '%' || :search || '%'\n    OR e.description ILIKE '%' || :search || '%'\n  )\nGROUP BY e.id, e.external_id, e.title, e.encounter_date, e.location_text, e.description, e.created_at, e.updated_at\nORDER BY e.encounter_date DESC, e.created_at DESC\nLIMIT :pageSize\nOFFSET :offset"};
+const getEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"friendExternalId":true,"fromDate":true,"toDate":true,"encounterType":true,"search":true,"pageSize":true,"offset":true},"params":[{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":369,"b":383}]},{"name":"friendExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":403,"b":419},{"a":627,"b":643}]},{"name":"fromDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":673,"b":681},{"a":724,"b":732}]},{"name":"toDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":756,"b":762},{"a":805,"b":811}]},{"name":"encounterType","required":false,"transform":{"type":"scalar"},"locs":[{"a":835,"b":848},{"a":890,"b":903}]},{"name":"search","required":false,"transform":{"type":"scalar"},"locs":[{"a":921,"b":927},{"a":971,"b":977},{"a":1020,"b":1026}]},{"name":"pageSize","required":false,"transform":{"type":"scalar"},"locs":[{"a":1229,"b":1237}]},{"name":"offset","required":false,"transform":{"type":"scalar"},"locs":[{"a":1246,"b":1252}]}],"statement":"SELECT\n    e.external_id,\n    e.title,\n    e.encounter_type,\n    e.encounter_date,\n    e.location_text,\n    e.description,\n    e.created_at,\n    e.updated_at,\n    COUNT(DISTINCT ef.id)::int AS friend_count\nFROM encounters.encounters e\nINNER JOIN auth.users u ON e.user_id = u.id\nLEFT JOIN encounters.encounter_friends ef ON ef.encounter_id = e.id\nWHERE u.external_id = :userExternalId::uuid\n  AND (\n    :friendExternalId::uuid IS NULL\n    OR EXISTS (\n      SELECT 1 FROM encounters.encounter_friends ef2\n      INNER JOIN friends.friends f ON ef2.friend_id = f.id\n      WHERE ef2.encounter_id = e.id\n        AND f.external_id = :friendExternalId::uuid\n    )\n  )\n  AND (\n    :fromDate::date IS NULL\n    OR e.encounter_date >= :fromDate::date\n  )\n  AND (\n    :toDate::date IS NULL\n    OR e.encounter_date <= :toDate::date\n  )\n  AND (\n    :encounterType::text IS NULL\n    OR e.encounter_type = :encounterType\n  )\n  AND (\n    :search::text IS NULL\n    OR e.title ILIKE '%' || :search || '%'\n    OR e.description ILIKE '%' || :search || '%'\n  )\nGROUP BY e.id, e.external_id, e.title, e.encounter_type, e.encounter_date, e.location_text, e.description, e.created_at, e.updated_at\nORDER BY e.encounter_date DESC, e.created_at DESC\nLIMIT :pageSize\nOFFSET :offset"};
 
 /**
  * Query generated from SQL:
@@ -47,6 +50,7 @@ const getEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"fri
  * SELECT
  *     e.external_id,
  *     e.title,
+ *     e.encounter_type,
  *     e.encounter_date,
  *     e.location_text,
  *     e.description,
@@ -75,11 +79,15 @@ const getEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"fri
  *     OR e.encounter_date <= :toDate::date
  *   )
  *   AND (
+ *     :encounterType::text IS NULL
+ *     OR e.encounter_type = :encounterType
+ *   )
+ *   AND (
  *     :search::text IS NULL
  *     OR e.title ILIKE '%' || :search || '%'
  *     OR e.description ILIKE '%' || :search || '%'
  *   )
- * GROUP BY e.id, e.external_id, e.title, e.encounter_date, e.location_text, e.description, e.created_at, e.updated_at
+ * GROUP BY e.id, e.external_id, e.title, e.encounter_type, e.encounter_date, e.location_text, e.description, e.created_at, e.updated_at
  * ORDER BY e.encounter_date DESC, e.created_at DESC
  * LIMIT :pageSize
  * OFFSET :offset
@@ -90,6 +98,7 @@ export const getEncountersByUserId = new PreparedQuery<IGetEncountersByUserIdPar
 
 /** 'CountEncountersByUserId' parameters type */
 export interface ICountEncountersByUserIdParams {
+  encounterType?: string | null | void;
   friendExternalId?: string | null | void;
   fromDate?: DateOrString | null | void;
   search?: string | null | void;
@@ -108,7 +117,7 @@ export interface ICountEncountersByUserIdQuery {
   result: ICountEncountersByUserIdResult;
 }
 
-const countEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"friendExternalId":true,"fromDate":true,"toDate":true,"search":true},"params":[{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":143,"b":157}]},{"name":"friendExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":177,"b":193},{"a":398,"b":414}]},{"name":"fromDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":444,"b":452},{"a":495,"b":503}]},{"name":"toDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":527,"b":533},{"a":576,"b":582}]},{"name":"search","required":false,"transform":{"type":"scalar"},"locs":[{"a":606,"b":612},{"a":656,"b":662},{"a":705,"b":711}]}],"statement":"SELECT COUNT(DISTINCT e.id)::int AS total_count\nFROM encounters.encounters e\nINNER JOIN auth.users u ON e.user_id = u.id\nWHERE u.external_id = :userExternalId::uuid\n  AND (\n    :friendExternalId::uuid IS NULL\n    OR EXISTS (\n      SELECT 1 FROM encounters.encounter_friends ef\n      INNER JOIN friends.friends f ON ef.friend_id = f.id\n      WHERE ef.encounter_id = e.id\n        AND f.external_id = :friendExternalId::uuid\n    )\n  )\n  AND (\n    :fromDate::date IS NULL\n    OR e.encounter_date >= :fromDate::date\n  )\n  AND (\n    :toDate::date IS NULL\n    OR e.encounter_date <= :toDate::date\n  )\n  AND (\n    :search::text IS NULL\n    OR e.title ILIKE '%' || :search || '%'\n    OR e.description ILIKE '%' || :search || '%'\n  )"};
+const countEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"friendExternalId":true,"fromDate":true,"toDate":true,"encounterType":true,"search":true},"params":[{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":143,"b":157}]},{"name":"friendExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":177,"b":193},{"a":398,"b":414}]},{"name":"fromDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":444,"b":452},{"a":495,"b":503}]},{"name":"toDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":527,"b":533},{"a":576,"b":582}]},{"name":"encounterType","required":false,"transform":{"type":"scalar"},"locs":[{"a":606,"b":619},{"a":661,"b":674}]},{"name":"search","required":false,"transform":{"type":"scalar"},"locs":[{"a":692,"b":698},{"a":742,"b":748},{"a":791,"b":797}]}],"statement":"SELECT COUNT(DISTINCT e.id)::int AS total_count\nFROM encounters.encounters e\nINNER JOIN auth.users u ON e.user_id = u.id\nWHERE u.external_id = :userExternalId::uuid\n  AND (\n    :friendExternalId::uuid IS NULL\n    OR EXISTS (\n      SELECT 1 FROM encounters.encounter_friends ef\n      INNER JOIN friends.friends f ON ef.friend_id = f.id\n      WHERE ef.encounter_id = e.id\n        AND f.external_id = :friendExternalId::uuid\n    )\n  )\n  AND (\n    :fromDate::date IS NULL\n    OR e.encounter_date >= :fromDate::date\n  )\n  AND (\n    :toDate::date IS NULL\n    OR e.encounter_date <= :toDate::date\n  )\n  AND (\n    :encounterType::text IS NULL\n    OR e.encounter_type = :encounterType\n  )\n  AND (\n    :search::text IS NULL\n    OR e.title ILIKE '%' || :search || '%'\n    OR e.description ILIKE '%' || :search || '%'\n  )"};
 
 /**
  * Query generated from SQL:
@@ -135,6 +144,10 @@ const countEncountersByUserIdIR: any = {"usedParamSet":{"userExternalId":true,"f
  *     OR e.encounter_date <= :toDate::date
  *   )
  *   AND (
+ *     :encounterType::text IS NULL
+ *     OR e.encounter_type = :encounterType
+ *   )
+ *   AND (
  *     :search::text IS NULL
  *     OR e.title ILIKE '%' || :search || '%'
  *     OR e.description ILIKE '%' || :search || '%'
@@ -157,12 +170,14 @@ export interface IGetEncounterByIdResult {
   description: string | null;
   /** Date when the encounter occurred */
   encounter_date: Date;
+  /** Kind of contact: 'in_person', 'phone_call', 'video_call' or 'message' */
+  encounter_type: string;
   /** Public UUID for API exposure (always use this in APIs) */
   external_id: string;
   /** Free-text location description */
   location_text: string | null;
   /** Title/name of the encounter (e.g., "Coffee at Starbucks", "Birthday Party") */
-  title: string;
+  title: string | null;
   updated_at: Date;
 }
 
@@ -172,7 +187,7 @@ export interface IGetEncounterByIdQuery {
   result: IGetEncounterByIdResult;
 }
 
-const getEncounterByIdIR: any = {"usedParamSet":{"encounterExternalId":true,"userExternalId":true},"params":[{"name":"encounterExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":231,"b":250}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":280,"b":294}]}],"statement":"SELECT\n    e.external_id,\n    e.title,\n    e.encounter_date,\n    e.location_text,\n    e.description,\n    e.created_at,\n    e.updated_at\nFROM encounters.encounters e\nINNER JOIN auth.users u ON e.user_id = u.id\nWHERE e.external_id = :encounterExternalId::uuid\n  AND u.external_id = :userExternalId::uuid"};
+const getEncounterByIdIR: any = {"usedParamSet":{"encounterExternalId":true,"userExternalId":true},"params":[{"name":"encounterExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":253,"b":272}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":302,"b":316}]}],"statement":"SELECT\n    e.external_id,\n    e.title,\n    e.encounter_type,\n    e.encounter_date,\n    e.location_text,\n    e.description,\n    e.created_at,\n    e.updated_at\nFROM encounters.encounters e\nINNER JOIN auth.users u ON e.user_id = u.id\nWHERE e.external_id = :encounterExternalId::uuid\n  AND u.external_id = :userExternalId::uuid"};
 
 /**
  * Query generated from SQL:
@@ -180,6 +195,7 @@ const getEncounterByIdIR: any = {"usedParamSet":{"encounterExternalId":true,"use
  * SELECT
  *     e.external_id,
  *     e.title,
+ *     e.encounter_type,
  *     e.encounter_date,
  *     e.location_text,
  *     e.description,
@@ -284,6 +300,7 @@ export const getEncounterFriendsPreview = new PreparedQuery<IGetEncounterFriends
 export interface ICreateEncounterParams {
   description?: string | null | void;
   encounterDate?: DateOrString | null | void;
+  encounterType?: string | null | void;
   locationText?: string | null | void;
   title?: string | null | void;
   userExternalId?: string | null | void;
@@ -296,12 +313,14 @@ export interface ICreateEncounterResult {
   description: string | null;
   /** Date when the encounter occurred */
   encounter_date: Date;
+  /** Kind of contact: 'in_person', 'phone_call', 'video_call' or 'message' */
+  encounter_type: string;
   /** Public UUID for API exposure (always use this in APIs) */
   external_id: string;
   /** Free-text location description */
   location_text: string | null;
   /** Title/name of the encounter (e.g., "Coffee at Starbucks", "Birthday Party") */
-  title: string;
+  title: string | null;
   updated_at: Date;
 }
 
@@ -311,7 +330,7 @@ export interface ICreateEncounterQuery {
   result: ICreateEncounterResult;
 }
 
-const createEncounterIR: any = {"usedParamSet":{"title":true,"encounterDate":true,"locationText":true,"description":true,"userExternalId":true},"params":[{"name":"title","required":false,"transform":{"type":"scalar"},"locs":[{"a":138,"b":143}]},{"name":"encounterDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":150,"b":163}]},{"name":"locationText","required":false,"transform":{"type":"scalar"},"locs":[{"a":176,"b":188}]},{"name":"description","required":false,"transform":{"type":"scalar"},"locs":[{"a":195,"b":206}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":248,"b":262}]}],"statement":"INSERT INTO encounters.encounters (\n    user_id,\n    title,\n    encounter_date,\n    location_text,\n    description\n)\nSELECT\n    u.id,\n    :title,\n    :encounterDate::date,\n    :locationText,\n    :description\nFROM auth.users u\nWHERE u.external_id = :userExternalId::uuid\nRETURNING\n    external_id,\n    title,\n    encounter_date,\n    location_text,\n    description,\n    created_at,\n    updated_at"};
+const createEncounterIR: any = {"usedParamSet":{"title":true,"encounterType":true,"encounterDate":true,"locationText":true,"description":true,"userExternalId":true},"params":[{"name":"title","required":false,"transform":{"type":"scalar"},"locs":[{"a":158,"b":163}]},{"name":"encounterType","required":false,"transform":{"type":"scalar"},"locs":[{"a":170,"b":183}]},{"name":"encounterDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":190,"b":203}]},{"name":"locationText","required":false,"transform":{"type":"scalar"},"locs":[{"a":216,"b":228}]},{"name":"description","required":false,"transform":{"type":"scalar"},"locs":[{"a":235,"b":246}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":288,"b":302}]}],"statement":"INSERT INTO encounters.encounters (\n    user_id,\n    title,\n    encounter_type,\n    encounter_date,\n    location_text,\n    description\n)\nSELECT\n    u.id,\n    :title,\n    :encounterType,\n    :encounterDate::date,\n    :locationText,\n    :description\nFROM auth.users u\nWHERE u.external_id = :userExternalId::uuid\nRETURNING\n    external_id,\n    title,\n    encounter_type,\n    encounter_date,\n    location_text,\n    description,\n    created_at,\n    updated_at"};
 
 /**
  * Query generated from SQL:
@@ -319,6 +338,7 @@ const createEncounterIR: any = {"usedParamSet":{"title":true,"encounterDate":tru
  * INSERT INTO encounters.encounters (
  *     user_id,
  *     title,
+ *     encounter_type,
  *     encounter_date,
  *     location_text,
  *     description
@@ -326,6 +346,7 @@ const createEncounterIR: any = {"usedParamSet":{"title":true,"encounterDate":tru
  * SELECT
  *     u.id,
  *     :title,
+ *     :encounterType,
  *     :encounterDate::date,
  *     :locationText,
  *     :description
@@ -334,6 +355,7 @@ const createEncounterIR: any = {"usedParamSet":{"title":true,"encounterDate":tru
  * RETURNING
  *     external_id,
  *     title,
+ *     encounter_type,
  *     encounter_date,
  *     location_text,
  *     description,
@@ -349,10 +371,12 @@ export interface IUpdateEncounterParams {
   description?: string | null | void;
   encounterDate?: DateOrString | null | void;
   encounterExternalId?: string | null | void;
+  encounterType?: string | null | void;
   locationText?: string | null | void;
   title?: string | null | void;
   updateDescription?: boolean | null | void;
   updateLocationText?: boolean | null | void;
+  updateTitle?: boolean | null | void;
   userExternalId?: string | null | void;
 }
 
@@ -363,12 +387,14 @@ export interface IUpdateEncounterResult {
   description: string | null;
   /** Date when the encounter occurred */
   encounter_date: Date;
+  /** Kind of contact: 'in_person', 'phone_call', 'video_call' or 'message' */
+  encounter_type: string;
   /** Public UUID for API exposure (always use this in APIs) */
   external_id: string;
   /** Free-text location description */
   location_text: string | null;
   /** Title/name of the encounter (e.g., "Coffee at Starbucks", "Birthday Party") */
-  title: string;
+  title: string | null;
   updated_at: Date;
 }
 
@@ -378,14 +404,18 @@ export interface IUpdateEncounterQuery {
   result: IUpdateEncounterResult;
 }
 
-const updateEncounterIR: any = {"usedParamSet":{"title":true,"encounterDate":true,"updateLocationText":true,"locationText":true,"updateDescription":true,"description":true,"encounterExternalId":true,"userExternalId":true},"params":[{"name":"title","required":false,"transform":{"type":"scalar"},"locs":[{"a":56,"b":61}]},{"name":"encounterDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":104,"b":117}]},{"name":"updateLocationText","required":false,"transform":{"type":"scalar"},"locs":[{"a":183,"b":201}]},{"name":"locationText","required":false,"transform":{"type":"scalar"},"locs":[{"a":224,"b":236}]},{"name":"updateDescription","required":false,"transform":{"type":"scalar"},"locs":[{"a":312,"b":329}]},{"name":"description","required":false,"transform":{"type":"scalar"},"locs":[{"a":352,"b":363}]},{"name":"encounterExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":476,"b":495}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":548,"b":562}]}],"statement":"UPDATE encounters.encounters e\nSET\n    title = COALESCE(:title, e.title),\n    encounter_date = COALESCE(:encounterDate::date, e.encounter_date),\n    location_text = CASE\n        WHEN :updateLocationText::boolean = true THEN :locationText\n        ELSE e.location_text\n    END,\n    description = CASE\n        WHEN :updateDescription::boolean = true THEN :description\n        ELSE e.description\n    END,\n    updated_at = current_timestamp\nFROM auth.users u\nWHERE e.external_id = :encounterExternalId::uuid\n  AND e.user_id = u.id\n  AND u.external_id = :userExternalId::uuid\nRETURNING\n    e.external_id,\n    e.title,\n    e.encounter_date,\n    e.location_text,\n    e.description,\n    e.created_at,\n    e.updated_at"};
+const updateEncounterIR: any = {"usedParamSet":{"updateTitle":true,"title":true,"encounterType":true,"encounterDate":true,"updateLocationText":true,"locationText":true,"updateDescription":true,"description":true,"encounterExternalId":true,"userExternalId":true},"params":[{"name":"updateTitle","required":false,"transform":{"type":"scalar"},"locs":[{"a":65,"b":76}]},{"name":"title","required":false,"transform":{"type":"scalar"},"locs":[{"a":99,"b":104}]},{"name":"encounterType","required":false,"transform":{"type":"scalar"},"locs":[{"a":166,"b":179}]},{"name":"encounterDate","required":false,"transform":{"type":"scalar"},"locs":[{"a":231,"b":244}]},{"name":"updateLocationText","required":false,"transform":{"type":"scalar"},"locs":[{"a":310,"b":328}]},{"name":"locationText","required":false,"transform":{"type":"scalar"},"locs":[{"a":351,"b":363}]},{"name":"updateDescription","required":false,"transform":{"type":"scalar"},"locs":[{"a":439,"b":456}]},{"name":"description","required":false,"transform":{"type":"scalar"},"locs":[{"a":479,"b":490}]},{"name":"encounterExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":603,"b":622}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":675,"b":689}]}],"statement":"UPDATE encounters.encounters e\nSET\n    title = CASE\n        WHEN :updateTitle::boolean = true THEN :title\n        ELSE e.title\n    END,\n    encounter_type = COALESCE(:encounterType, e.encounter_type),\n    encounter_date = COALESCE(:encounterDate::date, e.encounter_date),\n    location_text = CASE\n        WHEN :updateLocationText::boolean = true THEN :locationText\n        ELSE e.location_text\n    END,\n    description = CASE\n        WHEN :updateDescription::boolean = true THEN :description\n        ELSE e.description\n    END,\n    updated_at = current_timestamp\nFROM auth.users u\nWHERE e.external_id = :encounterExternalId::uuid\n  AND e.user_id = u.id\n  AND u.external_id = :userExternalId::uuid\nRETURNING\n    e.external_id,\n    e.title,\n    e.encounter_type,\n    e.encounter_date,\n    e.location_text,\n    e.description,\n    e.created_at,\n    e.updated_at"};
 
 /**
  * Query generated from SQL:
  * ```
  * UPDATE encounters.encounters e
  * SET
- *     title = COALESCE(:title, e.title),
+ *     title = CASE
+ *         WHEN :updateTitle::boolean = true THEN :title
+ *         ELSE e.title
+ *     END,
+ *     encounter_type = COALESCE(:encounterType, e.encounter_type),
  *     encounter_date = COALESCE(:encounterDate::date, e.encounter_date),
  *     location_text = CASE
  *         WHEN :updateLocationText::boolean = true THEN :locationText
@@ -403,6 +433,7 @@ const updateEncounterIR: any = {"usedParamSet":{"title":true,"encounterDate":tru
  * RETURNING
  *     e.external_id,
  *     e.title,
+ *     e.encounter_type,
  *     e.encounter_date,
  *     e.location_text,
  *     e.description,
@@ -457,10 +488,12 @@ export interface IGetLastEncounterForFriendParams {
 export interface IGetLastEncounterForFriendResult {
   /** Date when the encounter occurred */
   encounter_date: Date;
+  /** Kind of contact: 'in_person', 'phone_call', 'video_call' or 'message' */
+  encounter_type: string;
   /** Public UUID for API exposure (always use this in APIs) */
   external_id: string;
   /** Title/name of the encounter (e.g., "Coffee at Starbucks", "Birthday Party") */
-  title: string;
+  title: string | null;
 }
 
 /** 'GetLastEncounterForFriend' query type */
@@ -469,7 +502,7 @@ export interface IGetLastEncounterForFriendQuery {
   result: IGetLastEncounterForFriendResult;
 }
 
-const getLastEncounterForFriendIR: any = {"usedParamSet":{"friendExternalId":true,"userExternalId":true},"params":[{"name":"friendExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":276,"b":292}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":322,"b":336}]}],"statement":"SELECT\n    e.external_id,\n    e.title,\n    e.encounter_date\nFROM encounters.encounters e\nINNER JOIN encounters.encounter_friends ef ON ef.encounter_id = e.id\nINNER JOIN friends.friends f ON ef.friend_id = f.id\nINNER JOIN auth.users u ON e.user_id = u.id\nWHERE f.external_id = :friendExternalId::uuid\n  AND u.external_id = :userExternalId::uuid\n  AND f.deleted_at IS NULL\nORDER BY e.encounter_date DESC, e.created_at DESC\nLIMIT 1"};
+const getLastEncounterForFriendIR: any = {"usedParamSet":{"friendExternalId":true,"userExternalId":true},"params":[{"name":"friendExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":298,"b":314}]},{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":344,"b":358}]}],"statement":"SELECT\n    e.external_id,\n    e.title,\n    e.encounter_type,\n    e.encounter_date\nFROM encounters.encounters e\nINNER JOIN encounters.encounter_friends ef ON ef.encounter_id = e.id\nINNER JOIN friends.friends f ON ef.friend_id = f.id\nINNER JOIN auth.users u ON e.user_id = u.id\nWHERE f.external_id = :friendExternalId::uuid\n  AND u.external_id = :userExternalId::uuid\n  AND f.deleted_at IS NULL\nORDER BY e.encounter_date DESC, e.created_at DESC\nLIMIT 1"};
 
 /**
  * Query generated from SQL:
@@ -477,6 +510,7 @@ const getLastEncounterForFriendIR: any = {"usedParamSet":{"friendExternalId":tru
  * SELECT
  *     e.external_id,
  *     e.title,
+ *     e.encounter_type,
  *     e.encounter_date
  * FROM encounters.encounters e
  * INNER JOIN encounters.encounter_friends ef ON ef.encounter_id = e.id

--- a/apps/backend/src/models/queries/encounters.sql
+++ b/apps/backend/src/models/queries/encounters.sql
@@ -2,6 +2,7 @@
 SELECT
     e.external_id,
     e.title,
+    e.encounter_type,
     e.encounter_date,
     e.location_text,
     e.description,
@@ -30,11 +31,15 @@ WHERE u.external_id = :userExternalId::uuid
     OR e.encounter_date <= :toDate::date
   )
   AND (
+    :encounterType::text IS NULL
+    OR e.encounter_type = :encounterType
+  )
+  AND (
     :search::text IS NULL
     OR e.title ILIKE '%' || :search || '%'
     OR e.description ILIKE '%' || :search || '%'
   )
-GROUP BY e.id, e.external_id, e.title, e.encounter_date, e.location_text, e.description, e.created_at, e.updated_at
+GROUP BY e.id, e.external_id, e.title, e.encounter_type, e.encounter_date, e.location_text, e.description, e.created_at, e.updated_at
 ORDER BY e.encounter_date DESC, e.created_at DESC
 LIMIT :pageSize
 OFFSET :offset;
@@ -62,6 +67,10 @@ WHERE u.external_id = :userExternalId::uuid
     OR e.encounter_date <= :toDate::date
   )
   AND (
+    :encounterType::text IS NULL
+    OR e.encounter_type = :encounterType
+  )
+  AND (
     :search::text IS NULL
     OR e.title ILIKE '%' || :search || '%'
     OR e.description ILIKE '%' || :search || '%'
@@ -71,6 +80,7 @@ WHERE u.external_id = :userExternalId::uuid
 SELECT
     e.external_id,
     e.title,
+    e.encounter_type,
     e.encounter_date,
     e.location_text,
     e.description,
@@ -113,6 +123,7 @@ LIMIT :limit;
 INSERT INTO encounters.encounters (
     user_id,
     title,
+    encounter_type,
     encounter_date,
     location_text,
     description
@@ -120,6 +131,7 @@ INSERT INTO encounters.encounters (
 SELECT
     u.id,
     :title,
+    :encounterType,
     :encounterDate::date,
     :locationText,
     :description
@@ -128,6 +140,7 @@ WHERE u.external_id = :userExternalId::uuid
 RETURNING
     external_id,
     title,
+    encounter_type,
     encounter_date,
     location_text,
     description,
@@ -137,7 +150,11 @@ RETURNING
 /* @name UpdateEncounter */
 UPDATE encounters.encounters e
 SET
-    title = COALESCE(:title, e.title),
+    title = CASE
+        WHEN :updateTitle::boolean = true THEN :title
+        ELSE e.title
+    END,
+    encounter_type = COALESCE(:encounterType, e.encounter_type),
     encounter_date = COALESCE(:encounterDate::date, e.encounter_date),
     location_text = CASE
         WHEN :updateLocationText::boolean = true THEN :locationText
@@ -155,6 +172,7 @@ WHERE e.external_id = :encounterExternalId::uuid
 RETURNING
     e.external_id,
     e.title,
+    e.encounter_type,
     e.encounter_date,
     e.location_text,
     e.description,
@@ -173,6 +191,7 @@ RETURNING e.external_id;
 SELECT
     e.external_id,
     e.title,
+    e.encounter_type,
     e.encounter_date
 FROM encounters.encounters e
 INNER JOIN encounters.encounter_friends ef ON ef.encounter_id = e.id

--- a/apps/backend/src/services/encounters.service.ts
+++ b/apps/backend/src/services/encounters.service.ts
@@ -5,6 +5,7 @@ import type {
   EncounterListItem,
   EncounterListOptions,
   EncounterListResponse,
+  EncounterType,
   EncounterUpdate,
   LastEncounterSummary,
 } from '@freundebuch/shared/index.js';
@@ -59,6 +60,7 @@ export class EncountersService {
           friendExternalId: options.friendId ?? null,
           fromDate: options.fromDate ?? null,
           toDate: options.toDate ?? null,
+          encounterType: options.type ?? null,
           search: options.search ?? null,
           pageSize: options.pageSize,
           offset,
@@ -71,6 +73,7 @@ export class EncountersService {
           friendExternalId: options.friendId ?? null,
           fromDate: options.fromDate ?? null,
           toDate: options.toDate ?? null,
+          encounterType: options.type ?? null,
           search: options.search ?? null,
         },
         this.db,
@@ -129,7 +132,8 @@ export class EncountersService {
       const encounterResults = await createEncounter.run(
         {
           userExternalId,
-          title: input.title,
+          title: input.title ?? null,
+          encounterType: input.encounter_type,
           encounterDate: input.encounter_date,
           locationText: input.location_text ?? null,
           description: input.description ?? null,
@@ -185,7 +189,9 @@ export class EncountersService {
         {
           userExternalId,
           encounterExternalId,
+          updateTitle: 'title' in input,
           title: input.title ?? null,
+          encounterType: input.encounter_type ?? null,
           encounterDate: input.encounter_date ?? null,
           updateLocationText: 'location_text' in input,
           locationText: input.location_text ?? null,
@@ -267,6 +273,7 @@ export class EncountersService {
     return {
       id: row.external_id,
       title: row.title,
+      encounterType: row.encounter_type as EncounterType,
       encounterDate: this.formatDate(row.encounter_date),
     };
   }
@@ -282,6 +289,7 @@ export class EncountersService {
     return {
       id: row.external_id,
       title: row.title,
+      encounterType: row.encounter_type as EncounterType,
       encounterDate: this.formatDate(row.encounter_date),
       locationText: row.location_text,
       description: row.description,
@@ -298,6 +306,7 @@ export class EncountersService {
     return {
       id: row.external_id,
       title: row.title,
+      encounterType: row.encounter_type as EncounterType,
       encounterDate: this.formatDate(row.encounter_date),
       locationText: row.location_text,
       friendCount: row.friend_count ?? 0,

--- a/apps/frontend/src/lib/api/encounters.ts
+++ b/apps/frontend/src/lib/api/encounters.ts
@@ -2,6 +2,7 @@ import type {
   Encounter,
   EncounterInput,
   EncounterListResponse,
+  EncounterType,
   EncounterUpdate,
   LastEncounterSummary,
 } from '$shared';
@@ -18,6 +19,7 @@ export interface EncounterListParams {
   fromDate?: string;
   toDate?: string;
   search?: string;
+  type?: EncounterType;
 }
 
 function buildQueryString(params: EncounterListParams): string {
@@ -40,6 +42,9 @@ function buildQueryString(params: EncounterListParams): string {
   }
   if (params.search) {
     searchParams.set('search', params.search);
+  }
+  if (params.type) {
+    searchParams.set('type', params.type);
   }
 
   const queryString = searchParams.toString();

--- a/apps/frontend/src/lib/components/encounters/encounter-card.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-card.svelte
@@ -10,6 +10,8 @@ import {
 } from '$lib/stores/ui';
 import type { EncounterListItem } from '$shared';
 import FriendAvatar from '../friends/friend-avatar.svelte';
+import { encounterDisplayTitle, encounterTypeLabel } from './encounter-display';
+import EncounterTypeIcon from './encounter-type-icon.svelte';
 
 const i18n = createI18n();
 
@@ -21,6 +23,8 @@ interface Props {
 }
 
 let { encounter, href = `/encounters/${encounter.id}`, index }: Props = $props();
+
+let displayTitle = $derived(encounterDisplayTitle($i18n.t, encounter));
 
 // Keyboard hint logic
 function getKeyHint(): string | null {
@@ -70,8 +74,14 @@ function formatDate(dateStr: string): string {
   {/if}
   <div class="flex items-start justify-between gap-4">
     <div class="flex-1 min-w-0">
-      <h3 class="font-heading font-semibold text-gray-900 truncate">
-        {encounter.title}
+      <h3 class="font-heading font-semibold text-gray-900 truncate flex items-center gap-2">
+        <span
+          class="flex-shrink-0 text-forest"
+          title={encounterTypeLabel($i18n.t, encounter.encounterType)}
+        >
+          <EncounterTypeIcon type={encounter.encounterType} class="w-4 h-4" />
+        </span>
+        <span class="truncate">{displayTitle}</span>
       </h3>
 
       <div class="mt-1 flex items-center gap-2 text-sm text-gray-500 font-body">

--- a/apps/frontend/src/lib/components/encounters/encounter-detail.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-detail.svelte
@@ -8,6 +8,8 @@ import { createI18n } from '$lib/i18n/index.js';
 import { encounters } from '$lib/stores/encounters';
 import type { Encounter } from '$shared';
 import FriendAvatar from '../friends/friend-avatar.svelte';
+import { encounterDisplayTitle, encounterTypeLabel } from './encounter-display';
+import EncounterTypeIcon from './encounter-type-icon.svelte';
 
 const i18n = createI18n();
 
@@ -20,6 +22,8 @@ let { encounter, onEdit }: Props = $props();
 
 let isDeleting = $state(false);
 let showDeleteConfirm = $state(false);
+
+let displayTitle = $derived(encounterDisplayTitle($i18n.t, encounter));
 
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr);
@@ -58,13 +62,17 @@ async function handleDelete() {
 <div class="space-y-6">
   <!-- Header with icon avatar and actions -->
   <div class="flex flex-col sm:flex-row items-center gap-6">
-    <!-- Calendar icon as avatar -->
+    <!-- Type icon as avatar -->
     <div class="flex-shrink-0 w-20 h-20 rounded-full bg-forest/10 text-forest flex items-center justify-center">
-      <Calendar class="w-10 h-10" strokeWidth="2" />
+      <EncounterTypeIcon type={encounter.encounterType} class="w-10 h-10" />
     </div>
 
     <div class="flex-1 text-center sm:text-left">
-      <h1 class="text-3xl font-heading text-gray-900">{encounter.title}</h1>
+      <h1 class="text-3xl font-heading text-gray-900">{displayTitle}</h1>
+      <div class="mt-1 flex items-center gap-2 text-gray-600 font-body justify-center sm:justify-start">
+        <EncounterTypeIcon type={encounter.encounterType} class="w-4 h-4 flex-shrink-0" />
+        <span>{encounterTypeLabel($i18n.t, encounter.encounterType)}</span>
+      </div>
       <div class="mt-1 flex items-center gap-2 text-gray-600 font-body justify-center sm:justify-start">
         <Calendar class="w-4 h-4 flex-shrink-0" strokeWidth="2" />
         <span>{formatDate(encounter.encounterDate)}</span>
@@ -154,7 +162,7 @@ async function handleDelete() {
         {$i18n.t('encounters.detail.deleteConfirmTitle')}
       </h3>
       <p class="text-gray-600 font-body mb-6">
-        {$i18n.t('encounters.detail.deleteConfirmMessage', { title: encounter.title })}
+        {$i18n.t('encounters.detail.deleteConfirmMessage', { title: displayTitle })}
       </p>
       <div class="flex gap-3">
         <button

--- a/apps/frontend/src/lib/components/encounters/encounter-display.ts
+++ b/apps/frontend/src/lib/components/encounters/encounter-display.ts
@@ -1,0 +1,56 @@
+import { getCurrentLanguage } from '$lib/i18n/index.js';
+import type { EncounterType } from '$shared';
+
+/** Minimal shape needed to render an encounter's title/type, shared by card/detail/badge. */
+export interface DisplayableEncounter {
+  title: string | null;
+  encounterType: EncounterType;
+  friends: { displayName: string }[];
+  /** Total friend count when `friends` is only a preview slice */
+  friendCount?: number;
+}
+
+type Translate = (key: string, opts?: Record<string, unknown>) => string;
+
+/** Localized name of an interaction type, e.g. "Phone call". */
+export function encounterTypeLabel(t: Translate, type: EncounterType): string {
+  return t(`encounters.types.${type}`);
+}
+
+/**
+ * Locale-aware list of friend names. Uses Intl.ListFormat so separators follow
+ * the active language; when the list is a preview, the remaining count is rendered
+ * via the localized `encounters.friendCountMore` string instead of a hard-coded "+N".
+ */
+function friendNames(
+  t: Translate,
+  friends: { displayName: string }[],
+  friendCount?: number,
+): string {
+  const names = friends.map((f) => f.displayName);
+  if (names.length === 0) return '';
+
+  const locale = getCurrentLanguage();
+  const total = friendCount ?? names.length;
+  const extra = total - names.length;
+
+  if (extra > 0) {
+    const shown = new Intl.ListFormat(locale, { style: 'narrow', type: 'unit' }).format(names);
+    return `${shown} ${t('encounters.friendCountMore', { count: extra })}`;
+  }
+  return new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' }).format(names);
+}
+
+/**
+ * The title to show for an encounter. Uses the user-provided title when present,
+ * otherwise derives a label from the interaction type and friends
+ * (e.g. "Phone call with Sarah") so calls/messages don't need a title.
+ */
+export function encounterDisplayTitle(t: Translate, e: DisplayableEncounter): string {
+  if (e.title && e.title.trim().length > 0) return e.title;
+  const names = friendNames(t, e.friends, e.friendCount);
+  // Without any friend names, fall back to the plain type label to avoid a
+  // dangling "Phone call with " (e.g. badge with no friendName prop).
+  if (!names) return encounterTypeLabel(t, e.encounterType);
+  return t(`encounters.derivedTitle.${e.encounterType}`, { names });
+}

--- a/apps/frontend/src/lib/components/encounters/encounter-form.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-form.svelte
@@ -3,7 +3,16 @@ import { goto } from '$app/navigation';
 import { autoFocus } from '$lib/actions/auto-focus';
 import { createI18n } from '$lib/i18n/index.js';
 import { encounters } from '$lib/stores/encounters';
-import type { Encounter, EncounterInput, EncounterUpdate, FriendSearchResult } from '$shared';
+import {
+  ENCOUNTER_TYPES,
+  type Encounter,
+  type EncounterInput,
+  type EncounterType,
+  type EncounterUpdate,
+  type FriendSearchResult,
+} from '$shared';
+import { encounterTypeLabel } from './encounter-display';
+import EncounterTypeIcon from './encounter-type-icon.svelte';
 import FriendMultiSelect from './friend-multi-select.svelte';
 
 const i18n = createI18n();
@@ -25,6 +34,7 @@ let isEditMode = $derived(!!encounter);
 
 // Form state
 let title = $state(encounter?.title ?? '');
+let encounterType = $state<EncounterType>(encounter?.encounterType ?? 'in_person');
 let encounterDate = $state(encounter?.encounterDate ?? new Date().toISOString().split('T')[0]);
 let locationText = $state(encounter?.locationText ?? '');
 let description = $state(encounter?.description ?? '');
@@ -39,10 +49,11 @@ let selectedFriends = $state<FriendSearchResult[]>(
 let isSubmitting = $state(false);
 let error = $state('');
 
-// Validation
-let isValid = $derived(
-  title.trim().length > 0 && encounterDate.length > 0 && selectedFriends.length > 0,
-);
+// Location only applies to in-person encounters
+let showLocation = $derived(encounterType === 'in_person');
+
+// Validation — title is optional (a label is derived for calls/messages)
+let isValid = $derived(encounterDate.length > 0 && selectedFriends.length > 0);
 
 function handleFriendsChange(friends: FriendSearchResult[]) {
   selectedFriends = friends;
@@ -64,19 +75,21 @@ async function handleSubmit(e: Event) {
 
     if (isEditMode && encounter) {
       const input: EncounterUpdate = {
-        title: title.trim(),
+        title: title.trim() || null,
+        encounter_type: encounterType,
         encounter_date: encounterDate,
         friend_ids: selectedFriends.map((f) => f.id),
-        location_text: locationText.trim() || null,
+        location_text: showLocation ? locationText.trim() || null : null,
         description: description.trim() || null,
       };
       result = await encounters.updateEncounter(encounter.id, input);
     } else {
       const input: EncounterInput = {
-        title: title.trim(),
+        title: title.trim() || undefined,
+        encounter_type: encounterType,
         encounter_date: encounterDate,
         friend_ids: selectedFriends.map((f) => f.id),
-        location_text: locationText.trim() || undefined,
+        location_text: showLocation ? locationText.trim() || undefined : undefined,
         description: description.trim() || undefined,
       };
       result = await encounters.createEncounter(input);
@@ -113,10 +126,31 @@ function handleCancel() {
     </div>
   {/if}
 
+  <!-- Type -->
+  <div>
+    <span class="block text-sm font-body font-medium text-gray-700 mb-1">
+      {$i18n.t('encounters.form.typeLabel')}
+    </span>
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      {#each ENCOUNTER_TYPES as type (type)}
+        <button
+          type="button"
+          onclick={() => (encounterType = type)}
+          disabled={isSubmitting}
+          aria-pressed={encounterType === type}
+          class="flex items-center justify-center gap-2 px-3 py-2 border rounded-lg font-body text-sm transition-colors disabled:opacity-50 {encounterType === type ? 'border-forest bg-forest/10 text-forest font-semibold' : 'border-gray-300 text-gray-700 hover:border-forest'}"
+        >
+          <EncounterTypeIcon {type} class="w-4 h-4 flex-shrink-0" />
+          <span class="truncate">{encounterTypeLabel($i18n.t, type)}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+
   <!-- Title -->
   <div>
     <label for="title" class="block text-sm font-body font-medium text-gray-700 mb-1">
-      {$i18n.t('encounters.form.titleLabel')} <span class="text-red-500">{$i18n.t('encounters.form.required')}</span>
+      {$i18n.t('encounters.form.titleLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
     </label>
     <input
       use:autoFocus
@@ -126,7 +160,6 @@ function handleCancel() {
       placeholder={$i18n.t('encounters.form.titlePlaceholder')}
       disabled={isSubmitting}
       class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm disabled:opacity-50"
-      required
     />
   </div>
 
@@ -163,20 +196,22 @@ function handleCancel() {
     {/if}
   </div>
 
-  <!-- Location -->
-  <div>
-    <label for="location" class="block text-sm font-body font-medium text-gray-700 mb-1">
-      {$i18n.t('encounters.form.locationLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
-    </label>
-    <input
-      id="location"
-      type="text"
-      bind:value={locationText}
-      placeholder={$i18n.t('encounters.form.locationPlaceholder')}
-      disabled={isSubmitting}
-      class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm disabled:opacity-50"
-    />
-  </div>
+  <!-- Location (in-person only) -->
+  {#if showLocation}
+    <div>
+      <label for="location" class="block text-sm font-body font-medium text-gray-700 mb-1">
+        {$i18n.t('encounters.form.locationLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
+      </label>
+      <input
+        id="location"
+        type="text"
+        bind:value={locationText}
+        placeholder={$i18n.t('encounters.form.locationPlaceholder')}
+        disabled={isSubmitting}
+        class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm disabled:opacity-50"
+      />
+    </div>
+  {/if}
 
   <!-- Description -->
   <div>

--- a/apps/frontend/src/lib/components/encounters/encounter-list.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-list.svelte
@@ -9,6 +9,8 @@ import type { EncounterListParams } from '$lib/api/encounters';
 import { createI18n } from '$lib/i18n/index.js';
 import { encounters, encountersList } from '$lib/stores/encounters';
 import { visibleEncounterIds } from '$lib/stores/ui';
+import { ENCOUNTER_TYPES, type EncounterType } from '$shared';
+import { encounterTypeLabel } from './encounter-display';
 import EncounterCard from './encounter-card.svelte';
 
 const i18n = createI18n();
@@ -25,6 +27,7 @@ let { friendId, initialSearch = '' }: Props = $props();
 let searchQuery = $state(initialSearch);
 let fromDate = $state('');
 let toDate = $state('');
+let selectedType = $state<EncounterType | ''>('');
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Derived state
@@ -62,6 +65,9 @@ async function loadEncounters(page = 1) {
   if (toDate) {
     params.toDate = toDate;
   }
+  if (selectedType) {
+    params.type = selectedType;
+  }
 
   await encounters.loadEncounters(params);
 }
@@ -86,6 +92,7 @@ function clearFilters() {
   searchQuery = '';
   fromDate = '';
   toDate = '';
+  selectedType = '';
   loadEncounters();
 }
 
@@ -113,6 +120,24 @@ function goToPage(page: number) {
           class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm"
         />
       </div>
+    </div>
+
+    <!-- Type filter -->
+    <div>
+      <label for="type-filter" class="block text-sm font-body font-medium text-gray-700 mb-1">
+        {$i18n.t('encounters.typeFilter')}
+      </label>
+      <select
+        id="type-filter"
+        bind:value={selectedType}
+        onchange={() => loadEncounters()}
+        class="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm bg-white"
+      >
+        <option value="">{$i18n.t('encounters.allTypes')}</option>
+        {#each ENCOUNTER_TYPES as type (type)}
+          <option value={type}>{encounterTypeLabel($i18n.t, type)}</option>
+        {/each}
+      </select>
     </div>
 
     <!-- Date filters -->
@@ -144,7 +169,7 @@ function goToPage(page: number) {
     </div>
 
     <!-- Clear filters -->
-    {#if searchQuery || fromDate || toDate}
+    {#if searchQuery || fromDate || toDate || selectedType}
       <button
         type="button"
         onclick={clearFilters}
@@ -158,7 +183,7 @@ function goToPage(page: number) {
   <!-- Results count -->
   <div class="text-sm text-gray-600 font-body">
     {$i18n.t('encounters.encounterCount', { count: pagination.totalCount })}
-    {#if searchQuery || fromDate || toDate}
+    {#if searchQuery || fromDate || toDate || selectedType}
       <span class="text-forest">{$i18n.t('encounters.filtered')}</span>
     {/if}
   </div>
@@ -181,7 +206,7 @@ function goToPage(page: number) {
       <Calendar class="mx-auto h-12 w-12 text-gray-400" strokeWidth="2" />
       <h3 class="mt-4 text-lg font-heading text-gray-900">{$i18n.t('encounters.noEncounters')}</h3>
       <p class="mt-2 text-sm text-gray-600 font-body">
-        {#if searchQuery || fromDate || toDate}
+        {#if searchQuery || fromDate || toDate || selectedType}
           {$i18n.t('encounters.noEncountersFiltered')}
         {:else}
           {$i18n.t('encounters.noEncountersSubtitle')}

--- a/apps/frontend/src/lib/components/encounters/encounter-type-icon.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-type-icon.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import ChatBubbleLeftRight from 'svelte-heros-v2/ChatBubbleLeftRight.svelte';
+import Phone from 'svelte-heros-v2/Phone.svelte';
+import Users from 'svelte-heros-v2/Users.svelte';
+import VideoCamera from 'svelte-heros-v2/VideoCamera.svelte';
+import type { EncounterType } from '$shared';
+
+interface Props {
+  type: EncounterType;
+  class?: string;
+  strokeWidth?: string;
+}
+
+let { type, class: className = 'w-4 h-4', strokeWidth = '2' }: Props = $props();
+
+const icons = {
+  in_person: Users,
+  phone_call: Phone,
+  video_call: VideoCamera,
+  message: ChatBubbleLeftRight,
+};
+
+let Icon = $derived(icons[type]);
+</script>
+
+<Icon class={className} {strokeWidth} />

--- a/apps/frontend/src/lib/components/encounters/last-encounter-badge.svelte
+++ b/apps/frontend/src/lib/components/encounters/last-encounter-badge.svelte
@@ -5,6 +5,7 @@ import Plus from 'svelte-heros-v2/Plus.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { getLastEncounter } from '$lib/stores/encounters';
 import type { LastEncounterSummary } from '$shared';
+import { encounterDisplayTitle } from './encounter-display';
 
 const i18n = createI18n();
 
@@ -18,6 +19,15 @@ let { friendId, friendName }: Props = $props();
 let lastEncounter = $state<LastEncounterSummary | null>(null);
 let isLoading = $state(true);
 let error = $state<string | null>(null);
+
+let displayTitle = $derived(
+  lastEncounter
+    ? encounterDisplayTitle($i18n.t, {
+        ...lastEncounter,
+        friends: friendName ? [{ displayName: friendName }] : [],
+      })
+    : '',
+);
 
 onMount(async () => {
   try {
@@ -73,7 +83,7 @@ function getDateColor(dateStr: string): string {
   <a
     href="/encounters/{lastEncounter.id}"
     class="inline-flex items-center gap-2 px-3 py-1.5 border rounded-full text-sm font-body transition-colors hover:opacity-80 {getDateColor(lastEncounter.encounterDate)}"
-    title="{$i18n.t('encounters.lastSeen.label')}: {lastEncounter.title}"
+    title="{$i18n.t('encounters.lastSeen.label')}: {displayTitle}"
   >
     <Calendar class="w-4 h-4" strokeWidth="2" />
     <span>{$i18n.t('encounters.lastSeen.label')}: {formatDate(lastEncounter.encounterDate)}</span>

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -73,6 +73,20 @@
     "pageOf": "Seite {{page}} von {{total}}",
     "friendCountMore": "+{{count}} weitere",
     "logEncounter": "Begegnung erfassen",
+    "typeFilter": "Art",
+    "allTypes": "Alle Arten",
+    "types": {
+      "in_person": "Persönlich",
+      "phone_call": "Anruf",
+      "video_call": "Videoanruf",
+      "message": "Nachricht"
+    },
+    "derivedTitle": {
+      "in_person": "{{names}} getroffen",
+      "phone_call": "Anruf mit {{names}}",
+      "video_call": "Videoanruf mit {{names}}",
+      "message": "Nachricht mit {{names}}"
+    },
     "lastSeen": {
       "label": "Zuletzt gesehen",
       "today": "heute",
@@ -87,6 +101,7 @@
       "yearsAgo_other": "vor {{count}} Jahren"
     },
     "form": {
+      "typeLabel": "Art",
       "titleLabel": "Titel",
       "titlePlaceholder": "z.B. Kaffee bei Starbucks, Geburtstagsfeier",
       "dateLabel": "Datum",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -73,6 +73,20 @@
     "pageOf": "Page {{page}} of {{total}}",
     "friendCountMore": "+{{count}} more",
     "logEncounter": "Log encounter",
+    "typeFilter": "Type",
+    "allTypes": "All types",
+    "types": {
+      "in_person": "In person",
+      "phone_call": "Phone call",
+      "video_call": "Video call",
+      "message": "Message"
+    },
+    "derivedTitle": {
+      "in_person": "Met {{names}}",
+      "phone_call": "Phone call with {{names}}",
+      "video_call": "Video call with {{names}}",
+      "message": "Message with {{names}}"
+    },
     "lastSeen": {
       "label": "Last seen",
       "today": "today",
@@ -87,6 +101,7 @@
       "yearsAgo_other": "{{count}} years ago"
     },
     "form": {
+      "typeLabel": "Type",
       "titleLabel": "Title",
       "titlePlaceholder": "e.g., Coffee at Starbucks, Birthday Party",
       "dateLabel": "Date",

--- a/apps/frontend/src/lib/stores/encounters.ts
+++ b/apps/frontend/src/lib/stores/encounters.ts
@@ -82,6 +82,7 @@ function createEncountersStore() {
             {
               id: encounter.id,
               title: encounter.title,
+              encounterType: encounter.encounterType,
               encounterDate: encounter.encounterDate,
               locationText: encounter.locationText,
               friendCount: encounter.friends.length,
@@ -111,6 +112,7 @@ function createEncountersStore() {
               ? {
                   id: encounter.id,
                   title: encounter.title,
+                  encounterType: encounter.encounterType,
                   encounterDate: encounter.encounterDate,
                   locationText: encounter.locationText,
                   friendCount: encounter.friends.length,

--- a/database/migrations/1779667200000_encounters-add-type.ts
+++ b/database/migrations/1779667200000_encounters-add-type.ts
@@ -1,0 +1,79 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/**
+ * Encounter interaction type
+ *
+ * Expands encounters to cover non-in-person contact (calls, messages, etc.):
+ * - adds encounters.encounters.encounter_type with a CHECK constraint
+ *   (existing rows default to 'in_person', so nothing breaks)
+ * - relaxes the title to be optional (calls/messages don't need one;
+ *   the UI derives a label like "Phone call with Sarah" when title is null)
+ *
+ * Epic: #2 - Encounter Management
+ */
+
+const VALID_TYPES = "encounter_type IN ('in_person', 'phone_call', 'video_call', 'message')";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // ============================================================================
+  // Step 1: Add encounter_type discriminator
+  // ============================================================================
+  pgm.addColumn(
+    { schema: 'encounters', name: 'encounters' },
+    {
+      encounter_type: {
+        type: 'text',
+        notNull: true,
+        default: 'in_person',
+        comment: "Kind of contact: 'in_person', 'phone_call', 'video_call' or 'message'",
+      },
+    },
+  );
+
+  pgm.addConstraint(
+    { schema: 'encounters', name: 'encounters' },
+    'encounters_encounter_type_valid',
+    { check: VALID_TYPES },
+  );
+
+  // Composite index for filtering a user's encounters by type
+  pgm.createIndex({ schema: 'encounters', name: 'encounters' }, ['user_id', 'encounter_type'], {
+    name: 'idx_encounters_user_type',
+  });
+
+  // ============================================================================
+  // Step 2: Make title optional (calls/messages may have no title)
+  // ============================================================================
+  pgm.alterColumn({ schema: 'encounters', name: 'encounters' }, 'title', { notNull: false });
+
+  // Replace the not-empty check so it allows NULL but still rejects blank/oversized titles
+  pgm.dropConstraint({ schema: 'encounters', name: 'encounters' }, 'encounters_title_not_empty');
+  pgm.addConstraint({ schema: 'encounters', name: 'encounters' }, 'encounters_title_not_empty', {
+    check: 'title IS NULL OR (LENGTH(TRIM(title)) > 0 AND LENGTH(title) <= 200)',
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // ============================================================================
+  // Step 1: Restore title NOT NULL (backfill any null titles first)
+  // ============================================================================
+  pgm.sql(`UPDATE encounters.encounters SET title = 'Untitled' WHERE title IS NULL`);
+
+  pgm.dropConstraint({ schema: 'encounters', name: 'encounters' }, 'encounters_title_not_empty');
+  pgm.alterColumn({ schema: 'encounters', name: 'encounters' }, 'title', { notNull: true });
+  pgm.addConstraint({ schema: 'encounters', name: 'encounters' }, 'encounters_title_not_empty', {
+    check: 'LENGTH(TRIM(title)) > 0 AND LENGTH(title) <= 200',
+  });
+
+  // ============================================================================
+  // Step 2: Drop encounter_type
+  // ============================================================================
+  pgm.dropIndex({ schema: 'encounters', name: 'encounters' }, ['user_id', 'encounter_type'], {
+    name: 'idx_encounters_user_type',
+  });
+  pgm.dropConstraint(
+    { schema: 'encounters', name: 'encounters' },
+    'encounters_encounter_type_valid',
+  );
+  pgm.dropColumn({ schema: 'encounters', name: 'encounters' }, 'encounter_type');
+}

--- a/packages/shared/src/encounters.test.ts
+++ b/packages/shared/src/encounters.test.ts
@@ -1,15 +1,46 @@
 import { describe, expect, it } from 'vitest';
-import { EncounterInputSchema } from './encounters.js';
+import { ENCOUNTER_TYPES, EncounterInputSchema, EncounterUpdateSchema } from './encounters.js';
 
 describe('EncounterInputSchema', () => {
-  it('accepts a valid encounter', () => {
+  it('accepts a valid encounter and defaults the type to in_person', () => {
     const data = {
       title: 'Coffee meetup',
       encounter_date: '2025-01-15',
       friend_ids: ['abc-123'],
     };
     const result = EncounterInputSchema(data);
-    expect(result).toEqual(data);
+    expect(result).toEqual({ ...data, encounter_type: 'in_person' });
+  });
+
+  it('accepts an encounter without a title (title is optional)', () => {
+    const result = EncounterInputSchema({
+      encounter_date: '2025-01-15',
+      encounter_type: 'phone_call',
+      friend_ids: ['abc-123'],
+    });
+    expect(result).toEqual({
+      encounter_date: '2025-01-15',
+      encounter_type: 'phone_call',
+      friend_ids: ['abc-123'],
+    });
+  });
+
+  it.each(ENCOUNTER_TYPES)('accepts the %s interaction type', (type) => {
+    const result = EncounterInputSchema({
+      encounter_date: '2025-01-15',
+      encounter_type: type,
+      friend_ids: ['abc-123'],
+    });
+    expect(result).toMatchObject({ encounter_type: type });
+  });
+
+  it('rejects an unknown interaction type', () => {
+    const result = EncounterInputSchema({
+      encounter_date: '2025-01-15',
+      encounter_type: 'carrier_pigeon',
+      friend_ids: ['abc-123'],
+    });
+    expect(result.summary).toContain('encounter_type');
   });
 
   it('rejects an invalid date format', () => {
@@ -18,9 +49,7 @@ describe('EncounterInputSchema', () => {
       encounter_date: '01/15/2025',
       friend_ids: ['abc-123'],
     });
-    expect(result.summary).toMatchInlineSnapshot(
-      `"must be an encounter with a valid date (YYYY-MM-DD format) (was {"title":"Coffee","encounter_date":"01/15/2025","friend_ids":["abc-123"]})"`,
-    );
+    expect(result.summary).toContain('valid date (YYYY-MM-DD format)');
   });
 
   it('rejects empty friend_ids', () => {
@@ -29,29 +58,68 @@ describe('EncounterInputSchema', () => {
       encounter_date: '2025-01-15',
       friend_ids: [],
     });
-    expect(result.summary).toMatchInlineSnapshot(
-      `"must be an encounter with at least one friend (was {"title":"Coffee","encounter_date":"2025-01-15","friend_ids":[]})"`,
-    );
+    expect(result.summary).toContain('at least one friend');
   });
 
-  it('rejects an empty title', () => {
+  it('rejects an empty title when one is provided', () => {
     const result = EncounterInputSchema({
       title: '',
       encounter_date: '2025-01-15',
       friend_ids: ['abc-123'],
     });
-    expect(result.summary).toMatchInlineSnapshot(`"title must be non-empty"`);
+    expect(result.summary).toContain('title must be non-empty');
+  });
+
+  it('rejects a whitespace-only title', () => {
+    const result = EncounterInputSchema({
+      title: '   ',
+      encounter_date: '2025-01-15',
+      friend_ids: ['abc-123'],
+    });
+    expect(result.summary).toContain('non-blank title');
+  });
+
+  it('rejects a title longer than 200 characters', () => {
+    const result = EncounterInputSchema({
+      title: 'x'.repeat(201),
+      encounter_date: '2025-01-15',
+      friend_ids: ['abc-123'],
+    });
+    expect(result.summary).toContain('at most 200 characters');
   });
 
   it('accepts an encounter with optional fields', () => {
     const data = {
       title: 'Dinner',
       encounter_date: '2025-03-20',
+      encounter_type: 'in_person',
       friend_ids: ['abc-123', 'def-456'],
       location_text: 'Restaurant',
       description: 'Great evening',
     };
     const result = EncounterInputSchema(data);
     expect(result).toEqual(data);
+  });
+});
+
+describe('EncounterUpdateSchema', () => {
+  it('accepts a partial update with a new type', () => {
+    const result = EncounterUpdateSchema({ encounter_type: 'video_call' });
+    expect(result).toEqual({ encounter_type: 'video_call' });
+  });
+
+  it('allows clearing the title with null', () => {
+    const result = EncounterUpdateSchema({ title: null });
+    expect(result).toEqual({ title: null });
+  });
+
+  it('rejects a whitespace-only title', () => {
+    const result = EncounterUpdateSchema({ title: '   ' });
+    expect(result.summary).toContain('non-blank title');
+  });
+
+  it('rejects an unknown interaction type', () => {
+    const result = EncounterUpdateSchema({ encounter_type: 'smoke_signal' });
+    expect(result.summary).toContain('encounter_type');
   });
 });

--- a/packages/shared/src/encounters.ts
+++ b/packages/shared/src/encounters.ts
@@ -6,13 +6,33 @@ import type { PaginationInfo } from './pagination.js';
  */
 
 // ============================================================================
+// Interaction Type
+// ============================================================================
+
+/** All supported kinds of contact an encounter can represent */
+export const ENCOUNTER_TYPES = ['in_person', 'phone_call', 'video_call', 'message'] as const;
+export type EncounterType = (typeof ENCOUNTER_TYPES)[number];
+
+/** arktype literal union for the interaction type */
+const encounterTypeDef = "'in_person' | 'phone_call' | 'video_call' | 'message'";
+
+/** Max title length, kept in sync with the DB CHECK constraint on encounters.title */
+export const ENCOUNTER_TITLE_MAX_LENGTH = 200;
+
+/** A title is valid when it's non-blank after trimming and within the DB length limit. */
+function isValidTitle(title: string): boolean {
+  return title.trim().length > 0 && title.length <= ENCOUNTER_TITLE_MAX_LENGTH;
+}
+
+// ============================================================================
 // Input Schemas
 // ============================================================================
 
 /** Schema for creating an encounter */
 export const EncounterInputSchema = type({
-  title: 'string > 0',
+  'title?': 'string > 0', // optional; UI derives a label for calls/messages
   encounter_date: 'string', // ISO date string (YYYY-MM-DD)
+  encounter_type: `(${encounterTypeDef}) = 'in_person'`,
   friend_ids: 'string[]', // Array of friend external_ids
   'location_text?': 'string | null',
   'description?': 'string | null',
@@ -27,14 +47,20 @@ export const EncounterInputSchema = type({
     ctx.mustBe('an encounter with at least one friend');
     return false;
   }
+  // Validate the title (when present) matches the DB constraint: non-blank, <= 200 chars
+  if (data.title !== undefined && !isValidTitle(data.title)) {
+    ctx.mustBe('an encounter with a non-blank title of at most 200 characters');
+    return false;
+  }
   return true;
 });
 export type EncounterInput = typeof EncounterInputSchema.infer;
 
 /** Schema for updating an encounter (all fields optional) */
 export const EncounterUpdateSchema = type({
-  'title?': 'string > 0',
+  'title?': 'string > 0 | null',
   'encounter_date?': 'string', // ISO date string (YYYY-MM-DD)
+  'encounter_type?': encounterTypeDef,
   'friend_ids?': 'string[]', // Array of friend external_ids
   'location_text?': 'string | null',
   'description?': 'string | null',
@@ -49,6 +75,11 @@ export const EncounterUpdateSchema = type({
     ctx.mustBe('an encounter with at least one friend');
     return false;
   }
+  // A provided (non-null) title must match the DB constraint: non-blank, <= 200 chars
+  if (typeof data.title === 'string' && !isValidTitle(data.title)) {
+    ctx.mustBe('an encounter with a non-blank title of at most 200 characters');
+    return false;
+  }
   return true;
 });
 export type EncounterUpdate = typeof EncounterUpdateSchema.infer;
@@ -61,6 +92,7 @@ export const EncounterListQuerySchema = type({
   'from_date?': 'string', // Filter from date (YYYY-MM-DD)
   'to_date?': 'string', // Filter to date (YYYY-MM-DD)
   'search?': 'string', // Search in title/description
+  'type?': encounterTypeDef, // Filter by interaction type
 });
 export type EncounterListQuery = typeof EncounterListQuerySchema.infer;
 
@@ -72,6 +104,7 @@ export interface EncounterListOptions {
   fromDate?: string;
   toDate?: string;
   search?: string;
+  type?: EncounterType;
 }
 
 /**
@@ -88,6 +121,7 @@ export function parseEncounterListQuery(query: EncounterListQuery): EncounterLis
     fromDate: query.from_date || undefined,
     toDate: query.to_date || undefined,
     search: query.search || undefined,
+    type: query.type || undefined,
   };
 }
 
@@ -105,7 +139,9 @@ export interface EncounterFriendSummary {
 /** Full encounter in API responses */
 export interface Encounter {
   id: string;
-  title: string;
+  /** User-provided title; null for calls/messages where the UI derives a label */
+  title: string | null;
+  encounterType: EncounterType;
   encounterDate: string; // ISO date string (YYYY-MM-DD)
   locationText: string | null;
   description: string | null;
@@ -117,7 +153,8 @@ export interface Encounter {
 /** Encounter in list responses (may have fewer details) */
 export interface EncounterListItem {
   id: string;
-  title: string;
+  title: string | null;
+  encounterType: EncounterType;
   encounterDate: string;
   locationText: string | null;
   friendCount: number;
@@ -134,6 +171,7 @@ export interface EncounterListResponse {
 /** Last encounter summary for friend detail page */
 export interface LastEncounterSummary {
   id: string;
-  title: string;
+  title: string | null;
+  encounterType: EncounterType;
   encounterDate: string;
 }


### PR DESCRIPTION
## Why

Encounters only modeled **in-person meetings**. This lets you also log calls and messages — e.g. "I called for someone."

Chosen approach: **expand encounters with a type discriminator**, not a separate "interactions" entity. Matches the original `docs/concept.md` Feature 2 ("Encounter Log: meetings, **calls, messages** — Date, **type**, notes") and Activity Timeline ("Filter by encounter type"). One table keeps last-contact / frequency / timeline / reminders reading from a single source.

## Types
`in_person`, `phone_call`, `video_call`, `message` (message folds in email/SMS/letter).

## Changes
- **DB** (`1779667200000_encounters-add-type.ts`): `encounter_type TEXT NOT NULL DEFAULT 'in_person'` + CHECK; existing rows backfilled to `in_person`; `title` relaxed to nullable; index `(user_id, encounter_type)`.
- **Shared**: `ENCOUNTER_TYPES`/`EncounterType`; `title` optional on input + nullable in responses; `encounter_type` on input/update/list-filter; `encounterType` on response shapes.
- **Backend**: type threaded through SQL (select/create/update/list filter); `title` switched to set-or-clear update pattern; pgtyped regenerated.
- **Frontend**: 4-way type picker (title optional, location hidden for remote types); per-type icon; derived label "Phone call with Sarah" when title blank (localization stays client-side); type filter on the list.
- **i18n**: en + de type labels, derived-title templates, filter labels.

## Behavior notes
- Existing encounters become `in_person` — no breakage.
- API responses now return `title: string | null` + `encounterType`; the UI derives the display label, so it tracks current friend names.
- Out of scope (future): call direction, duration, attachments.

## Verification
- Migration applied; live DB round-trip: null-title `phone_call` accepted, bad type rejected by CHECK, backfill correct.
- Backend type-check + **154 tests pass**.
- Shared schema **14 tests pass** (default type, null title, bad type).
- Frontend `svelte-check` (in container): **0 new errors** (only pre-existing `leaflet` errors/warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)