### PR TITLE
feat(frontend): inline-preview markdown editor for encounter notes

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,23 +1,15 @@
 {
   "name": "@freundebuch/frontend",
   "version": "2.73.0",
-  "private": true,
-  "license": "AGPL-3.0-only",
-  "type": "module",
-  "scripts": {
-    "dev": "vite dev --host",
-    "build": "vite build",
-    "preview": "vite preview",
-    "sync": "svelte-kit sync",
-    "test": "vitest run --passWithNoTests",
-    "test:unit": "vitest run --reporter=verbose",
-    "test:e2e": "playwright test",
-    "test:watch": "vitest",
-    "type-check": "svelte-check --tsconfig ./tsconfig.json",
-    "check": "aube run sync && svelte-check --tsconfig ./tsconfig.json"
-  },
   "dependencies": {
     "@better-auth/passkey": "1.5.5",
+    "@codemirror/commands": "6.10.3",
+    "@codemirror/lang-markdown": "6.5.0",
+    "@codemirror/language": "6.12.3",
+    "@codemirror/state": "6.6.0",
+    "@codemirror/view": "6.43.0",
+    "@lezer/common": "1.5.2",
+    "@lezer/highlight": "1.2.3",
     "@sentry/sveltekit": "10.32.1",
     "arktype": "2.1.29",
     "better-auth": "1.5.5",
@@ -26,6 +18,7 @@
     "i18next-browser-languagedetector": "8.2.0",
     "isomorphic-dompurify": "2.35.0",
     "leaflet": "1.9.4",
+    "markdown-it": "14.2.0",
     "svelte-easy-crop": "5.0.0",
     "svelte-heros-v2": "3.0.1",
     "svelte-i18next": "2.2.2"
@@ -39,6 +32,7 @@
     "@testing-library/svelte": "5.3.0",
     "@types/d3": "7.4.3",
     "@types/leaflet": "1.9.21",
+    "@types/markdown-it": "14.1.2",
     "autoprefixer": "10.4.23",
     "jsdom": "27.3.0",
     "postcss": "8.5.6",
@@ -49,5 +43,20 @@
     "typescript": "5.9.3",
     "vite": "7.3.0",
     "vitest": "4.0.16"
-  }
+  },
+  "scripts": {
+    "build": "vite build",
+    "check": "aube run sync && svelte-check --tsconfig ./tsconfig.json",
+    "dev": "vite dev --host",
+    "preview": "vite preview",
+    "sync": "svelte-kit sync",
+    "test": "vitest run --passWithNoTests",
+    "test:e2e": "playwright test",
+    "test:unit": "vitest run --reporter=verbose",
+    "test:watch": "vitest",
+    "type-check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "license": "AGPL-3.0-only",
+  "private": true,
+  "type": "module"
 }

--- a/apps/frontend/src/lib/components/encounters/encounter-detail.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-detail.svelte
@@ -4,6 +4,7 @@ import DocumentText from 'svelte-heros-v2/DocumentText.svelte';
 import MapPin from 'svelte-heros-v2/MapPin.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { goto } from '$app/navigation';
+import MarkdownView from '$lib/editor/markdown-view.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { encounters } from '$lib/stores/encounters';
 import type { Encounter } from '$shared';
@@ -134,8 +135,8 @@ async function handleDelete() {
         <DocumentText class="w-5 h-5" strokeWidth="2" />
         {$i18n.t('encounters.detail.notes')}
       </h2>
-      <div class="p-3 bg-gray-50 rounded-lg font-body text-gray-700 whitespace-pre-wrap">
-        {encounter.description}
+      <div class="p-3 bg-gray-50 rounded-lg">
+        <MarkdownView source={encounter.description} />
       </div>
     </section>
   {/if}

--- a/apps/frontend/src/lib/components/encounters/encounter-form.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-form.svelte
@@ -216,10 +216,9 @@ function handleCancel() {
 
   <!-- Description -->
   <div>
-    <!-- svelte-ignore a11y_label_has_associated_control -->
-    <label id="notes-label" class="block text-sm font-body font-medium text-gray-700 mb-1">
+    <span id="notes-label" class="block text-sm font-body font-medium text-gray-700 mb-1">
       {$i18n.t('encounters.form.notesLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
-    </label>
+    </span>
     <MarkdownEditor
       bind:value={description}
       labelledBy="notes-label"

--- a/apps/frontend/src/lib/components/encounters/encounter-form.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-form.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
 import { autoFocus } from '$lib/actions/auto-focus';
+import MarkdownEditor from '$lib/editor/markdown-editor.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { encounters } from '$lib/stores/encounters';
 import {
@@ -218,14 +219,12 @@ function handleCancel() {
     <label for="description" class="block text-sm font-body font-medium text-gray-700 mb-1">
       {$i18n.t('encounters.form.notesLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
     </label>
-    <textarea
-      id="description"
+    <MarkdownEditor
       bind:value={description}
-      rows="3"
+      ariaLabel={$i18n.t('encounters.form.notesLabel')}
       placeholder={$i18n.t('encounters.form.notesPlaceholder')}
       disabled={isSubmitting}
-      class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm resize-none disabled:opacity-50"
-    ></textarea>
+    />
   </div>
 
   <!-- Form Actions -->

--- a/apps/frontend/src/lib/components/encounters/encounter-form.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-form.svelte
@@ -216,6 +216,9 @@ function handleCancel() {
 
   <!-- Description -->
   <div>
+    <!-- Field label, associated to the editor via aria-labelledby. The editor
+         box is large and click/tab focusable, so no label click-to-focus
+         handler (which would need a role + a11y suppression on a static span). -->
     <span id="notes-label" class="block text-sm font-body font-medium text-gray-700 mb-1">
       {$i18n.t('encounters.form.notesLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
     </span>

--- a/apps/frontend/src/lib/components/encounters/encounter-form.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-form.svelte
@@ -216,12 +216,13 @@ function handleCancel() {
 
   <!-- Description -->
   <div>
-    <label for="description" class="block text-sm font-body font-medium text-gray-700 mb-1">
+    <!-- svelte-ignore a11y_label_has_associated_control -->
+    <label id="notes-label" class="block text-sm font-body font-medium text-gray-700 mb-1">
       {$i18n.t('encounters.form.notesLabel')} <span class="text-gray-400">{$i18n.t('encounters.form.optional')}</span>
     </label>
     <MarkdownEditor
       bind:value={description}
-      ariaLabel={$i18n.t('encounters.form.notesLabel')}
+      labelledBy="notes-label"
       placeholder={$i18n.t('encounters.form.notesPlaceholder')}
       disabled={isSubmitting}
     />

--- a/apps/frontend/src/lib/editor/inline-preview/LICENSE
+++ b/apps/frontend/src/lib/editor/inline-preview/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kenny Bergquist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/frontend/src/lib/editor/inline-preview/atomic-theme.ts
+++ b/apps/frontend/src/lib/editor/inline-preview/atomic-theme.ts
@@ -1,0 +1,207 @@
+/*
+ * Vendored from atomic-editor — https://github.com/kenforthewin/atomic-editor
+ * Pinned at commit 26f75e76491e3f9dd698ea91ab91efd5a5e84080 (MIT, see ./LICENSE).
+ * Local modifications are marked with `FB:` comments. See ./vendored.md.
+ */
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
+import { tags as t } from '@lezer/highlight';
+import type { Extension } from '@codemirror/state';
+
+// Package CSS custom properties. Every value below falls back to a
+// dark-neutral default; consumers override by setting the prefixed vars
+// (`--atomic-editor-*`) at any ancestor of the editor. The defaults are
+// deliberately unscoped so the package is usable standalone without
+// forcing the consumer to theme it first.
+
+export const atomicEditorTheme: Extension = EditorView.theme(
+  {
+    '&': {
+      color: 'var(--atomic-editor-fg, #dcddde)',
+      backgroundColor: 'transparent',
+      fontFamily: 'var(--atomic-editor-font, system-ui, -apple-system, BlinkMacSystemFont, sans-serif)',
+      fontSize: 'var(--atomic-editor-body-size, 1rem)',
+      height: '100%',
+    },
+    '.cm-scroller': {
+      fontFamily: 'var(--atomic-editor-font, system-ui, -apple-system, BlinkMacSystemFont, sans-serif)',
+      lineHeight: 'var(--atomic-editor-body-leading, 1.7)',
+      overflow: 'auto',
+    },
+    '.cm-content': {
+      caretColor: 'var(--atomic-editor-accent-bright, #a78bfa)',
+      padding: '0',
+      paddingBottom: '40vh',
+      // CM6's base theme sets `min-width: max-content` on
+      // `.cm-content` so it always grows to fit its widest child.
+      // That defeats every width constraint on our block widgets
+      // (tables especially): a wide table tells `.cm-content`
+      // "I'm 800px", content grows to 800px, and the scroller
+      // shows horizontal scroll — the "editor overflows
+      // horizontally" behavior you see on mobile when a wide
+      // table enters the viewport. Forcing `min-width: 0` lets
+      // the content box stay at its parent width; wide children
+      // are expected to own their own horizontal scroll (see
+      // `.cm-atomic-table-scroll`) rather than pushing the
+      // content.
+      minWidth: '0',
+    },
+    '.cm-line': {
+      padding: '0',
+      // Force-wrap words that have no natural break opportunity —
+      // long URLs, base64 chunks, and code tokens that would
+      // otherwise overflow the line and push the scroll container
+      // wider than the viewport. Without this, long unbroken
+      // tokens blow past the reading column and we get the
+      // transient horizontal overflow on mobile.
+      overflowWrap: 'anywhere',
+    },
+    '&.cm-focused': {
+      outline: 'none',
+    },
+    '.cm-cursor, .cm-dropCursor': {
+      borderLeftColor: 'var(--atomic-editor-accent-bright, #a78bfa)',
+      borderLeftWidth: '2px',
+    },
+    '&.cm-focused .cm-selectionBackground, ::selection, .cm-selectionBackground': {
+      backgroundColor:
+        'var(--atomic-editor-selection-bg, color-mix(in srgb, #7c3aed 28%, #1e1e1e 72%))',
+    },
+    '.cm-activeLine': {
+      backgroundColor: 'transparent',
+    },
+    '.cm-gutters': {
+      display: 'none',
+    },
+    '.cm-tooltip': {
+      backgroundColor: 'var(--atomic-editor-bg-surface, #2d2d2d)',
+      color: 'var(--atomic-editor-fg, #dcddde)',
+      border: '1px solid var(--atomic-editor-border, #3d3d3d)',
+      borderRadius: '6px',
+    },
+    '.cm-panels': {
+      backgroundColor: 'var(--atomic-editor-bg-panel, #252525)',
+      color: 'var(--atomic-editor-fg, #dcddde)',
+      borderColor: 'var(--atomic-editor-border, #3d3d3d)',
+    },
+    '.cm-panel.cm-search': {
+      padding: '8px 12px',
+      fontFamily: 'var(--atomic-editor-font, system-ui, sans-serif)',
+    },
+    '.cm-panel.cm-search input, .cm-panel.cm-search button, .cm-panel.cm-search label': {
+      fontFamily: 'var(--atomic-editor-font, system-ui, sans-serif)',
+      fontSize: '0.8125rem',
+    },
+    '.cm-panel.cm-search input[type=text]': {
+      backgroundColor: 'var(--atomic-editor-bg, #1e1e1e)',
+      color: 'var(--atomic-editor-fg, #dcddde)',
+      border: '1px solid var(--atomic-editor-border, #3d3d3d)',
+      borderRadius: '4px',
+      padding: '4px 8px',
+    },
+    '.cm-panel.cm-search button': {
+      backgroundColor: 'transparent',
+      color: 'var(--atomic-editor-fg-muted, #888)',
+      border: '1px solid var(--atomic-editor-border, #3d3d3d)',
+      borderRadius: '4px',
+      padding: '4px 10px',
+      cursor: 'pointer',
+    },
+    '.cm-searchMatch': {
+      backgroundColor:
+        'var(--atomic-editor-search-bg, color-mix(in srgb, #7c3aed 26%, transparent 74%))',
+      borderRadius: '2px',
+    },
+    '.cm-searchMatch.cm-searchMatch-selected': {
+      backgroundColor:
+        'var(--atomic-editor-search-bg-active, color-mix(in srgb, #7c3aed 60%, transparent 40%))',
+      outline: '1px solid var(--atomic-editor-accent-bright, #a78bfa)',
+    },
+  },
+  // FB: app is light-only; flipped from upstream `dark: true`. All colors
+  // come from `--atomic-editor-*` vars set by the markdown-editor host.
+  { dark: false },
+);
+
+// Markdown syntax tinting plus highlight colors for tokens emitted by
+// grammars nested inside fenced code blocks (see `code-languages.ts`).
+// Punctuation tokens (#, *, `, [, ]) stay muted so the surrounding
+// prose reads cleanly; headings and structural markdown tokens get
+// real visual weight. Code-language tokens (keyword, string, number,
+// etc.) adopt a Material Palenight palette tuned for dark backgrounds;
+// override any color via the `--atomic-editor-hl-*` CSS variables.
+export const atomicMarkdownHighlight = HighlightStyle.define([
+  { tag: t.heading1, fontWeight: '700' },
+  { tag: t.heading2, fontWeight: '700' },
+  { tag: t.heading3, fontWeight: '700' },
+  { tag: t.heading4, fontWeight: '700' },
+  { tag: [t.heading5, t.heading6], fontWeight: '700' },
+
+  { tag: t.strong, fontWeight: '700', color: 'var(--atomic-editor-fg, #dcddde)' },
+  { tag: t.emphasis, fontStyle: 'italic', color: 'var(--atomic-editor-fg, #dcddde)' },
+  { tag: t.strikethrough, textDecoration: 'line-through', color: 'var(--atomic-editor-fg-muted, #888)' },
+
+  {
+    tag: [t.monospace],
+    fontFamily: 'var(--atomic-editor-font-mono, ui-monospace, monospace)',
+    color: 'var(--atomic-editor-link, #60a5fa)',
+  },
+
+  { tag: t.link, color: 'var(--atomic-editor-link, #60a5fa)' },
+  { tag: t.url, color: 'var(--atomic-editor-link, #60a5fa)' },
+
+  { tag: t.processingInstruction, color: 'var(--atomic-editor-fg-faint, #666)' },
+  { tag: t.contentSeparator, color: 'var(--atomic-editor-fg-faint, #666)' },
+  { tag: t.quote, color: 'var(--atomic-editor-fg-muted, #888)' },
+  { tag: t.list, color: 'var(--atomic-editor-fg, #dcddde)' },
+  { tag: t.meta, color: 'var(--atomic-editor-fg-faint, #666)' },
+
+  // Nested code-language tokens. `@codemirror/lang-markdown` wires the
+  // grammars from `code-languages.ts` into fenced blocks whose info
+  // string matches — each fence gets a real AST, so tags below apply.
+  {
+    tag: [t.keyword, t.modifier, t.operatorKeyword, t.controlKeyword, t.definitionKeyword, t.moduleKeyword, t.self],
+    color: 'var(--atomic-editor-hl-keyword, #c792ea)',
+  },
+  {
+    tag: [t.string, t.special(t.string), t.character, t.attributeValue],
+    color: 'var(--atomic-editor-hl-string, #c3e88d)',
+  },
+  {
+    tag: [t.number, t.integer, t.float, t.bool, t.null, t.atom],
+    color: 'var(--atomic-editor-hl-number, #f78c6c)',
+  },
+  {
+    tag: [t.comment, t.lineComment, t.blockComment, t.docComment],
+    color: 'var(--atomic-editor-hl-comment, #6a7a82)',
+    fontStyle: 'italic',
+  },
+  {
+    tag: [t.typeName, t.className, t.namespace, t.standard(t.variableName)],
+    color: 'var(--atomic-editor-hl-type, #ffcb6b)',
+  },
+  {
+    tag: [t.function(t.variableName), t.function(t.propertyName), t.macroName],
+    color: 'var(--atomic-editor-hl-function, #82aaff)',
+  },
+  {
+    tag: [t.propertyName, t.attributeName, t.definition(t.propertyName)],
+    color: 'var(--atomic-editor-hl-property, #82aaff)',
+  },
+  { tag: t.regexp, color: 'var(--atomic-editor-hl-regexp, #f07178)' },
+  { tag: t.escape, color: 'var(--atomic-editor-hl-escape, #89ddff)' },
+  {
+    tag: [t.tagName, t.angleBracket],
+    color: 'var(--atomic-editor-hl-tag, #f07178)',
+  },
+  {
+    tag: [t.variableName, t.labelName, t.definition(t.variableName), t.local(t.variableName)],
+    color: 'var(--atomic-editor-hl-variable, #eeffff)',
+  },
+  { tag: t.operator, color: 'var(--atomic-editor-hl-operator, #89ddff)' },
+  { tag: t.invalid, color: 'var(--atomic-editor-hl-invalid, #ff5370)' },
+
+  { tag: [t.punctuation, t.bracket, t.squareBracket, t.paren, t.brace], color: 'var(--atomic-editor-fg-muted, #888)' },
+]);
+
+export const atomicMarkdownSyntax = syntaxHighlighting(atomicMarkdownHighlight);

--- a/apps/frontend/src/lib/editor/inline-preview/edit-helpers.ts
+++ b/apps/frontend/src/lib/editor/inline-preview/edit-helpers.ts
@@ -1,0 +1,115 @@
+/*
+ * Vendored from atomic-editor — https://github.com/kenforthewin/atomic-editor
+ * Pinned at commit 26f75e76491e3f9dd698ea91ab91efd5a5e84080 (MIT, see ./LICENSE).
+ * Local modifications are marked with `FB:` comments. See ./vendored.md.
+ */
+import { Prec } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+// Obsidian-style extension of emphasis pairs.
+//
+// Problem: CM6's built-in `closeBrackets()` handles single-char pairs
+// well (type `*`, get `*|*`). Typing a second `*` with the cursor
+// between them is treated as "step through the closer" and produces
+// `**|` — which means writing bold (`**foo**`) is a 5-keystroke dance
+// (star, star-step, content, star-new-pair, star-step).
+//
+// This handler fires when the user types `*` (or `_`) with the cursor
+// sitting exactly between two matching characters — an empty pair
+// that closeBrackets just inserted. Instead of stepping through, we
+// extend the pair: `*|*` becomes `**|**`, ready for bold content. All
+// other cases fall through to closeBrackets.
+//
+// Runs at Prec.high so it beats closeBrackets' input handler when
+// both want to act on the keystroke.
+export const extendEmphasisPair = Prec.high(
+  EditorView.inputHandler.of((view, from, to, text) => {
+    if (text !== '*' && text !== '_') return false;
+    const { state } = view;
+    const sel = state.selection.main;
+    if (!sel.empty || from !== to) return false;
+
+    const before = state.doc.sliceString(Math.max(0, from - 1), from);
+    const after = state.doc.sliceString(
+      from,
+      Math.min(state.doc.length, from + 1),
+    );
+    if (before !== text || after !== text) return false;
+
+    view.dispatch({
+      changes: { from, insert: text + text },
+      selection: { anchor: from + 1 },
+    });
+    return true;
+  }),
+);
+
+// Auto-close markdown code fences.
+//
+// When the user completes an opening fence at the start of a line:
+//
+//   ```|
+//
+// immediately insert the matching closing fence below:
+//
+//   ```|
+//   ```
+//
+// The cursor deliberately stays after the opening marker, not inside
+// the block, so the user can still type an info string (`ts`, `rust`,
+// etc.) and then press Enter into the fenced body. If the cursor is
+// already inside an open fenced block, we do nothing — in that context
+// typing ``` is likely the user's manual closing fence.
+export const autoCloseCodeFence = Prec.highest(
+  EditorView.inputHandler.of(autoCloseCodeFenceInput),
+);
+
+export function autoCloseCodeFenceInput(
+  view: EditorView,
+  from: number,
+  to: number,
+  text: string,
+): boolean {
+  if (text !== '`' || from !== to) return false;
+
+  const { state } = view;
+  const line = state.doc.lineAt(from);
+  const before = state.doc.sliceString(line.from, from);
+  const after = state.doc.sliceString(from, line.to);
+  const match = before.match(/^(\s{0,3})``$/);
+  if (!match) return false;
+  if (after !== '' && after !== '`') return false;
+  if (isInsideFencedCodeBeforeLine(state.doc.toString(), line.number)) return false;
+
+  const indent = match[1];
+  const replaceTo = after === '`' ? from + 1 : from;
+  const insert = '`\n' + indent + '```';
+  view.dispatch({
+    changes: { from, to: replaceTo, insert },
+    selection: { anchor: from + 1 },
+  });
+  return true;
+}
+
+function isInsideFencedCodeBeforeLine(doc: string, lineNumber: number): boolean {
+  const lines = doc.split('\n');
+  let marker: '`' | '~' | null = null;
+  let markerLength = 0;
+
+  for (let i = 0; i < lineNumber - 1; i++) {
+    const match = lines[i].match(/^ {0,3}(`{3,}|~{3,})/);
+    if (!match) continue;
+
+    const currentMarker = match[1][0] as '`' | '~';
+    const currentLength = match[1].length;
+    if (!marker) {
+      marker = currentMarker;
+      markerLength = currentLength;
+    } else if (currentMarker === marker && currentLength >= markerLength) {
+      marker = null;
+      markerLength = 0;
+    }
+  }
+
+  return marker !== null;
+}

--- a/apps/frontend/src/lib/editor/inline-preview/index.ts
+++ b/apps/frontend/src/lib/editor/inline-preview/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Local barrel for the vendored atomic-editor CM6 engine. Unlike upstream's
+ * `index.ts`, this exports ONLY the React-free CodeMirror extensions we use —
+ * the upstream React component (`AtomicCodeMirrorEditor.tsx`) is not vendored.
+ */
+export { inlinePreview } from './inline-preview';
+export type { InlinePreviewConfig } from './inline-preview';
+export { atomicEditorTheme, atomicMarkdownSyntax } from './atomic-theme';
+export { extendEmphasisPair, autoCloseCodeFence } from './edit-helpers';

--- a/apps/frontend/src/lib/editor/inline-preview/inline-preview.css
+++ b/apps/frontend/src/lib/editor/inline-preview/inline-preview.css
@@ -1,0 +1,708 @@
+/*
+ * Vendored from atomic-editor — https://github.com/kenforthewin/atomic-editor
+ * Pinned at commit 26f75e76491e3f9dd698ea91ab91efd5a5e84080 (MIT, see ./LICENSE).
+ * Unmodified from upstream; theming is done via `--atomic-editor-*` vars set
+ * by the markdown-editor host. See ./vendored.md.
+ *
+ * @atomic/editor — inline live-preview styles.
+ *
+ * Every rule below sets font-size / weight / decoration purely by CSS
+ * class, and does NOT depend on cursor state. Line heights therefore
+ * stay constant whether the line is "active" (syntax tokens visible)
+ * or "inactive" (tokens hidden by the inline-preview extension's
+ * replace-decorations) — that's what eliminates the layout-shift
+ * problem from widget-replacement approaches.
+ *
+ * Vertical-rhythm rules use `padding` on .cm-line, not `margin`. CM6
+ * measures each line's bounding-box height for virtualization;
+ * padding is inside the box (measured), margin is outside (not
+ * measured), so only padding yields the reader's spacing without
+ * confusing CM6.
+ *
+ * Theming contract: every color / font / size token below reads from
+ * a `--atomic-editor-*` custom property with an inline fallback. The
+ * defaults target a dark background; override the prefixed vars on
+ * any ancestor of the editor to theme it for your app.
+ */
+
+/* Root container — fills its parent so the CM6 scroller can take over
+ * scrolling behavior. Previously relied on Tailwind `h-full w-full`
+ * applied in the React layer, which only worked for consumers who had
+ * Tailwind configured. Baking the sizing into the package means
+ * dropping the editor into any height-bounded parent just works. */
+.atomic-cm-editor {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+/* Content container — constrain to a comfortable reading width. This
+ * is where the prose feel mostly comes from: line length in the
+ * 60–75ch range is what lets the eye sweep naturally. The full editor
+ * frame can still be wide (for search UI, sidebars, etc.) — only the
+ * text column is narrowed. */
+.atomic-cm-editor .cm-content {
+  max-width: var(--atomic-editor-measure, 70ch);
+  margin-inline: auto;
+  padding-inline: 0.5rem;
+  font-family: var(--atomic-editor-font, system-ui, -apple-system, BlinkMacSystemFont, sans-serif);
+  font-size: var(--atomic-editor-body-size, 1.0625rem);
+  line-height: var(--atomic-editor-body-leading, 1.7);
+  color: var(--atomic-editor-fg, #dcddde);
+  text-wrap: pretty;
+}
+
+/* Heading lines. Padding-top (not margin-top) creates the rhythm so
+ * CM6's line-height measurement stays correct.
+ *
+ * These values are intentionally small (≤ 0.2em). Prior values
+ * (0.4em–0.7em) produced a tall visual strip above the heading's
+ * text that belongs to the heading's hit-box but looks identical to
+ * the empty separator line above it. Users would click the visual
+ * "blank space above the heading" and land on the heading by
+ * surprise. The empty markdown line before a heading (which almost
+ * every real doc has) supplies the rest of the rhythm naturally. */
+.cm-line.cm-atomic-h1 {
+  font-size: 1.35em;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+  padding-top: 0.15em;
+  padding-bottom: 0.1em;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-line.cm-atomic-h2 {
+  font-size: 1.2em;
+  font-weight: 700;
+  line-height: 1.35;
+  padding-top: 0.15em;
+  padding-bottom: 0.1em;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-line.cm-atomic-h3 {
+  font-size: 1.1em;
+  font-weight: 600;
+  line-height: 1.4;
+  padding-top: 0.12em;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-line.cm-atomic-h4 {
+  font-size: 1em;
+  font-weight: 600;
+  padding-top: 0.1em;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-line.cm-atomic-h5 {
+  font-size: 0.95em;
+  font-weight: 600;
+  padding-top: 0.08em;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-line.cm-atomic-h6 {
+  font-size: 0.9em;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding-top: 0.08em;
+  color: var(--atomic-editor-fg-muted, #888);
+}
+
+/* Blockquote lines — each line in the quote gets a left rail. Putting
+ * the rail on every line means the visual continues for multi-line
+ * quotes even though each line is an independent DOM element. */
+.cm-line.cm-atomic-blockquote {
+  padding-left: 1rem;
+  border-left: 3px solid var(--atomic-editor-accent-soft, color-mix(in srgb, #7c3aed 72%, white 28%));
+  color: var(--atomic-editor-fg-muted, #888);
+}
+
+/* Fenced-code lines — subtle backdrop so the block reads as code. */
+.cm-line.cm-atomic-fenced-code {
+  font-family: var(--atomic-editor-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.92em;
+  background: var(--atomic-editor-code-bg, color-mix(in srgb, #2d2d2d 88%, black 12%));
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+/* Inline content marks — applied on the text inside **…**, *…*, `…`,
+ * ~~…~~, [text](url). Styling only; no height changes. */
+.cm-atomic-strong {
+  font-weight: 700;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-atomic-em {
+  font-style: italic;
+}
+
+.cm-atomic-inline-code {
+  font-family: var(--atomic-editor-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.88em;
+  color: var(--atomic-editor-fg, #dcddde);
+  background: var(--atomic-editor-code-bg, color-mix(in srgb, #2d2d2d 88%, black 12%));
+  border-radius: 0.35rem;
+  padding: 0.08em 0.35em;
+  word-break: break-word;
+}
+
+.cm-atomic-strike {
+  text-decoration: line-through;
+  color: var(--atomic-editor-fg-muted, #888);
+}
+
+/* Delimiter characters for emphasis marks we supplemented manually
+ * (see `supplementMidTypingEmphasis` in inline-preview.ts). Each
+ * class mirrors what an `EmphasisMark` token would pick up through
+ * syntax highlighting when lezer does parse the pattern: faint
+ * color from `processingInstruction`, plus the parent scope's
+ * weight / style / decoration so the delimiter glyph keeps the
+ * same metrics whether lezer recognized the emphasis or not.
+ * Without the matching weight / style, `**` would visibly change
+ * width as the user types through a trailing space. */
+.cm-atomic-strong-mark {
+  color: var(--atomic-editor-fg-faint, #666);
+  font-weight: 700;
+}
+
+.cm-atomic-em-mark {
+  color: var(--atomic-editor-fg-faint, #666);
+  font-style: italic;
+}
+
+.cm-atomic-strike-mark {
+  color: var(--atomic-editor-fg-faint, #666);
+  text-decoration: line-through;
+}
+
+.cm-atomic-link {
+  color: var(--atomic-editor-link, #60a5fa);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  /* No pointer cursor on the link text — the text is editable like
+   * any other content. The pointer cursor is scoped to the trailing
+   * icon below, which is the actual open-in-new-tab affordance. */
+}
+
+.cm-atomic-link:hover {
+  color: var(--atomic-editor-link-hover, #93c5fd);
+}
+
+/* External-link icon — pseudo-element after the link text. SVG is
+ * encoded as a mask so the color tracks the link color via
+ * `background-color`. */
+.cm-atomic-link::after {
+  content: "";
+  display: inline-block;
+  width: 0.78em;
+  height: 0.78em;
+  margin-left: 0.32em;
+  vertical-align: -0.02em;
+  cursor: pointer;
+  background-color: color-mix(in srgb, var(--atomic-editor-link, #60a5fa) 82%, white 18%);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg%3E%3Cpath d='M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11' stroke='%23000000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/g%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg%3E%3Cpath d='M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11' stroke='%23000000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/g%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  opacity: 0.9;
+}
+
+.cm-atomic-link:hover::after {
+  background-color: color-mix(in srgb, var(--atomic-editor-link-hover, #93c5fd) 84%, white 16%);
+  opacity: 1;
+}
+
+.cm-atomic-wiki-link {
+  color: var(--atomic-editor-link, #60a5fa);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  cursor: pointer;
+}
+
+.cm-atomic-wiki-link:hover {
+  color: var(--atomic-editor-link-hover, #93c5fd);
+}
+
+.cm-atomic-wiki-link-missing,
+.cm-atomic-wiki-link-unresolved {
+  color: var(--atomic-editor-fg-muted, #888);
+  text-decoration-style: dotted;
+}
+
+.cm-atomic-wiki-link-loading {
+  color: var(--atomic-editor-fg-muted, #888);
+}
+
+.cm-atomic-wiki-link-hidden-syntax {
+  color: transparent;
+  font-size: 0;
+  letter-spacing: 0;
+  user-select: none;
+}
+
+/* Horizontal rule — on inactive lines, the raw `***` / `---` /
+ * `___` characters are hidden by Decoration.replace, and a visual
+ * rule is drawn through the center of the line via a pseudo-element.
+ * The line keeps its natural line-height so height stays stable
+ * between active and inactive states (active shows the raw chars). */
+.cm-line.cm-atomic-hr {
+  position: relative;
+}
+
+.cm-line.cm-atomic-hr::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  border-top: 1px solid var(--atomic-editor-border, #3d3d3d);
+  pointer-events: none;
+}
+
+/* Image block widget — rendered below the source line containing
+ * the `![alt](url)` markdown. Natural image size up to the editor's
+ * content width (`max-width: 100%` of .cm-content, which is the
+ * reading-width column). Smaller images render at their own size,
+ * left-aligned. Aspect ratio preserved by `height: auto`. */
+.cm-atomic-image {
+  padding: 0.35em 0;
+}
+
+.cm-atomic-image img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.4em;
+}
+
+/* Bullet widget — replaces the raw `-` / `*` marker on bullet-list
+ * items. Matches the visual weight of a real list marker while
+ * staying in the muted-secondary color so the item text dominates. */
+/* Shared marker alcove — forces bullet, task checkbox, and
+ * ordered-list number into the same fixed horizontal width so the
+ * inline-preview line padding / text-indent math is stable across
+ * list kinds. Width here must match ALCOVE_EM in inline-preview.ts
+ * (`ListMark` branch). Without the fixed width, wrapped-line
+ * indent lands in different places for each kind because the raw
+ * marker widths differ per font. */
+.cm-atomic-list-marker {
+  display: inline-block;
+  width: 0.9em;
+  margin-right: 0.3em;
+  text-align: right;
+}
+
+/* Bullet-only visual styling on top of the shared alcove. */
+.cm-atomic-bullet {
+  color: var(--atomic-editor-fg-muted, #888);
+  font-weight: 700;
+}
+
+/* GFM task-list checkbox widget — replaces `[ ]` / `[x]` in a task
+ * item. Width matches the list-marker wrapper (0.9em); `margin-right:
+ * 0.3em` adds the breathing room between the checkbox and the item
+ * text. Total footprint = 1.2em, which is what ALCOVE_EM expects in
+ * inline-preview.ts (bullets and checkboxes share the same alcove so
+ * first-line content aligns with wrapped-line content consistently).
+ * The trailing space after `[ ]` in the source is swallowed by the
+ * replace decoration. */
+.cm-atomic-task-checkbox {
+  width: 0.9em;
+  height: 0.9em;
+  margin: 0 0.3em 0 0;
+  vertical-align: -0.15em;
+  accent-color: var(--atomic-editor-accent, #7c3aed);
+  cursor: pointer;
+}
+
+/* Whole-line strike for completed task items. */
+.cm-line.cm-atomic-task-done {
+  color: var(--atomic-editor-fg-faint, #666);
+  text-decoration: line-through;
+}
+
+/* WYSIWYG table block widget — emitted by `tables()` in
+ * table-widget.ts. The Table node's source range is fully replaced
+ * by this rendered `<table>`; users interact with cells directly
+ * via `contenteditable`, with Tab / Shift-Tab moving focus between
+ * cells and Tab past the last cell appending a new row.
+ *
+ * Horizontal scroll on the wrapper so wide tables (common in
+ * RSS-ingested content) don't squish their cells to unreadable
+ * widths on narrow viewports. The inner `<table>` uses
+ * `width: max-content` + `min-width: 100%` so it fills the reading
+ * column when narrow and grows past it (triggering the scrollbar)
+ * when content needs more room. `overscroll-behavior-x: contain`
+ * keeps a horizontal flick from bubbling up and scrolling the
+ * whole editor sideways. */
+/* Table wrapper — horizontal scroll contained here so wide
+ * tables don't push the editor's content box wider than the
+ * viewport. Paired with `.cm-content { min-width: 0 }` in the
+ * theme, which is what actually keeps the content box pinned to
+ * parent width (CM6's base theme sets `min-width: max-content`,
+ * which otherwise lets a wide child expand the whole scroller).
+ * Without that pairing no amount of table-level overflow
+ * constraints would hold — the symptom was the editor briefly
+ * going wider than the viewport on mobile when a wide table
+ * entered the rendered viewport. */
+.cm-atomic-table {
+  /* Use padding, not margin, for vertical rhythm around the table.
+   * CM6's heightmap measures block-widget heights via
+   * `getBoundingClientRect`, which EXCLUDES margin but INCLUDES
+   * padding. A `margin: 0.5em 0` here meant the heightmap allocated
+   * less height than the DOM layout flow actually consumed — 1em
+   * (~17px) less on typical font sizes. That drift shifted every
+   * line below the table in CM6's heightmap vs the DOM, so clicks
+   * at a visual Y were routed to the doc line BELOW the one
+   * visually targeted. User-visible symptom: clicking an empty
+   * line above a heading placed the caret on the heading; clicking
+   * text in a task item with the caret on the empty line below
+   * left the caret in place (because the "wrong" line was the same
+   * as the current caret). Padding keeps the bbox honest so CM6's
+   * heightmap matches the DOM. */
+  padding: 0.5em 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.cm-atomic-table table {
+  border-collapse: collapse;
+  width: max-content;
+  min-width: 100%;
+  font-family: var(--atomic-editor-font, system-ui, sans-serif);
+}
+
+.cm-atomic-table th,
+.cm-atomic-table td {
+  border: 1px solid var(--atomic-editor-border, #3d3d3d);
+  padding: 0.35em 0.6em;
+  text-align: left;
+  vertical-align: top;
+  min-width: 2em;
+  min-height: 1.5em;
+}
+
+.cm-atomic-table th {
+  font-weight: 700;
+  background: var(--atomic-editor-code-bg, color-mix(in srgb, #2d2d2d 88%, black 12%));
+}
+
+/* Cells aren't contenteditable themselves; the inner source element
+ * is. Outline the whole cell when focus lands inside so the edit
+ * target reads as "the cell" even though the DOM is split. */
+.cm-atomic-table th:focus-within,
+.cm-atomic-table td:focus-within {
+  outline: 2px solid var(--atomic-editor-accent, #7c3aed);
+  outline-offset: -2px;
+}
+
+/* The editable source inside a cell — always shows the raw markdown
+ * the user types, whether or not the cell also has a rendered image
+ * preview below. Blank outline because the cell's :focus-within
+ * ring is what signals the active edit target. */
+.cm-atomic-table-cell-source {
+  outline: none;
+  min-height: 1.2em;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Inline-mark delimiters (`**`, `__`, `*`, `_`, `~~`, `[`, `]`, `(`, `)`,
+ * URLs) inside table cells. Hidden by default so the reader sees only
+ * the rendered content — bold text without `**`, link text without
+ * brackets or URL. The delimiters remain in the DOM (so textContent
+ * round-trips to the raw markdown on input) but take zero space and
+ * the caret can't navigate into them.
+ *
+ * When the caret enters a mark wrap, JS adds `active` and the
+ * descendant delimiters reveal — so the user can actually edit them.
+ * Nested marks (bold-containing-italic) all reveal together when any
+ * of them contains the caret, because the JS walks ancestors. */
+.cm-atomic-table-cell-source .cm-atomic-mark {
+  display: none;
+}
+
+.cm-atomic-table-cell-source .cm-atomic-strong-wrap.active > .cm-atomic-mark,
+.cm-atomic-table-cell-source .cm-atomic-em-wrap.active > .cm-atomic-mark,
+.cm-atomic-table-cell-source .cm-atomic-strike-wrap.active > .cm-atomic-mark,
+.cm-atomic-table-cell-source .cm-atomic-link-wrap.active > .cm-atomic-mark {
+  display: inline;
+  color: var(--atomic-editor-fg-faint, #666);
+  font-weight: normal;
+  font-style: normal;
+  text-decoration: none;
+}
+
+/* Link URL: monospace hint + size cut so a long URL doesn't dominate
+ * the cell's width once its wrap becomes active. */
+.cm-atomic-table-cell-source .cm-atomic-link-wrap.active > .cm-atomic-link-url {
+  font-family: var(--atomic-editor-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.88em;
+}
+
+/* Rendered image preview strip below the source text. Mirrors how
+ * block-level images render outside a table: the `![alt](url)`
+ * markdown is the source of truth, but the user sees the image in
+ * the resting state — the raw markdown only appears when the cell
+ * is focused for editing (see :focus-within rule below). */
+.cm-atomic-table-cell-preview {
+  margin-top: 0.35em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+  user-select: none;
+}
+
+/* Mirror the block-image invariant from outside tables: on an
+ * inactive cell, the raw `![alt](url)` markdown hides and only the
+ * rendered image shows. Focus the cell (click or Tab) to bring the
+ * source back so it can be edited.
+ *
+ * We visually hide the source without `display: none` so it stays in
+ * the DOM and remains focusable — Tab nav calls `source.focus()`
+ * explicitly and would silently fail on a display:none element. The
+ * position:absolute + zero-size pattern keeps the element interactive
+ * while taking no visible space. */
+.cm-atomic-table th[data-has-image]:not(:focus-within) .cm-atomic-table-cell-source,
+.cm-atomic-table td[data-has-image]:not(:focus-within) .cm-atomic-table-cell-source {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+/* Inline images inside table cells. Capped so a tall image doesn't
+ * balloon a single row into half the viewport. Users who want larger
+ * in-cell images can do without for now — we'd need Obsidian's
+ * `[[file|width]]` alias syntax to make it controllable. */
+.cm-atomic-table-cell-image {
+  display: block;
+  max-width: 14em;
+  max-height: 5em;
+  border-radius: 0.2em;
+  cursor: pointer;
+}
+
+/* Table context menu — right-click a cell to insert / delete rows
+ * and columns. Mounted on document.body so positioning isn't
+ * affected by CM6's overflow scroll. */
+.cm-atomic-table-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 170px;
+  padding: 0.25rem 0;
+  background: var(--atomic-editor-bg-panel, #252525);
+  border: 1px solid var(--atomic-editor-border, #3d3d3d);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  font-family: var(--atomic-editor-font, system-ui, sans-serif);
+  font-size: 0.82rem;
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-atomic-table-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.35rem 0.75rem;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.cm-atomic-table-menu-item:hover {
+  background: var(--atomic-editor-bg-surface, #2d2d2d);
+}
+
+.cm-atomic-table-menu-sep {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: var(--atomic-editor-border, #3d3d3d);
+}
+
+/* Find-in-document panel — single compact row of input + match
+ * counter + prev / next / close icon buttons. Rendered at the top
+ * of the editor by the `search()` extension; DOM built in the
+ * editor component (`defaultSearchPanel`). Styled to match the
+ * rest of the app's control surface: card-toned background,
+ * rounded inputs with an accent focus ring, muted-secondary for
+ * secondary text. */
+.atomic-editor-search-panel {
+  padding: 0.5rem 0.6rem;
+  background: var(--atomic-editor-bg-panel, #252525);
+  border-bottom: 1px solid var(--atomic-editor-border, #3d3d3d);
+  font-family: var(--atomic-editor-font, system-ui, sans-serif);
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.atomic-editor-search-panel form {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.cm-atomic-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.4rem 0.65rem;
+  background: var(--atomic-editor-bg-surface, #2d2d2d);
+  border: 1px solid var(--atomic-editor-border, #3d3d3d);
+  border-radius: 6px;
+  color: inherit;
+  font: inherit;
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.cm-atomic-search-input:focus {
+  border-color: transparent;
+  box-shadow: 0 0 0 2px var(--atomic-editor-accent, #7c3aed);
+}
+
+.cm-atomic-search-input::placeholder {
+  color: var(--atomic-editor-fg-muted, #888);
+}
+
+.cm-atomic-search-count {
+  flex: 0 0 auto;
+  color: var(--atomic-editor-fg-muted, #888);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  min-width: 0;
+  user-select: none;
+}
+
+.cm-atomic-search-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--atomic-editor-fg-muted, #888);
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.cm-atomic-search-btn:hover {
+  background: var(--atomic-editor-bg-surface, #2d2d2d);
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-atomic-search-btn:focus-visible {
+  outline: none;
+  border-color: var(--atomic-editor-accent, #7c3aed);
+  color: var(--atomic-editor-fg, #dcddde);
+}
+
+.cm-atomic-search-btn svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+/* Highlight matches in the document. Active match gets a stronger
+ * fill; other matches share the same tone in a lighter shade. The
+ * background-color custom properties are pre-mixed in src/index.css
+ * to alpha-blend cleanly over whatever theme backdrop is active. */
+.cm-searchMatch {
+  background: var(--atomic-editor-search-bg, rgba(124, 58, 237, 0.28));
+  border-radius: 2px;
+}
+
+.cm-searchMatch-selected {
+  background: var(--atomic-editor-search-bg-active, rgba(124, 58, 237, 0.6));
+}
+
+/* Initial reveal highlight — paired with the `initialRevealText` prop
+ * and the `revealText()` imperative method on the editor handle.
+ * Starts at a stronger accent-tinted background, settles to a softer
+ * one, then fades to transparent over ~3.2s so the reader's eye
+ * catches the match on arrival without the highlight lingering.
+ *
+ * Two tokens so consumers can theme either the peak or the settled
+ * state independently of the main search-match colors. */
+.cm-initialRevealMatch {
+  background: var(
+    --atomic-editor-initial-reveal-bg,
+    color-mix(in srgb, var(--atomic-editor-accent-soft, #a78bfa) 28%, transparent 72%)
+  );
+  border-radius: 0.2rem;
+  animation: atomic-initial-reveal-fade 3.2s ease-out forwards;
+}
+
+@keyframes atomic-initial-reveal-fade {
+  0% {
+    background: var(
+      --atomic-editor-initial-reveal-bg-strong,
+      color-mix(in srgb, var(--atomic-editor-accent-soft, #a78bfa) 42%, transparent 58%)
+    );
+  }
+  65% {
+    background: var(
+      --atomic-editor-initial-reveal-bg,
+      color-mix(in srgb, var(--atomic-editor-accent-soft, #a78bfa) 28%, transparent 72%)
+    );
+  }
+  100% {
+    background: transparent;
+  }
+}
+
+/* Light-theme overrides. Consumers opt in by setting `data-theme="light"`
+ * on any ancestor of the editor. The dark defaults above remain unchanged;
+ * this block just re-maps the `--atomic-editor-*` variables with light
+ * values so the same class graph renders cleanly on a pale backdrop.
+ *
+ * Code-highlight colors swap from Material Palenight to a set tuned for
+ * light backgrounds — the palette ideas come from GitHub's light theme
+ * and the original Solarized Light. */
+[data-theme="light"] .atomic-cm-editor {
+  --atomic-editor-fg: #24292f;
+  --atomic-editor-fg-muted: #57606a;
+  --atomic-editor-fg-faint: #8c959f;
+  --atomic-editor-bg: #ffffff;
+  --atomic-editor-bg-panel: #f6f8fa;
+  --atomic-editor-bg-surface: #eaeef2;
+  --atomic-editor-border: #d0d7de;
+  --atomic-editor-accent: #6639ba;
+  --atomic-editor-accent-bright: #8250df;
+  --atomic-editor-link: #0969da;
+  --atomic-editor-link-hover: #1f6feb;
+  --atomic-editor-code-bg: #f6f8fa;
+  --atomic-editor-selection-bg: rgba(84, 174, 255, 0.25);
+  --atomic-editor-search-bg: rgba(251, 189, 8, 0.35);
+  --atomic-editor-search-bg-active: rgba(251, 189, 8, 0.6);
+  --atomic-editor-hl-keyword: #cf222e;
+  --atomic-editor-hl-string: #0a3069;
+  --atomic-editor-hl-number: #0550ae;
+  --atomic-editor-hl-comment: #6e7781;
+  --atomic-editor-hl-type: #953800;
+  --atomic-editor-hl-function: #8250df;
+  --atomic-editor-hl-property: #0550ae;
+  --atomic-editor-hl-regexp: #116329;
+  --atomic-editor-hl-escape: #0550ae;
+  --atomic-editor-hl-tag: #116329;
+  --atomic-editor-hl-variable: #24292f;
+  --atomic-editor-hl-operator: #cf222e;
+  --atomic-editor-hl-invalid: #82071e;
+}

--- a/apps/frontend/src/lib/editor/inline-preview/inline-preview.ts
+++ b/apps/frontend/src/lib/editor/inline-preview/inline-preview.ts
@@ -1,0 +1,897 @@
+/*
+ * Vendored from atomic-editor — https://github.com/kenforthewin/atomic-editor
+ * Pinned at commit 26f75e76491e3f9dd698ea91ab91efd5a5e84080 (MIT, see ./LICENSE).
+ * Local modifications are marked with `FB:` comments. See ./vendored.md.
+ */
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import {
+  EditorSelection,
+  Prec,
+  StateEffect,
+  StateField,
+  type Extension,
+  type Range,
+  type Text,
+} from '@codemirror/state';
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+  keymap,
+  type DecorationSet,
+  type ViewUpdate,
+} from '@codemirror/view';
+import { treeGrowthEffect, treeProgressPlugin } from './tree-progress';
+
+// Inline preview — the Obsidian "Live Preview" model.
+//
+// Goals:
+//   1. No layout shifts between active/inactive state. The raw markdown
+//      source is always the DOM text; we only apply line-level CSS
+//      classes (setting font-size / weight unconditionally) and hide
+//      syntax tokens on inactive lines via empty Decoration.replace.
+//      Line heights are driven by CSS class, not by token visibility.
+//
+//   2. No reveal during mouse interaction. Clicking a heading places the
+//      cursor on its line, which would normally "reveal" the `# ` prefix
+//      — and that reveal shifts the heading text rightward under the
+//      user's cursor, sometimes turning a click into a micro-drag.
+//      Obsidian sidesteps this by delaying the reveal until the mouse
+//      has been released for a moment; we do the same via a freeze flag.
+
+export interface InlinePreviewConfig {
+  /**
+   * Called when the user plain-clicks a rendered link. Defaults to
+   * `window.open(url, '_blank', 'noopener,noreferrer')`. Consumers in
+   * platform-specific shells (Tauri, Electron, Capacitor) should pass
+   * their own opener so links route through the host's external-URL
+   * mechanism.
+   */
+  onLinkClick?: (url: string) => void;
+}
+
+function defaultOnLinkClick(url: string): void {
+  try {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  } catch {
+    // window.open can throw in sandboxed iframes etc. — silent failure
+    // is fine; the caller can supply an opener that handles this.
+  }
+}
+
+const FREEZE_TAIL_MS = 100;
+
+// ---- freeze plumbing -----------------------------------------------------
+
+const setFrozen = StateEffect.define<boolean>();
+
+const previewFrozenField = StateField.define<boolean>({
+  create: () => false,
+  update(prev, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setFrozen)) return effect.value;
+    }
+    return prev;
+  },
+});
+
+function linkIconHitTarget(event: MouseEvent, root?: HTMLElement): HTMLElement | null {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const linkEl = target.closest<HTMLElement>('.cm-atomic-link');
+  if (!linkEl || (root && !root.contains(linkEl))) return null;
+
+  // The icon is a `::after` pseudo-element, so it doesn't have its own
+  // event target. Compute the same trailing hit-zone used by the click
+  // opener and treat pointerdown in that zone as "on the icon", not
+  // "inside editable link text".
+  const rects = Array.from(linkEl.getClientRects());
+  if (rects.length === 0) return null;
+  const lastRect = rects[rects.length - 1];
+  const emSize = parseFloat(window.getComputedStyle(linkEl).fontSize);
+  const iconZone = emSize * 1.25;
+  const onIcon =
+    event.clientX >= lastRect.right - iconZone &&
+    event.clientX <= lastRect.right &&
+    event.clientY >= lastRect.top &&
+    event.clientY <= lastRect.bottom;
+
+  return onIcon ? linkEl : null;
+}
+
+// Tracks mouse state on the editor and drives the freeze flag. We listen
+// on the content DOM for pointerdown and on the window for pointerup —
+// users can release outside the editor after a drag, and we'd miss the
+// up event if we listened on the content DOM only.
+const freezeMousePlugin = ViewPlugin.fromClass(
+  class {
+    private down = false;
+    private releaseTimer: number | null = null;
+    private readonly onDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      // Only freeze when the pointerdown lands inside the content. The
+      // scrollbar (on the outer .cm-scroller) would otherwise engage the
+      // freeze too — which keeps decorations stale for the whole drag
+      // and the syntax only "pops in" on release. Gesture/wheel scroll
+      // doesn't have this issue because it never fires a pointerdown on
+      // the scrollbar chrome.
+      const target = event.target;
+      if (!(target instanceof Node) || !this.view.contentDOM.contains(target)) {
+        return;
+      }
+      if (linkIconHitTarget(event, this.view.contentDOM)) {
+        // Let the follow-up click open the link, but stop CM6 from
+        // interpreting the icon press as a text-editing click. Without
+        // this, pointerdown moves the selection into the Link node and
+        // reveals `[label](url)` before the click handler opens it.
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return;
+      }
+      this.down = true;
+      if (this.releaseTimer != null) {
+        window.clearTimeout(this.releaseTimer);
+        this.releaseTimer = null;
+      }
+      if (!this.view.state.field(previewFrozenField)) {
+        this.view.dispatch({ effects: setFrozen.of(true) });
+      }
+    };
+    private readonly onUp = () => {
+      if (!this.down) return;
+      this.down = false;
+      if (this.releaseTimer != null) window.clearTimeout(this.releaseTimer);
+      this.releaseTimer = window.setTimeout(() => {
+        this.releaseTimer = null;
+        if (!this.view.state.field(previewFrozenField)) return;
+        try {
+          this.view.dispatch({ effects: setFrozen.of(false) });
+        } catch {
+          // view destroyed while timer was pending.
+        }
+      }, FREEZE_TAIL_MS);
+    };
+
+    constructor(readonly view: EditorView) {
+      // Capture-phase listener on view.dom so we dispatch setFrozen(true)
+      // BEFORE CM6's own pointerdown handler runs its selection logic.
+      // Without capture, CM6's listener can win the order race and
+      // rebuild decorations (revealing `# `/`**`) before we freeze.
+      view.dom.addEventListener('pointerdown', this.onDown, true);
+      window.addEventListener('pointerup', this.onUp);
+      window.addEventListener('pointercancel', this.onUp);
+    }
+
+    update(_: ViewUpdate) {
+      // No-op — we don't drive freeze off doc changes.
+    }
+
+    destroy() {
+      this.view.dom.removeEventListener('pointerdown', this.onDown, true);
+      window.removeEventListener('pointerup', this.onUp);
+      window.removeEventListener('pointercancel', this.onUp);
+      if (this.releaseTimer != null) window.clearTimeout(this.releaseTimer);
+    }
+  },
+);
+
+// ---- decoration building --------------------------------------------------
+
+const LINE_CLASS_BY_BLOCK: Record<string, string> = {
+  ATXHeading1: 'cm-atomic-h1',
+  ATXHeading2: 'cm-atomic-h2',
+  ATXHeading3: 'cm-atomic-h3',
+  ATXHeading4: 'cm-atomic-h4',
+  ATXHeading5: 'cm-atomic-h5',
+  ATXHeading6: 'cm-atomic-h6',
+  SetextHeading1: 'cm-atomic-h1',
+  SetextHeading2: 'cm-atomic-h2',
+  Blockquote: 'cm-atomic-blockquote',
+  FencedCode: 'cm-atomic-fenced-code',
+};
+
+const HIDEABLE_SYNTAX = new Set([
+  'HeaderMark',
+  'EmphasisMark',
+  'CodeMark',
+  'CodeInfo',
+  'LinkMark',
+  'URL',
+  'LinkTitle',
+  'StrikethroughMark',
+  'QuoteMark',
+]);
+
+// Children of a Link node whose visibility follows the link-scoped
+// rule (cursor-inside-link) instead of the default line-based rule.
+// The same token names can appear under an Image node — those stay
+// on the line-based rule because images are a different UX surface.
+const LINK_CHILD_SYNTAX = new Set(['LinkMark', 'URL', 'LinkTitle']);
+
+const INLINE_MARK_CLASS: Record<string, string> = {
+  StrongEmphasis: 'cm-atomic-strong',
+  Emphasis: 'cm-atomic-em',
+  InlineCode: 'cm-atomic-inline-code',
+  Strikethrough: 'cm-atomic-strike',
+  Link: 'cm-atomic-link',
+};
+
+class BulletWidget extends WidgetType {
+  eq(): boolean {
+    return true;
+  }
+  toDOM(): HTMLElement {
+    // The `.cm-atomic-list-marker` class is what forces the
+    // uniform 1.2em inline-block alcove shared by bullets, task
+    // checkboxes, and ordered-list numbers. `.cm-atomic-bullet`
+    // layers on bullet-specific color / weight.
+    const span = document.createElement('span');
+    span.className = 'cm-atomic-list-marker cm-atomic-bullet';
+    span.textContent = '•';
+    return span;
+  }
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+const BULLET_WIDGET = new BulletWidget();
+
+class TaskCheckboxWidget extends WidgetType {
+  constructor(readonly checked: boolean) {
+    super();
+  }
+
+  eq(other: TaskCheckboxWidget): boolean {
+    return other.checked === this.checked;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    // The `.cm-atomic-list-marker` class provides the uniform
+    // inline-block alcove shared by bullets, checkboxes, and
+    // ordered numbers. We apply it directly to the `<input>` so
+    // selectors like `input.cm-atomic-task-checkbox` still work
+    // (a wrapper span broke a Playwright probe that targets the
+    // input by its class).
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = this.checked;
+    input.className = 'cm-atomic-list-marker cm-atomic-task-checkbox';
+    input.setAttribute('contenteditable', 'false');
+    input.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    input.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const pos = view.posAtDOM(input);
+      if (pos < 0) return;
+      const current = view.state.doc.sliceString(pos, pos + 3);
+      const next = /\[x\]/i.test(current) ? '[ ]' : '[x]';
+      if (current === next) return;
+      view.dispatch({ changes: { from: pos, to: pos + 3, insert: next } });
+    });
+    return input;
+  }
+
+  ignoreEvent(event: Event): boolean {
+    return event.type === 'mousedown' || event.type === 'click';
+  }
+}
+
+// ViewPlugin-sourced Decoration.replace ranges are forbidden from
+// crossing a line break — CM6 throws "Decorations that replace line
+// breaks may not be specified via plugins" at build time. Lezer
+// happily emits tokens that do cross line breaks (a LinkTitle /
+// Image title "wrapping across\ntwo lines", for instance), so every
+// Decoration.replace we push has to be split into per-line segments
+// first. The newline between segments stays visible — acceptable
+// compromise, and it matches how other markdown editors render these
+// uncommon multi-line forms.
+function pushReplace(
+  ranges: Range<Decoration>[],
+  doc: Text,
+  from: number,
+  to: number,
+  spec: Parameters<typeof Decoration.replace>[0] = {},
+): void {
+  if (from >= to) return;
+  const startLine = doc.lineAt(from);
+  if (to <= startLine.to) {
+    ranges.push(Decoration.replace(spec).range(from, to));
+    return;
+  }
+  // Multi-line: first segment carries the widget (if any) so it
+  // renders in place of the opening token; subsequent segments are
+  // plain hides. Emitting the widget on every segment would stack
+  // duplicates (e.g. a BulletWidget on line 2+ of a wrapped item).
+  let cursor = from;
+  let firstSegment = true;
+  while (cursor < to) {
+    const line = doc.lineAt(cursor);
+    const segEnd = Math.min(to, line.to);
+    if (segEnd > cursor) {
+      ranges.push(
+        Decoration.replace(firstSegment ? spec : {}).range(cursor, segEnd),
+      );
+      firstSegment = false;
+    }
+    cursor = line.to + 1;
+  }
+}
+
+function buildInlineDecorations(view: EditorView): DecorationSet {
+  const { state } = view;
+  const { doc } = state;
+  const ranges: Range<Decoration>[] = [];
+
+  const activeLines = new Set<number>();
+  if (view.hasFocus) {
+    for (const r of state.selection.ranges) {
+      const firstLine = doc.lineAt(r.from).number;
+      const lastLine = doc.lineAt(r.to).number;
+      for (let n = firstLine; n <= lastLine; n++) activeLines.add(n);
+    }
+  }
+
+  // Decorate the whole parsed tree — not the current viewport — so
+  // that scrolling never needs to rebuild the decoration set. Prior
+  // design walked viewport-only and rebuilt on every scroll, which
+  // on iOS caused scroll-up momentum halts whenever new decorations
+  // were applied to lines at the top of the viewport (anchor
+  // conflict with the scroll animation). Cost: a one-shot whole-doc
+  // walk on every doc / selection / focus change instead of a
+  // smaller walk on every scroll.
+  //
+  // `ensureSyntaxTree(..., doc.length, ...)` guarantees the tree
+  // actually covers the whole doc before we walk it. Without this,
+  // for moderately long atoms the incremental parser's initial
+  // pass falls short of the end, we'd walk only a prefix, and
+  // content past that point renders as raw `##`/`**` forever —
+  // decorations don't rebuild on scroll anymore. Subsequent calls
+  // are near-free because ensureSyntaxTree short-circuits once the
+  // tree reaches the target.
+  const tree =
+    ensureSyntaxTree(state, state.doc.length, 200) ?? syntaxTree(state);
+
+  const taskMarkerByLine = new Map<number, number>();
+  // `from` positions of Link nodes whose range overlaps a selection.
+  // Link children (LinkMark/URL/LinkTitle) hide unless their parent
+  // Link's `from` is in this set — i.e. the cursor has entered the
+  // link specifically, not merely landed on the same line. Images
+  // aren't included; they already have their own widget UX and the
+  // line-based reveal is the right fit for `![alt](url)`.
+  const activeLinkStarts = new Set<number>();
+  tree.iterate({
+    enter: (node) => {
+      if (node.name === 'FencedCode') {
+        const firstLine = doc.lineAt(node.from).number;
+        const lastLine = doc.lineAt(node.to).number;
+        let anyActive = false;
+        for (let n = firstLine; n <= lastLine; n++) {
+          if (activeLines.has(n)) {
+            anyActive = true;
+            break;
+          }
+        }
+        if (anyActive) {
+          for (let n = firstLine; n <= lastLine; n++) activeLines.add(n);
+        }
+      } else if (node.name === 'TaskMarker') {
+        taskMarkerByLine.set(doc.lineAt(node.from).number, node.from);
+      } else if (node.name === 'Link' && view.hasFocus) {
+        for (const range of state.selection.ranges) {
+          // Inclusive overlap: cursor sitting exactly on either
+          // boundary counts as inside, matching the UX where the
+          // next keystroke affects the link.
+          if (range.from <= node.to && range.to >= node.from) {
+            activeLinkStarts.add(node.from);
+            break;
+          }
+        }
+      }
+    },
+  });
+
+  tree.iterate({
+    enter: (node) => {
+      const lineClass = LINE_CLASS_BY_BLOCK[node.name];
+      if (lineClass) {
+        const firstLine = doc.lineAt(node.from);
+        const lastLine = doc.lineAt(node.to);
+        for (let n = firstLine.number; n <= lastLine.number; n++) {
+          const line = doc.line(n);
+          ranges.push(Decoration.line({ class: lineClass }).range(line.from));
+        }
+      }
+
+      const markClass = INLINE_MARK_CLASS[node.name];
+      if (markClass && node.from < node.to) {
+        ranges.push(Decoration.mark({ class: markClass }).range(node.from, node.to));
+      }
+
+      if (HIDEABLE_SYNTAX.has(node.name) && node.from < node.to) {
+        const lineNum = doc.lineAt(node.from).number;
+
+        // Link children use a link-scoped rule (cursor-inside-link)
+        // rather than the line-based rule. A LinkMark under an
+        // Image node falls through to line-based — images have
+        // their own widget UX that the line-based reveal fits.
+        let shouldHide: boolean;
+        if (LINK_CHILD_SYNTAX.has(node.name)) {
+          let parent = node.node.parent;
+          while (parent && parent.name !== 'Link' && parent.name !== 'Image') {
+            parent = parent.parent;
+          }
+          if (parent && parent.name === 'Link') {
+            shouldHide = !activeLinkStarts.has(parent.from);
+          } else {
+            shouldHide = !activeLines.has(lineNum);
+          }
+        } else {
+          shouldHide = !activeLines.has(lineNum);
+        }
+
+        if (shouldHide) {
+          let hideTo = node.to;
+          if (node.name === 'HeaderMark' || node.name === 'QuoteMark') {
+            while (hideTo < doc.length && doc.sliceString(hideTo, hideTo + 1) === ' ') {
+              hideTo++;
+            }
+          }
+          pushReplace(ranges, doc, node.from, hideTo);
+        }
+      }
+
+      // Backslash escapes: `\.`, `\*`, `\(`, etc. RSS-to-markdown
+      // converters escape a lot of punctuation defensively, and the
+      // backslashes show through as literal chars without preview.
+      // Hide just the leading backslash on inactive lines so the
+      // escaped character remains visible — mirrors how Obsidian
+      // renders escapes. The Escape node spans both characters
+      // (`\` + escaped char), so we only replace the first position.
+      if (node.name === 'Escape' && node.to - node.from >= 2) {
+        const lineNum = doc.lineAt(node.from).number;
+        if (!activeLines.has(lineNum)) {
+          pushReplace(ranges, doc, node.from, node.from + 1);
+        }
+      }
+
+      if (node.name === 'ListMark' && node.from < node.to) {
+        const line = doc.lineAt(node.from);
+        const lineNum = line.number;
+        const taskFrom = taskMarkerByLine.get(lineNum);
+
+        // Hanging-indent every list item. Layout:
+        //
+        //   <--BASE--><--ALCOVE--> first-line text
+        //             •            wrapped lines land at the
+        //                          same column as the first-line
+        //                          text, not back under the marker
+        //
+        // ALCOVE_EM is a fixed 1.2em regardless of list kind.
+        // Every marker (bullet widget, checkbox widget, ordered
+        // number via mark decoration) is forced into an
+        // inline-block of exactly that width via CSS — so the
+        // alignment math doesn't depend on per-font marker
+        // widths. `padding-left` sets the content column;
+        // negative `text-indent` of the same magnitude pulls the
+        // first line back so the marker lands in the alcove.
+        const rawIndent = node.from - line.from;
+        const depth = Math.max(0, Math.floor(rawIndent / 2));
+        const BASE_EM = 0.8;
+        const ALCOVE_EM = 1.2;
+        const LEVEL_EM = 0.6;
+        const padding = BASE_EM + ALCOVE_EM + depth * LEVEL_EM;
+        ranges.push(
+          Decoration.line({
+            attributes: {
+              style: `padding-left: ${padding}em; text-indent: -${ALCOVE_EM}em`,
+            },
+          }).range(line.from),
+        );
+
+        // Figure out how far past node.to the mark's trailing
+        // space lives. For tasks, CM6 pre-computed taskFrom as
+        // the start of the `[ ]`; the `- ` span runs from
+        // node.from to taskFrom, which already covers the space.
+        // For bullets / ordered, include a single trailing space
+        // if present so text flows from padding-left without a
+        // spurious leading space.
+        const hasTrailingSpace =
+          doc.sliceString(node.to, node.to + 1) === ' ';
+        const markEnd = hasTrailingSpace ? node.to + 1 : node.to;
+
+        if (taskFrom !== undefined) {
+          // Hide `- ` (ListMark through the space before `[`).
+          pushReplace(ranges, doc, node.from, taskFrom);
+        } else {
+          const markText = doc.sliceString(node.from, node.to);
+          if (markText === '-' || markText === '*' || markText === '+') {
+            // Bullet: substitute with the fixed-width marker
+            // widget, swallowing the trailing space so content
+            // starts precisely at padding-left.
+            pushReplace(ranges, doc, node.from, markEnd, { widget: BULLET_WIDGET });
+          } else {
+            // Ordered list (or anything else with a non-standard
+            // mark text like `1.`, `42.`): keep the text visible
+            // but mark it so CSS gives it the same fixed-width
+            // alcove. Hide the trailing space separately so the
+            // total marker-plus-space footprint matches ALCOVE.
+            ranges.push(
+              Decoration.mark({ class: 'cm-atomic-list-marker' }).range(
+                node.from,
+                node.to,
+              ),
+            );
+            if (hasTrailingSpace) {
+              pushReplace(ranges, doc, node.to, markEnd);
+            }
+          }
+        }
+      }
+
+      // Tables are rendered by the separate `tables()` block-widget
+      // extension (./table-widget.ts) — the whole Table range is
+      // replaced with an interactive HTML `<table>`. Any inline
+      // decorations on TableHeader/TableRow/TableDelimiter would
+      // target ranges that are already hidden behind the replace
+      // widget, so they're intentionally absent from this builder.
+
+      if (node.name === 'HorizontalRule') {
+        // CommonMark HR: a line of `***`, `---`, or `___` (3+, any
+        // spacing between). On inactive lines we hide the characters
+        // and render a horizontal rule via CSS `::after`. On active
+        // lines we leave the raw characters visible so the user can
+        // edit the marker without it vanishing.
+        const line = doc.lineAt(node.from);
+        if (!activeLines.has(line.number)) {
+          ranges.push(Decoration.line({ class: 'cm-atomic-hr' }).range(line.from));
+          pushReplace(ranges, doc, line.from, line.to);
+        }
+      }
+
+      // FB: upstream hides the raw `![alt](url)` on inactive lines and
+      // relies on the image-blocks widget (not vendored here) to render the
+      // image below the line. Without that widget the source would just
+      // vanish, and we intentionally don't render remote images anyway (the
+      // read-only viewer blocks them for privacy). So leave image markdown
+      // as visible source text — no replacement.
+      // (Upstream behavior was: if line inactive, pushReplace(node.from, node.to).)
+
+      if (node.name === 'TaskMarker' && node.from < node.to) {
+        const markText = doc.sliceString(node.from, node.to);
+        const checked = /\[x\]/i.test(markText);
+        // Swallow the single trailing space after `[ ]` / `[x]` so the
+        // checkbox widget owns the alcove exactly (mirrors how bullet
+        // markers also swallow their trailing space). Without this the
+        // space stays visible, pushing first-line content to the right
+        // of where wrapped lines start — visible as a 0.3em hang.
+        const hasTrailingSpace =
+          node.to < doc.length &&
+          doc.sliceString(node.to, node.to + 1) === ' ';
+        const replaceTo = hasTrailingSpace ? node.to + 1 : node.to;
+        pushReplace(ranges, doc, node.from, replaceTo, {
+          widget: new TaskCheckboxWidget(checked),
+        });
+        if (checked) {
+          const lineNum = doc.lineAt(node.from).number;
+          const line = doc.line(lineNum);
+          ranges.push(
+            Decoration.line({ class: 'cm-atomic-task-done' }).range(line.from),
+          );
+        }
+      }
+    },
+  });
+
+  // Supplemental inline marks for the line containing the cursor.
+  // CommonMark's flanking rules say that `**foo **` is not emphasis
+  // because the closing `**` is preceded by whitespace — lezer
+  // agrees and doesn't emit `StrongEmphasis`, so the walk above
+  // misses it. Result: while the user types a sentence inside
+  // `**...**`, the bold styling flicks on and off every time they
+  // hit the spacebar. We patch the UX by scanning the active line
+  // for matched delimiter pairs the cursor sits between and
+  // emitting the mark ourselves regardless of flanking. Once the
+  // cursor leaves, lezer's opinion wins and the visual reverts to
+  // what will actually persist when the line is serialized.
+  if (view.hasFocus) {
+    const head = state.selection.main.head;
+    const line = doc.lineAt(head);
+    if (activeLines.has(line.number)) {
+      supplementMidTypingEmphasis(
+        line.text,
+        line.from,
+        head - line.from,
+        ranges,
+      );
+    }
+  }
+
+  return Decoration.set(ranges, true);
+}
+
+// Delimiters we emit supplemental marks for, longest first so `**`
+// is matched before `*` and `__` before `_`. Backticks don't need
+// this treatment — CommonMark inline code isn't subject to
+// flanking rules. Each entry carries both the content class (what
+// lezer would style via `t.strong` / `t.emphasis` / `t.strikethrough`)
+// and the delimiter class (matches how the EmphasisMark token
+// renders when lezer *does* parse: parent tag's weight / style /
+// decoration plus `processingInstruction`'s faint color).
+const MID_TYPING_DELIMITERS: readonly {
+  delim: string;
+  contentCls: string;
+  delimCls: string;
+}[] = [
+  { delim: '**', contentCls: 'cm-atomic-strong', delimCls: 'cm-atomic-strong-mark' },
+  { delim: '__', contentCls: 'cm-atomic-strong', delimCls: 'cm-atomic-strong-mark' },
+  { delim: '~~', contentCls: 'cm-atomic-strike', delimCls: 'cm-atomic-strike-mark' },
+  { delim: '*', contentCls: 'cm-atomic-em', delimCls: 'cm-atomic-em-mark' },
+  { delim: '_', contentCls: 'cm-atomic-em', delimCls: 'cm-atomic-em-mark' },
+];
+
+function supplementMidTypingEmphasis(
+  text: string,
+  lineFrom: number,
+  localCursor: number,
+  out: Range<Decoration>[],
+): void {
+  // Track which characters of the line are already "owned" by a
+  // matched delimiter pair so a single-char delimiter doesn't
+  // accidentally pair halves of two different double-delimiter
+  // spans.
+  const consumed = new Uint8Array(text.length);
+
+  for (const { delim, contentCls, delimCls } of MID_TYPING_DELIMITERS) {
+    const dLen = delim.length;
+    let searchFrom = 0;
+    while (searchFrom < text.length) {
+      const open = indexOfUnconsumed(text, delim, searchFrom, consumed);
+      if (open < 0) break;
+      const close = indexOfUnconsumed(text, delim, open + dLen, consumed);
+      if (close < 0) break;
+
+      for (let i = open; i < close + dLen; i++) consumed[i] = 1;
+
+      const contentFrom = open + dLen;
+      const contentTo = close;
+      if (
+        contentFrom < contentTo &&
+        localCursor > open &&
+        localCursor < close + dLen
+      ) {
+        out.push(
+          Decoration.mark({ class: contentCls }).range(
+            lineFrom + contentFrom,
+            lineFrom + contentTo,
+          ),
+        );
+        // Style the delimiter characters to match how lezer's
+        // `EmphasisMark` tokens render when the pattern parses
+        // cleanly. Lezer tags `EmphasisMark` with both its parent
+        // (`strong` / `emphasis` / `strikethrough`) and
+        // `processingInstruction`, so the `**` characters get
+        // faint color AND the parent's weight / style / decoration
+        // — we mirror all of that here so the delimiters don't
+        // flip style / size / color when the cursor moves or a
+        // trailing space triggers / untriggers lezer's parse.
+        out.push(
+          Decoration.mark({ class: delimCls }).range(
+            lineFrom + open,
+            lineFrom + contentFrom,
+          ),
+        );
+        out.push(
+          Decoration.mark({ class: delimCls }).range(
+            lineFrom + contentTo,
+            lineFrom + close + dLen,
+          ),
+        );
+      }
+
+      searchFrom = close + dLen;
+    }
+  }
+}
+
+function indexOfUnconsumed(
+  text: string,
+  needle: string,
+  from: number,
+  consumed: Uint8Array,
+): number {
+  let i = from;
+  while (i <= text.length - needle.length) {
+    const found = text.indexOf(needle, i);
+    if (found < 0) return -1;
+    let isConsumed = false;
+    for (let k = found; k < found + needle.length; k++) {
+      if (consumed[k]) {
+        isConsumed = true;
+        break;
+      }
+    }
+    if (!isConsumed) return found;
+    i = found + 1;
+  }
+  return -1;
+}
+
+const inlinePreviewPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildInlineDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      const prevFrozen = update.startState.field(previewFrozenField);
+      const nextFrozen = update.state.field(previewFrozenField);
+      const justUnfroze = prevFrozen && !nextFrozen;
+
+      if (nextFrozen && !justUnfroze) return;
+
+      // Tree-growth effect: background parser advanced past where
+      // we last walked. For docs large enough that the initial
+      // parse didn't reach the end, later blocks (headings, lists,
+      // etc.) render as raw `##`/`**` until this fires.
+      let treeGrew = false;
+      for (const tr of update.transactions) {
+        for (const effect of tr.effects) {
+          if (effect.is(treeGrowthEffect)) {
+            treeGrew = true;
+            break;
+          }
+        }
+        if (treeGrew) break;
+      }
+
+      // Note: `update.viewportChanged` is intentionally NOT in this
+      // list. Scrolling alone must not rebuild decorations — doing
+      // so on iOS halts momentum whenever the rebuild produces new
+      // decorations for lines at the top of a scroll-up viewport
+      // (CM6 anchor conflict with the scroll animation). Walking
+      // the whole parsed tree on the remaining triggers means
+      // scroll-time cost is zero; the tree walk itself is
+      // single-digit ms for typical atoms.
+      if (
+        justUnfroze ||
+        update.docChanged ||
+        update.selectionSet ||
+        update.focusChanged ||
+        treeGrew
+      ) {
+        this.decorations = buildInlineDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
+// Tight-continuation Enter for bullet lists.
+//
+// Why we override the default: @codemirror/lang-markdown's
+// `insertNewlineContinueMarkup` uses the syntax tree to decide whether a
+// list is "loose" (blank lines between items) and, if so, inserts a
+// blank line as part of the continuation. That inference bleeds in when
+// you start a new list adjacent to an existing one — lezer sees both as
+// siblings in a loose list, and the new item sprouts a blank line the
+// user didn't intend. In our inline-preview mode loose vs tight lists
+// look identical anyway, so we always continue tight.
+function insertTightListItem(view: EditorView): boolean {
+  const { state } = view;
+  const sel = state.selection.main;
+  if (!sel.empty) return false;
+  const from = sel.from;
+  const line = state.doc.lineAt(from);
+
+  const tree = syntaxTree(state);
+  let cursor = tree.resolveInner(from, -1).cursor();
+  let inBulletList = false;
+  for (;;) {
+    if (cursor.name === 'BulletList') {
+      inBulletList = true;
+      break;
+    }
+    if (!cursor.parent()) break;
+  }
+  if (!inBulletList) return false;
+
+  const lineText = state.doc.sliceString(line.from, line.to);
+  const prefix = lineText.match(/^(\s*)([-*+])(\s+)/);
+  if (!prefix) return false;
+
+  const [whole, indent, marker] = prefix;
+  const rest = lineText.slice(whole.length);
+
+  const taskMatch = rest.match(/^(\[[ xX]\])(\s*)/);
+  const taskPrefixLen = taskMatch ? taskMatch[0].length : 0;
+  const contentAfterPrefix = rest.slice(taskPrefixLen);
+
+  if (!contentAfterPrefix.trim()) {
+    const depth = Math.floor(indent.length / 2);
+    if (depth >= 1) {
+      const outerIndent = indent.slice(0, indent.length - 2);
+      const continuation = taskMatch ? `${marker} [ ] ` : `${marker} `;
+      const replacement = `${outerIndent}${continuation}`;
+      view.dispatch({
+        changes: { from: line.from, to: line.to, insert: replacement },
+        selection: EditorSelection.cursor(line.from + replacement.length),
+      });
+    } else {
+      view.dispatch({
+        changes: { from: line.from, to: line.to, insert: '' },
+        selection: EditorSelection.cursor(line.from),
+      });
+    }
+    return true;
+  }
+
+  const continuation = taskMatch ? `${marker} [ ] ` : `${marker} `;
+  const insert = `\n${indent}${continuation}`;
+  view.dispatch({
+    changes: { from, to: from, insert },
+    selection: EditorSelection.cursor(from + insert.length),
+  });
+  return true;
+}
+
+function makeLinkClickHandler(onLinkClick: (url: string) => void): Extension {
+  return EditorView.domEventHandlers({
+    click: (event, view) => {
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
+      if (event.button !== 0) return false;
+      const linkEl = linkIconHitTarget(event, view.contentDOM);
+      if (!linkEl) return false;
+
+      const pos = view.posAtDOM(linkEl);
+      if (pos < 0) return false;
+
+      const tree = syntaxTree(view.state);
+      let node: SyntaxNode | null = tree.resolveInner(pos, 1);
+      while (node && node.name !== 'Link') node = node.parent;
+      if (!node) return false;
+      const urlNode = node.getChild('URL');
+      if (!urlNode) return false;
+
+      const url = view.state.doc.sliceString(urlNode.from, urlNode.to);
+      if (!url) return false;
+
+      event.preventDefault();
+      event.stopPropagation();
+      onLinkClick(url);
+      return true;
+    },
+  });
+}
+
+/**
+ * Assemble the inline-preview extension set. Call once per editor and
+ * include the result in your EditorState `extensions` list. Accepts an
+ * `onLinkClick` callback so consumers can route link opens through
+ * their platform's external-URL mechanism (Tauri IPC, Capacitor
+ * browser, etc.) instead of the default `window.open`.
+ */
+export function inlinePreview(config: InlinePreviewConfig = {}): Extension {
+  const { onLinkClick = defaultOnLinkClick } = config;
+  return [
+    previewFrozenField,
+    inlinePreviewPlugin,
+    freezeMousePlugin,
+    treeProgressPlugin,
+    makeLinkClickHandler(onLinkClick),
+    // Prec.highest to beat @codemirror/lang-markdown's own Enter
+    // handler, which is registered internally by the `markdown()`
+    // extension (not just via the exported markdownKeymap) and
+    // otherwise wins precedence.
+    Prec.highest(keymap.of([{ key: 'Enter', run: insertTightListItem }])),
+  ];
+}

--- a/apps/frontend/src/lib/editor/inline-preview/tree-progress.ts
+++ b/apps/frontend/src/lib/editor/inline-preview/tree-progress.ts
@@ -1,0 +1,139 @@
+/*
+ * Vendored from atomic-editor — https://github.com/kenforthewin/atomic-editor
+ * Pinned at commit 26f75e76491e3f9dd698ea91ab91efd5a5e84080 (MIT, see ./LICENSE).
+ * Local modifications are marked with `FB:` comments. See ./vendored.md.
+ */
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
+import { StateEffect } from '@codemirror/state';
+import { EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
+
+// Broadcasts that lezer's incremental parser has advanced past where
+// it was last observed. Consumers (tables, images, inline-preview)
+// watch for this effect and rebuild their decorations so content
+// parsed into existence during idle time actually renders.
+//
+// Needed because:
+//  - Our StateField builders call `ensureSyntaxTree(state, docLen,
+//    budget)` with a small budget (200ms) to avoid blocking the
+//    initial render. For documents large enough to exceed the
+//    budget, the tree covers only a prefix of the doc at mount.
+//  - StateFields only recompute on transactions. Without a transaction
+//    carrying a signal, the background parser can advance all it
+//    wants and the decorations never catch up — late tables and
+//    images stay as raw `| col |` / `![…](…)` text forever.
+//  - The inline-preview ViewPlugin has the same shape: it walks a
+//    possibly-partial tree and caches the result.
+export const treeGrowthEffect = StateEffect.define<null>();
+
+// How much must the parsed range grow before we dispatch a rebuild
+// effect. A too-small threshold means a storm of tiny rebuilds while
+// the parser chews through the doc; too large means the user might
+// scroll past an unparsed region before it catches up. 8KB is roughly
+// two viewport-heights of text and reliably contains several table/
+// image blocks in our sample content.
+const GROWTH_THRESHOLD = 8192;
+
+// Budget per idle tick — short enough to keep the main thread
+// responsive, long enough to make real progress. rIC/rAF fire at
+// 16ms+, so 30ms is "push a bit past one frame" rather than "steal a
+// whole frame."
+const TICK_BUDGET_MS = 30;
+
+type IdleHandle = { kind: 'idle'; id: number } | { kind: 'raf'; id: number };
+
+function scheduleIdle(cb: () => void): IdleHandle {
+  if (typeof window.requestIdleCallback === 'function') {
+    return { kind: 'idle', id: window.requestIdleCallback(() => cb()) };
+  }
+  return { kind: 'raf', id: window.requestAnimationFrame(() => cb()) };
+}
+
+function cancelIdle(handle: IdleHandle): void {
+  if (handle.kind === 'idle' && typeof window.cancelIdleCallback === 'function') {
+    window.cancelIdleCallback(handle.id);
+  } else if (handle.kind === 'raf') {
+    window.cancelAnimationFrame(handle.id);
+  }
+}
+
+/**
+ * View plugin that monitors lezer's parse progress and dispatches a
+ * `treeGrowthEffect` whenever the tree has grown enough that
+ * downstream decoration builders should re-run. Include this in your
+ * extension set alongside the state fields that depend on tree
+ * coverage — it's a no-op for small docs where the initial parse
+ * already covers everything.
+ */
+// TS caveat: ViewPlugin.fromClass takes an anonymous class, and
+// tsc's declaration emit (for the exported plugin constant) rejects
+// `private` / `protected` / `readonly` modifiers on its members
+// ("property may not be private or protected on an exported
+// anonymous class type"). Underscore prefix keeps the "don't touch"
+// convention without tripping that check.
+export const treeProgressPlugin = ViewPlugin.fromClass(
+  class {
+    view: EditorView;
+    _lastTreeLen: number;
+    _idleHandle: IdleHandle | null = null;
+    _destroyed = false;
+
+    constructor(view: EditorView) {
+      this.view = view;
+      this._lastTreeLen = syntaxTree(view.state).length;
+      this._schedule();
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged) {
+        // Doc edits invalidate everything we knew about tree length;
+        // lezer re-parses from the edit point. Reset and kick the
+        // loop so new content gets picked up.
+        this._lastTreeLen = syntaxTree(update.state).length;
+        this._schedule();
+      }
+    }
+
+    destroy() {
+      this._destroyed = true;
+      if (this._idleHandle !== null) {
+        cancelIdle(this._idleHandle);
+        this._idleHandle = null;
+      }
+    }
+
+    _schedule() {
+      if (this._idleHandle !== null) return;
+      this._idleHandle = scheduleIdle(() => {
+        this._idleHandle = null;
+        if (!this._destroyed) this._tick();
+      });
+    }
+
+    _tick() {
+      const state = this.view.state;
+      const docLen = state.doc.length;
+      if (this._lastTreeLen >= docLen) return;
+
+      // Push the parser further. `ensureSyntaxTree` returns null if
+      // the budget expires before reaching the target — in that case
+      // we still want to read whatever progress was made.
+      const ensured = ensureSyntaxTree(state, docLen, TICK_BUDGET_MS);
+      const newLen = (ensured ?? syntaxTree(state)).length;
+
+      if (newLen >= this._lastTreeLen + GROWTH_THRESHOLD || newLen >= docLen) {
+        const previous = this._lastTreeLen;
+        this._lastTreeLen = newLen;
+        try {
+          this.view.dispatch({ effects: treeGrowthEffect.of(null) });
+        } catch {
+          // View destroyed mid-flight; revert the baseline so a
+          // subsequent tick (if any) still has something to report.
+          this._lastTreeLen = previous;
+          return;
+        }
+      }
+
+      if (newLen < docLen) this._schedule();
+    }
+  },
+);

--- a/apps/frontend/src/lib/editor/inline-preview/vendored.md
+++ b/apps/frontend/src/lib/editor/inline-preview/vendored.md
@@ -1,0 +1,50 @@
+# Vendored: atomic-editor inline-preview engine
+
+These files are a partial vendor of [`@atomic-editor/editor`][repo] — the
+React-free CodeMirror 6 extensions that power Obsidian-style inline markdown
+live-preview. We vendor rather than depend on the npm package because it is
+pre-1.0, single-maintainer, and declares `react`/`react-dom` as **required**
+peer dependencies (only its `AtomicCodeMirrorEditor.tsx` uses React; the engine
+below does not). Vendoring keeps React out of the bundle and gives us a frozen,
+reviewable copy.
+
+[repo]: https://github.com/kenforthewin/atomic-editor
+
+## Source
+
+- Repo: `github.com/kenforthewin/atomic-editor`
+- Pinned commit: `26f75e76491e3f9dd698ea91ab91efd5a5e84080`
+- License: MIT (see `./LICENSE`)
+
+## Files
+
+| File | Upstream path | Notes |
+|---|---|---|
+| `inline-preview.ts` | `src/inline-preview.ts` | core live-preview decorations |
+| `tree-progress.ts` | `src/tree-progress.ts` | incremental-parse progress plugin (dep of above) |
+| `atomic-theme.ts` | `src/atomic-theme.ts` | **modified**: `dark:true`→`false` |
+| `edit-helpers.ts` | `src/edit-helpers.ts` | emphasis-pair + code-fence input handlers |
+| `inline-preview.css` | `src/styles/inline-preview.css` | unmodified |
+| `index.ts` | — | local barrel, not from upstream (no React re-exports) |
+
+**Not vendored:** `AtomicCodeMirrorEditor.tsx` (React), upstream `index.ts`
+(barrel), `table-widget.ts`, `image-blocks.ts`, `wiki-links.ts`,
+`code-languages.ts` — not needed for encounter notes.
+
+## Local modifications
+
+All local edits are marked with `FB:` comments. Currently:
+- `atomic-theme.ts`: flipped `{ dark: true }` → `{ dark: false }` (app is light-only).
+
+Theming is done entirely through `--atomic-editor-*` CSS variables, set on the
+editor host by `../markdown-editor.svelte` — the vendored files are otherwise
+verbatim.
+
+## Re-syncing
+
+Diff against upstream at the pinned commit, then bump the commit hash here and
+in the file headers:
+
+```
+curl -fsSL https://raw.githubusercontent.com/kenforthewin/atomic-editor/<sha>/src/inline-preview.ts | diff - inline-preview.ts
+```

--- a/apps/frontend/src/lib/editor/markdown-editor.svelte
+++ b/apps/frontend/src/lib/editor/markdown-editor.svelte
@@ -36,9 +36,21 @@ let {
 let host: HTMLDivElement;
 let view: EditorView | undefined;
 
-// Lets us reconfigure `editable` after mount when `disabled` changes —
-// `EditorView.editable.of(...)` is otherwise fixed at construction.
+// Compartments let us reconfigure these after mount when the corresponding
+// props change (e.g. the user switches language while the form is open) —
+// extensions baked into EditorState.create are otherwise fixed at construction.
 const editableConf = new Compartment();
+const placeholderConf = new Compartment();
+const attrsConf = new Compartment();
+
+function placeholderExt(text: string) {
+  return text ? cmPlaceholder(text) : [];
+}
+function attrsExt(forId: string, label: string) {
+  return EditorView.contentAttributes.of(
+    forId ? { 'aria-labelledby': forId } : { 'aria-label': label },
+  );
+}
 
 // FB: the vendored atomic theme targets full-page editors (height:100%,
 // 40vh bottom padding, internal scroll). For an inline form field we want
@@ -78,11 +90,9 @@ onMount(() => {
         atomicEditorTheme,
         inlineFieldTheme,
         EditorView.lineWrapping,
-        ...(placeholder ? [cmPlaceholder(placeholder)] : []),
+        placeholderConf.of(placeholderExt(placeholder)),
         editableConf.of(EditorView.editable.of(!disabled)),
-        EditorView.contentAttributes.of(
-          labelledBy ? { 'aria-labelledby': labelledBy } : { 'aria-label': ariaLabel },
-        ),
+        attrsConf.of(attrsExt(labelledBy, ariaLabel)),
         EditorView.updateListener.of((u) => {
           if (u.docChanged) value = u.state.doc.toString();
         }),
@@ -98,6 +108,15 @@ $effect(() => {
   if (!view) return;
   view.dispatch({ effects: editableConf.reconfigure(EditorView.editable.of(!disabled)) });
   if (disabled && view.hasFocus) view.contentDOM.blur();
+});
+
+// Keep the (translatable) placeholder and label attributes live when the
+// props change — e.g. an in-place language switch.
+$effect(() => {
+  view?.dispatch({ effects: placeholderConf.reconfigure(placeholderExt(placeholder)) });
+});
+$effect(() => {
+  view?.dispatch({ effects: attrsConf.reconfigure(attrsExt(labelledBy, ariaLabel)) });
 });
 
 // Reconcile external value changes (e.g. switching edit target) without

--- a/apps/frontend/src/lib/editor/markdown-editor.svelte
+++ b/apps/frontend/src/lib/editor/markdown-editor.svelte
@@ -181,9 +181,11 @@ onDestroy(() => view?.destroy());
   box-shadow: 0 0 0 2px #2d5016;
 }
 
+/* Editing is blocked via EditorView.editable(false); we only dim here.
+ * No `pointer-events: none` — a disabled textarea still scrolls and allows
+ * selection/copy, so long notes stay readable during submit. */
 :global(.fb-md-editor--disabled) {
   opacity: 0.5;
-  pointer-events: none;
 }
 
 /* Brand heading font on rendered heading lines, matching the detail view. */

--- a/apps/frontend/src/lib/editor/markdown-editor.svelte
+++ b/apps/frontend/src/lib/editor/markdown-editor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
 import { markdown } from '@codemirror/lang-markdown';
-import { Compartment, EditorState } from '@codemirror/state';
+import { Compartment, EditorState, Transaction } from '@codemirror/state';
 import { placeholder as cmPlaceholder, EditorView, keymap } from '@codemirror/view';
 import { onDestroy, onMount } from 'svelte';
 import {
@@ -50,6 +50,19 @@ const inlineFieldTheme = EditorView.theme({
   '.cm-content': { paddingBottom: '0.5rem', minHeight: '4.5rem' },
 });
 
+// Open links from the editor only for safe schemes — the URL comes straight
+// from note markdown, so reject javascript:/data: etc. before window.open.
+const SAFE_LINK_SCHEMES = ['http:', 'https:', 'mailto:', 'tel:'];
+function openSafeLink(url: string): void {
+  try {
+    const parsed = new URL(url, window.location.href);
+    if (!SAFE_LINK_SCHEMES.includes(parsed.protocol)) return;
+    window.open(parsed.href, '_blank', 'noopener,noreferrer');
+  } catch {
+    // Malformed URL — ignore rather than open anything.
+  }
+}
+
 onMount(() => {
   view = new EditorView({
     parent: host,
@@ -59,7 +72,7 @@ onMount(() => {
         history(),
         keymap.of([...defaultKeymap, ...historyKeymap]),
         markdown(),
-        inlinePreview(),
+        inlinePreview({ onLinkClick: openSafeLink }),
         extendEmphasisPair,
         atomicMarkdownSyntax,
         atomicEditorTheme,
@@ -93,6 +106,9 @@ $effect(() => {
   if (view && value !== view.state.doc.toString()) {
     view.dispatch({
       changes: { from: 0, to: view.state.doc.length, insert: value },
+      // An external swap isn't the user's edit — keep it out of undo history
+      // so Ctrl-Z doesn't jump back to the previous document's content.
+      annotations: Transaction.addToHistory.of(false),
     });
   }
 });

--- a/apps/frontend/src/lib/editor/markdown-editor.svelte
+++ b/apps/frontend/src/lib/editor/markdown-editor.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { markdown } from '@codemirror/lang-markdown';
+import { Compartment, EditorState } from '@codemirror/state';
+import { placeholder as cmPlaceholder, EditorView, keymap } from '@codemirror/view';
+import { onDestroy, onMount } from 'svelte';
+import {
+  atomicEditorTheme,
+  atomicMarkdownSyntax,
+  extendEmphasisPair,
+  inlinePreview,
+} from './inline-preview';
+import './inline-preview/inline-preview.css';
+
+interface Props {
+  /** Raw markdown — the source of truth. Two-way bound. */
+  value?: string;
+  /** Accessible label text for the editor content. Ignored if `labelledBy` is set. */
+  ariaLabel?: string;
+  /** ID of an element labelling the editor (wins over `ariaLabel`). */
+  labelledBy?: string;
+  /** Placeholder shown while the document is empty. */
+  placeholder?: string;
+  /** Disables editing (mirrors the textarea's `disabled`). */
+  disabled?: boolean;
+}
+
+let {
+  value = $bindable(''),
+  ariaLabel = 'Notes',
+  labelledBy = '',
+  placeholder = '',
+  disabled = false,
+}: Props = $props();
+
+let host: HTMLDivElement;
+let view: EditorView | undefined;
+
+// Lets us reconfigure `editable` after mount when `disabled` changes —
+// `EditorView.editable.of(...)` is otherwise fixed at construction.
+const editableConf = new Compartment();
+
+// FB: the vendored atomic theme targets full-page editors (height:100%,
+// 40vh bottom padding, internal scroll). For an inline form field we want
+// the editor to grow with its content up to a cap. Added after
+// atomicEditorTheme so these rules win on conflict.
+const inlineFieldTheme = EditorView.theme({
+  '&': { height: 'auto' },
+  '.cm-scroller': { overflow: 'auto', maxHeight: '50vh' },
+  '.cm-content': { paddingBottom: '0.5rem', minHeight: '4.5rem' },
+});
+
+onMount(() => {
+  view = new EditorView({
+    parent: host,
+    state: EditorState.create({
+      doc: value,
+      extensions: [
+        history(),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        markdown(),
+        inlinePreview(),
+        extendEmphasisPair,
+        atomicMarkdownSyntax,
+        atomicEditorTheme,
+        inlineFieldTheme,
+        EditorView.lineWrapping,
+        ...(placeholder ? [cmPlaceholder(placeholder)] : []),
+        editableConf.of(EditorView.editable.of(!disabled)),
+        EditorView.contentAttributes.of(
+          labelledBy ? { 'aria-labelledby': labelledBy } : { 'aria-label': ariaLabel },
+        ),
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) value = u.state.doc.toString();
+        }),
+      ],
+    }),
+  });
+});
+
+// Mirror a disabled <textarea>: actually toggle CM editability (the CSS
+// pointer-events guard alone wouldn't block keyboard input on a focused
+// editor). Blur on disable so a focused editor releases the caret.
+$effect(() => {
+  if (!view) return;
+  view.dispatch({ effects: editableConf.reconfigure(EditorView.editable.of(!disabled)) });
+  if (disabled && view.hasFocus) view.contentDOM.blur();
+});
+
+// Reconcile external value changes (e.g. switching edit target) without
+// clobbering the cursor or looping back through the update listener.
+$effect(() => {
+  if (view && value !== view.state.doc.toString()) {
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: value },
+    });
+  }
+});
+
+onDestroy(() => view?.destroy());
+</script>
+
+<div
+  bind:this={host}
+  class="fb-md-editor atomic-cm-editor"
+  class:fb-md-editor--disabled={disabled}
+></div>
+
+<style>
+/* Design-system palette for the vendored engine. All colors flow through
+ * the engine's `--atomic-editor-*` variables; set them on the host and they
+ * inherit into the CodeMirror DOM. :global because the CM nodes are created
+ * at runtime, outside this component's scoped markup. */
+:global(.fb-md-editor) {
+  --atomic-editor-font: var(--font-body);
+  --atomic-editor-font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  --atomic-editor-body-size: 0.875rem;
+  --atomic-editor-body-leading: 1.7;
+  --atomic-editor-measure: 100%;
+
+  --atomic-editor-fg: #374151;
+  --atomic-editor-fg-muted: #6b7280;
+  --atomic-editor-fg-faint: #9ca3af;
+  --atomic-editor-bg: #ffffff;
+  --atomic-editor-bg-surface: #f9fafb;
+  --atomic-editor-bg-panel: #f3f4f6;
+  --atomic-editor-border: #d1d5db;
+  --atomic-editor-code-bg: #f3f4f6;
+
+  --atomic-editor-accent: #2d5016;
+  --atomic-editor-accent-bright: #2d5016;
+  --atomic-editor-accent-soft: #8b9d83;
+  --atomic-editor-link: #2d5016;
+  --atomic-editor-link-hover: #3a6b1e;
+  --atomic-editor-selection-bg: color-mix(in srgb, #2d5016 16%, transparent);
+  --atomic-editor-initial-reveal-bg: color-mix(in srgb, #2d5016 14%, transparent);
+  --atomic-editor-initial-reveal-bg-strong: color-mix(in srgb, #2d5016 22%, transparent);
+
+  /* Code-block highlight palette tuned for a light background
+   * (GitHub-light, from the engine's own light theme). */
+  --atomic-editor-hl-keyword: #cf222e;
+  --atomic-editor-hl-string: #0a3069;
+  --atomic-editor-hl-number: #0550ae;
+  --atomic-editor-hl-comment: #6e7781;
+  --atomic-editor-hl-type: #953800;
+  --atomic-editor-hl-function: #8250df;
+  --atomic-editor-hl-property: #0550ae;
+  --atomic-editor-hl-regexp: #116329;
+  --atomic-editor-hl-escape: #0550ae;
+  --atomic-editor-hl-tag: #116329;
+  --atomic-editor-hl-variable: #24292f;
+  --atomic-editor-hl-operator: #cf222e;
+  --atomic-editor-hl-invalid: #82071e;
+
+  /* Match the surrounding form fields: bordered, rounded, forest focus ring. */
+  display: block;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+:global(.fb-md-editor:focus-within) {
+  border-color: transparent;
+  box-shadow: 0 0 0 2px #2d5016;
+}
+
+:global(.fb-md-editor--disabled) {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Brand heading font on rendered heading lines, matching the detail view. */
+:global(.fb-md-editor .cm-atomic-h1),
+:global(.fb-md-editor .cm-atomic-h2),
+:global(.fb-md-editor .cm-atomic-h3),
+:global(.fb-md-editor .cm-atomic-h4) {
+  font-family: var(--font-heading);
+}
+</style>

--- a/apps/frontend/src/lib/editor/markdown-editor.test.ts
+++ b/apps/frontend/src/lib/editor/markdown-editor.test.ts
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import MarkdownEditor from './markdown-editor.svelte';
+
+// CM6 mounts a real DOM, so these run under jsdom. We assert on the editor's
+// text content (the raw markdown is always present as DOM text — that's the
+// whole point of inline live-preview) rather than reaching into private view
+// internals.
+describe('MarkdownEditor', () => {
+  it('renders a heading line with the inline-preview decoration', async () => {
+    const { container } = render(MarkdownEditor, { props: { value: '## Hello' } });
+    await tick();
+    // Inline live-preview keeps the raw `## ` in the document but hides the
+    // marker in the DOM and tags the line as a heading. So we assert on the
+    // decoration class + visible text, not the raw markers.
+    const heading = container.querySelector('.cm-atomic-h2');
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toContain('Hello');
+  });
+
+  it('reconciles an external value change into the document', async () => {
+    const { container, rerender } = render(MarkdownEditor, { props: { value: 'first' } });
+    await tick();
+    await rerender({ value: 'second' });
+    await tick();
+    const content = container.querySelector('.cm-content');
+    expect(content?.textContent).toContain('second');
+    expect(content?.textContent).not.toContain('first');
+  });
+
+  it('mounts without a placeholder and stays empty', async () => {
+    const { container } = render(MarkdownEditor, { props: { value: '' } });
+    await tick();
+    const content = container.querySelector('.cm-content');
+    expect(content?.textContent).toBe('');
+  });
+});

--- a/apps/frontend/src/lib/editor/markdown-view.svelte
+++ b/apps/frontend/src/lib/editor/markdown-view.svelte
@@ -8,27 +8,28 @@ const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
 // (markers render as inert text) and forbid <img> at sanitize time.
 md.disable('image');
 
-// Harden every rendered link: open in a new tab and sever the opener so
-// note content can't reach back into the app. Runs after sanitization, so
-// it also covers autolinked bare URLs (linkify) and survives `html:false`.
-let hooked = false;
-function ensureHook() {
-  if (hooked) return;
-  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-    if (node.tagName === 'A') {
-      node.setAttribute('target', '_blank');
-      node.setAttribute('rel', 'noopener noreferrer nofollow');
-    }
-  });
-  hooked = true;
-}
+// Harden every rendered link at render time (this markdown-it instance is
+// module-local, so this is scoped to encounter notes — unlike a global
+// DOMPurify.addHook, which would mutate every sanitize() call in the app).
+// Covers both `[text](url)` links and linkified bare URLs.
+const defaultLinkOpen =
+  md.renderer.rules.link_open ??
+  ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));
+md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+  tokens[idx].attrSet('target', '_blank');
+  tokens[idx].attrSet('rel', 'noopener noreferrer nofollow');
+  return defaultLinkOpen(tokens, idx, options, env, self);
+};
 
 export function renderMarkdown(source: string): string {
-  ensureHook();
   // html:false already neutralizes raw HTML; DOMPurify is the belt to that
   // suspenders, and the only thing standing between note text and the DOM.
-  // FORBID_TAGS img backstops the parser-level image disable above.
-  return DOMPurify.sanitize(md.render(source ?? ''), { FORBID_TAGS: ['img'] });
+  // FORBID_TAGS img backstops the parser-level image disable above;
+  // ADD_ATTR keeps the target/rel that markdown-it added on links.
+  return DOMPurify.sanitize(md.render(source ?? ''), {
+    FORBID_TAGS: ['img'],
+    ADD_ATTR: ['target', 'rel'],
+  });
 }
 </script>
 

--- a/apps/frontend/src/lib/editor/markdown-view.svelte
+++ b/apps/frontend/src/lib/editor/markdown-view.svelte
@@ -1,0 +1,126 @@
+<script lang="ts" module>
+import DOMPurify from 'isomorphic-dompurify';
+import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+// No images: a note rendering `![](https://tracker/x.png)` would fire an
+// external request on view, leaking the reader's IP. Disable at the parser
+// (markers render as inert text) and forbid <img> at sanitize time.
+md.disable('image');
+
+// Harden every rendered link: open in a new tab and sever the opener so
+// note content can't reach back into the app. Runs after sanitization, so
+// it also covers autolinked bare URLs (linkify) and survives `html:false`.
+let hooked = false;
+function ensureHook() {
+  if (hooked) return;
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A') {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer nofollow');
+    }
+  });
+  hooked = true;
+}
+
+export function renderMarkdown(source: string): string {
+  ensureHook();
+  // html:false already neutralizes raw HTML; DOMPurify is the belt to that
+  // suspenders, and the only thing standing between note text and the DOM.
+  // FORBID_TAGS img backstops the parser-level image disable above.
+  return DOMPurify.sanitize(md.render(source ?? ''), { FORBID_TAGS: ['img'] });
+}
+</script>
+
+<script lang="ts">
+interface Props {
+  /** Raw markdown to render read-only. */
+  source?: string;
+}
+
+let { source = '' }: Props = $props();
+
+let html = $derived(renderMarkdown(source));
+</script>
+
+<div class="fb-md-view">
+  <!-- eslint-disable-next-line svelte/no-at-html-tags — sanitized above -->
+  {@html html}
+</div>
+
+<style>
+/* Tailwind's preflight strips default element styling, so the rendered
+ * markdown needs its own typography. Tokens match the rest of the app
+ * (Merriweather body, Yanone headings, forest links). :global because the
+ * markup arrives via {@html}. */
+.fb-md-view {
+  font-family: var(--font-body);
+  color: #374151;
+  line-height: 1.7;
+}
+.fb-md-view :global(h1),
+.fb-md-view :global(h2),
+.fb-md-view :global(h3),
+.fb-md-view :global(h4),
+.fb-md-view :global(h5),
+.fb-md-view :global(h6) {
+  font-family: var(--font-heading);
+  color: #111827;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0.75em 0 0.4em;
+}
+.fb-md-view :global(h1) { font-size: 1.5em; }
+.fb-md-view :global(h2) { font-size: 1.3em; }
+.fb-md-view :global(h3) { font-size: 1.15em; }
+.fb-md-view :global(h4) { font-size: 1em; }
+.fb-md-view :global(p) { margin: 0.5em 0; }
+.fb-md-view :global(:first-child) { margin-top: 0; }
+.fb-md-view :global(:last-child) { margin-bottom: 0; }
+.fb-md-view :global(a) {
+  color: #2d5016;
+  text-decoration: underline;
+}
+.fb-md-view :global(a:hover) { color: #3a6b1e; }
+.fb-md-view :global(strong) { font-weight: 700; }
+.fb-md-view :global(em) { font-style: italic; }
+.fb-md-view :global(ul),
+.fb-md-view :global(ol) {
+  margin: 0.5em 0;
+  padding-left: 1.5em;
+}
+.fb-md-view :global(ul) { list-style: disc; }
+.fb-md-view :global(ol) { list-style: decimal; }
+.fb-md-view :global(li) { margin: 0.2em 0; }
+.fb-md-view :global(blockquote) {
+  margin: 0.5em 0;
+  padding-left: 0.75em;
+  border-left: 3px solid #8b9d83;
+  color: #6b7280;
+}
+.fb-md-view :global(code) {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.875em;
+  background: #f3f4f6;
+  padding: 0.1em 0.3em;
+  border-radius: 0.25rem;
+}
+.fb-md-view :global(pre) {
+  background: #f3f4f6;
+  padding: 0.75em;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+.fb-md-view :global(pre code) {
+  background: none;
+  padding: 0;
+}
+.fb-md-view :global(hr) {
+  border: none;
+  border-top: 1px solid #d1d5db;
+  margin: 1em 0;
+}
+.fb-md-view :global(a) {
+  overflow-wrap: anywhere;
+}
+</style>

--- a/apps/frontend/src/lib/editor/markdown-view.svelte
+++ b/apps/frontend/src/lib/editor/markdown-view.svelte
@@ -80,6 +80,7 @@ let html = $derived(renderMarkdown(source));
 .fb-md-view :global(a) {
   color: #2d5016;
   text-decoration: underline;
+  overflow-wrap: anywhere;
 }
 .fb-md-view :global(a:hover) { color: #3a6b1e; }
 .fb-md-view :global(strong) { font-weight: 700; }
@@ -119,8 +120,5 @@ let html = $derived(renderMarkdown(source));
   border: none;
   border-top: 1px solid #d1d5db;
   margin: 1em 0;
-}
-.fb-md-view :global(a) {
-  overflow-wrap: anywhere;
 }
 </style>

--- a/apps/frontend/src/lib/editor/markdown-view.svelte
+++ b/apps/frontend/src/lib/editor/markdown-view.svelte
@@ -76,8 +76,10 @@ let html = $derived(renderMarkdown(source));
 .fb-md-view :global(h3) { font-size: 1.15em; }
 .fb-md-view :global(h4) { font-size: 1em; }
 .fb-md-view :global(p) { margin: 0.5em 0; }
-.fb-md-view :global(:first-child) { margin-top: 0; }
-.fb-md-view :global(:last-child) { margin-bottom: 0; }
+/* Trim only the outer block's leading/trailing margin — direct children
+ * (`>`) so nested first/last items (e.g. a list's first <li>) keep theirs. */
+.fb-md-view > :global(:first-child) { margin-top: 0; }
+.fb-md-view > :global(:last-child) { margin-bottom: 0; }
 .fb-md-view :global(a) {
   color: #2d5016;
   text-decoration: underline;

--- a/apps/frontend/src/lib/editor/markdown-view.svelte
+++ b/apps/frontend/src/lib/editor/markdown-view.svelte
@@ -44,7 +44,7 @@ let html = $derived(renderMarkdown(source));
 </script>
 
 <div class="fb-md-view">
-  <!-- eslint-disable-next-line svelte/no-at-html-tags — sanitized above -->
+  <!-- html is sanitized in renderMarkdown (markdown-it html:false + DOMPurify). -->
   {@html html}
 </div>
 

--- a/apps/frontend/src/lib/editor/markdown-view.test.ts
+++ b/apps/frontend/src/lib/editor/markdown-view.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from './markdown-view.svelte';
+
+describe('renderMarkdown', () => {
+  it('renders markdown headings as HTML', () => {
+    expect(renderMarkdown('## Coffee with Anja')).toContain('<h2>Coffee with Anja</h2>');
+  });
+
+  it('renders emphasis and lists', () => {
+    const html = renderMarkdown('- **bold** item');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<strong>bold</strong>');
+  });
+
+  it('strips a raw <script> payload (XSS regression)', () => {
+    const html = renderMarkdown('hi <script>alert("xss")</script>');
+    expect(html).not.toContain('<script');
+    expect(html.toLowerCase()).not.toContain('alert("xss")</script');
+  });
+
+  it('never produces an executable javascript: link', () => {
+    // markdown-it refuses to linkify javascript: (leaves inert text); even if
+    // it did, DOMPurify would scrub the href. Either way: no live anchor.
+    const html = renderMarkdown('[click](javascript:alert(1))');
+    expect(html).not.toMatch(/<a[^>]*href=["']?\s*javascript:/i);
+  });
+
+  it('hardens external links with target and rel', () => {
+    const html = renderMarkdown('[site](https://example.com)');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer nofollow"');
+  });
+
+  it('never renders an <img> (no external requests on view)', () => {
+    const html = renderMarkdown('![pixel](https://tracker.example/p.png)');
+    expect(html).not.toContain('<img');
+  });
+
+  it('handles empty input without throwing', () => {
+    expect(renderMarkdown('')).toBe('');
+  });
+});

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineConfig } from 'vitest/config';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
@@ -16,6 +17,9 @@ export default defineConfig({
       },
     }),
     sveltekit(),
+    // Enables Svelte 5 component testing under jsdom (browser resolve
+    // condition + auto-cleanup between tests).
+    svelteTesting(),
   ],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -18,8 +18,9 @@ export default defineConfig({
     }),
     sveltekit(),
     // Enables Svelte 5 component testing under jsdom (browser resolve
-    // condition + auto-cleanup between tests).
-    svelteTesting(),
+    // condition + auto-cleanup). Test-only — excluded from dev/preview/prod
+    // builds so it can't affect production module resolution.
+    ...(process.env.VITEST ? [svelteTesting()] : []),
   ],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
       "!**/coverage",
       "!**/*.types.ts",
       "!**/*.queries.ts",
-      "!**/vendor"
+      "!**/vendor",
+      "!**/editor/inline-preview"
     ]
   },
   "formatter": {
@@ -145,6 +146,16 @@
     },
     {
       "includes": ["**/i18n/**/*.ts", "**/shortcuts/**/index.ts", "**/components/ui/index.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useImportExtensions": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["apps/frontend/**/*.{test,spec}.ts"],
       "linter": {
         "rules": {
           "correctness": {

--- a/hk.pkl
+++ b/hk.pkl
@@ -26,8 +26,11 @@ local biomeGlobs = List(
 local linters = new Mapping<String, Step> {
   ["biome"] {
     glob = biomeGlobs
-    check = "biome check --no-errors-on-unmatched {{files}}"
-    fix = "biome check --write --no-errors-on-unmatched {{files}}"
+    // `npx` so the pinned node_modules biome resolves under `mise x` (which
+    // doesn't add node_modules/.bin to PATH) — matches the danger/commitlint
+    // steps below.
+    check = "npx biome check --no-errors-on-unmatched {{files}}"
+    fix = "npx biome check --write --no-errors-on-unmatched {{files}}"
     batch = true
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "seed": "aube --filter @freundebuch/backend run seed",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "prepare": "command -v hk >/dev/null && hk install --mise; ! command -v aube >/dev/null || aube --filter @freundebuch/frontend run sync --no-install || true",
+    "prepare": "git config --unset-all core.hooksPath 2>/dev/null || true; command -v hk >/dev/null && hk install --mise; ! command -v aube >/dev/null || aube --filter @freundebuch/frontend run sync --no-install || true",
     "release": "semantic-release",
     "version:sync": "node scripts/sync-versions.mjs",
     "generate:assets": "node scripts/generate-logo-assets.mjs"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "seed": "aube --filter @freundebuch/backend run seed",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "prepare": "git config --unset-all core.hooksPath 2>/dev/null || true; command -v hk >/dev/null && hk install --mise; ! command -v aube >/dev/null || aube --filter @freundebuch/frontend run sync --no-install || true",
+    "prepare": "(git config --get core.hooksPath 2>/dev/null | grep -q husky && git config --unset-all core.hooksPath) || true; command -v hk >/dev/null && hk install --mise; ! command -v aube >/dev/null || aube --filter @freundebuch/frontend run sync --no-install || true",
     "release": "semantic-release",
     "version:sync": "node scripts/sync-versions.mjs",
     "generate:assets": "node scripts/generate-logo-assets.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,32 +4,1245 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+time:
+  '@acemir/cssom@0.9.31': 2026-01-12T13:17:15.019Z
+  '@alloc/quick-lru@5.2.0': 2021-04-06T00:28:18.669Z
+  '@apm-js-collab/code-transformer@0.8.2': 2025-09-26T12:23:24.222Z
+  '@apm-js-collab/tracing-hooks@0.3.1': 2025-09-26T12:22:33.302Z
+  '@ark/schema@0.56.0': 2025-12-03T06:29:48.188Z
+  '@ark/util@0.56.0': 2025-12-03T06:30:07.868Z
+  '@asamuzakjp/css-color@4.1.2': 2026-02-05T13:42:15.026Z
+  '@asamuzakjp/dom-selector@6.8.1': 2026-02-14T16:09:21.337Z
+  '@asamuzakjp/nwsapi@2.3.9': 2025-03-28T13:43:07.844Z
+  '@babel/code-frame@7.29.0': 2026-01-31T17:39:09.387Z
+  '@babel/compat-data@7.29.3': 2026-04-30T21:33:28.843Z
+  '@babel/core@7.29.0': 2026-01-31T17:39:22.681Z
+  '@babel/generator@7.29.1': 2026-02-04T15:22:40.215Z
+  '@babel/helper-compilation-targets@7.28.6': 2026-01-12T17:49:40.714Z
+  '@babel/helper-globals@7.28.0': 2025-07-02T08:38:14.923Z
+  '@babel/helper-module-imports@7.28.6': 2026-01-12T17:50:04.268Z
+  '@babel/helper-module-transforms@7.28.6': 2026-01-12T17:50:07.751Z
+  '@babel/helper-string-parser@7.27.1': 2025-04-30T15:08:26.501Z
+  '@babel/helper-validator-identifier@7.28.5': 2025-10-23T15:17:38.203Z
+  '@babel/helper-validator-option@7.27.1': 2025-04-30T15:08:27.857Z
+  '@babel/helpers@7.29.2': 2026-03-16T22:33:19.245Z
+  '@babel/parser@7.26.9': 2025-02-14T11:48:05.798Z
+  '@babel/parser@7.29.3': 2026-04-30T21:33:29.634Z
+  '@babel/runtime@7.29.2': 2026-03-16T22:33:19.064Z
+  '@babel/template@7.28.6': 2026-01-12T17:50:00.355Z
+  '@babel/traverse@7.29.0': 2026-01-31T17:39:20.668Z
+  '@babel/types@7.29.0': 2026-01-31T17:39:13.578Z
+  '@balena/dockerignore@1.0.2': 2020-05-13T08:53:55.553Z
+  '@better-auth/core@1.5.5': 2026-03-11T19:35:05.214Z
+  '@better-auth/drizzle-adapter@1.5.5': 2026-03-11T19:35:08.711Z
+  '@better-auth/kysely-adapter@1.5.5': 2026-03-11T19:35:12.620Z
+  '@better-auth/memory-adapter@1.5.5': 2026-03-11T19:35:16.636Z
+  '@better-auth/mongo-adapter@1.5.5': 2026-03-11T19:35:19.871Z
+  '@better-auth/passkey@1.5.5': 2026-03-11T19:36:03.451Z
+  '@better-auth/prisma-adapter@1.5.5': 2026-03-11T19:35:23.411Z
+  '@better-auth/telemetry@1.5.5': 2026-03-11T19:35:30.890Z
+  '@better-auth/utils@0.3.1': 2026-01-27T07:11:01.569Z
+  '@better-fetch/fetch@1.1.21': 2025-12-10T19:41:43.895Z
+  '@biomejs/biome@2.3.10': 2025-12-17T14:33:44.365Z
+  '@biomejs/cli-darwin-arm64@2.3.10': 2025-12-17T14:33:51.296Z
+  '@biomejs/cli-linux-arm64-musl@2.3.10': 2025-12-17T14:34:11.993Z
+  '@biomejs/cli-linux-arm64@2.3.10': 2025-12-17T14:34:05.510Z
+  '@biomejs/cli-linux-x64-musl@2.3.10': 2025-12-17T14:34:27.994Z
+  '@biomejs/cli-linux-x64@2.3.10': 2025-12-17T14:34:20.359Z
+  '@biomejs/cli-win32-arm64@2.3.10': 2025-12-17T14:34:35.250Z
+  '@biomejs/cli-win32-x64@2.3.10': 2025-12-17T14:34:43.525Z
+  '@codemirror/autocomplete@6.20.2': 2026-05-06T10:13:08.891Z
+  '@codemirror/commands@6.10.3': 2026-03-12T09:57:49.662Z
+  '@codemirror/lang-css@6.3.1': 2024-11-26T08:33:43.665Z
+  '@codemirror/lang-html@6.4.11': 2025-10-02T08:19:04.806Z
+  '@codemirror/lang-javascript@6.2.5': 2026-03-02T07:58:09.714Z
+  '@codemirror/lang-markdown@6.5.0': 2025-10-23T11:47:24.694Z
+  '@codemirror/language@6.12.3': 2026-03-25T09:34:19.545Z
+  '@codemirror/lint@6.9.6': 2026-05-06T10:12:47.430Z
+  '@codemirror/state@6.6.0': 2026-03-12T09:55:26.504Z
+  '@codemirror/view@6.43.0': 2026-05-14T13:34:50.320Z
+  '@colors/colors@1.5.0': 2022-02-12T07:39:04.960Z
+  '@commitlint/cli@20.2.0': 2025-12-05T05:01:03.723Z
+  '@commitlint/config-conventional@20.2.0': 2025-12-05T05:01:03.975Z
+  '@commitlint/config-validator@20.5.0': 2026-03-15T13:08:37.382Z
+  '@commitlint/ensure@20.5.3': 2026-04-30T08:16:06.338Z
+  '@commitlint/execute-rule@20.0.0': 2025-09-25T12:59:04.906Z
+  '@commitlint/format@20.5.0': 2026-03-15T13:08:37.332Z
+  '@commitlint/is-ignored@20.5.0': 2026-03-15T13:08:38.854Z
+  '@commitlint/lint@20.2.0': 2025-12-05T05:01:00.829Z
+  '@commitlint/load@20.2.0': 2025-12-05T05:01:00.505Z
+  '@commitlint/message@20.4.3': 2026-03-03T17:46:46.448Z
+  '@commitlint/parse@20.5.0': 2026-03-15T13:08:37.130Z
+  '@commitlint/read@20.5.0': 2026-03-15T13:08:36.814Z
+  '@commitlint/resolve-extends@20.5.3': 2026-04-30T08:16:05.776Z
+  '@commitlint/rules@20.5.3': 2026-04-30T08:16:10.938Z
+  '@commitlint/to-lines@20.0.0': 2025-09-25T12:59:04.560Z
+  '@commitlint/top-level@20.4.3': 2026-03-03T17:46:46.970Z
+  '@commitlint/types@20.5.0': 2026-03-15T13:08:35.313Z
+  '@conventional-changelog/git-client@2.7.0': 2026-04-07T20:41:11.487Z
+  '@csstools/color-helpers@6.0.2': 2026-02-21T15:05:33.253Z
+  '@csstools/css-calc@3.2.1': 2026-05-13T14:25:16.342Z
+  '@csstools/css-color-parser@4.1.1': 2026-05-13T15:11:41.638Z
+  '@csstools/css-parser-algorithms@4.0.0': 2026-01-14T07:20:09.455Z
+  '@csstools/css-syntax-patches-for-csstree@1.1.4': 2026-05-13T14:25:21.448Z
+  '@csstools/css-tokenizer@4.0.0': 2026-01-14T07:14:15.368Z
+  '@esbuild/darwin-arm64@0.27.7': 2026-04-02T16:41:35.638Z
+  '@esbuild/linux-arm64@0.27.7': 2026-04-02T16:42:03.486Z
+  '@esbuild/linux-x64@0.27.7': 2026-04-02T16:42:42.543Z
+  '@esbuild/win32-arm64@0.27.7': 2026-04-02T16:43:29.208Z
+  '@esbuild/win32-x64@0.27.7': 2026-04-02T16:43:41.245Z
+  '@exodus/bytes@1.15.1': 2026-05-20T10:53:15.306Z
+  '@gitbeaker/core@38.12.1': 2023-06-07T02:58:12.022Z
+  '@gitbeaker/requester-utils@38.12.1': 2023-06-07T02:58:10.569Z
+  '@gitbeaker/rest@38.12.1': 2023-06-07T02:58:13.292Z
+  '@grpc/grpc-js@1.14.4': 2026-05-20T17:17:09.002Z
+  '@grpc/proto-loader@0.7.15': 2025-04-18T21:00:44.831Z
+  '@grpc/proto-loader@0.8.1': 2026-05-07T22:16:48.216Z
+  '@hexagon/base64@1.1.28': 2023-09-18T22:28:26.440Z
+  '@hono/node-server@1.19.14': 2026-04-13T01:20:00.328Z
+  '@hono/node-server@1.19.7': 2025-12-08T12:42:41.292Z
+  '@img/colour@1.1.0': 2026-03-01T10:42:44.217Z
+  '@img/sharp-darwin-arm64@0.34.5': 2025-11-06T14:18:48.456Z
+  '@img/sharp-libvips-darwin-arm64@1.2.4': 2025-11-01T11:15:06.267Z
+  '@img/sharp-libvips-linux-arm64@1.2.4': 2025-11-01T11:15:15.004Z
+  '@img/sharp-libvips-linux-x64@1.2.4': 2025-11-01T11:15:47.380Z
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4': 2025-11-01T11:15:20.619Z
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4': 2025-11-01T11:15:25.944Z
+  '@img/sharp-linux-arm64@0.34.5': 2025-11-06T14:18:57.606Z
+  '@img/sharp-linux-x64@0.34.5': 2025-11-06T14:19:10.357Z
+  '@img/sharp-linuxmusl-arm64@0.34.5': 2025-11-06T14:19:13.518Z
+  '@img/sharp-linuxmusl-x64@0.34.5': 2025-11-06T14:19:16.256Z
+  '@img/sharp-win32-arm64@0.34.5': 2025-11-06T14:19:25.773Z
+  '@img/sharp-win32-x64@0.34.5': 2025-11-06T14:19:36.428Z
+  '@isaacs/cliui@8.0.2': 2023-05-02T03:24:28.835Z
+  '@isaacs/cliui@9.0.0': 2026-02-05T18:40:56.258Z
+  '@jridgewell/gen-mapping@0.3.13': 2025-08-12T06:43:21.134Z
+  '@jridgewell/remapping@2.3.5': 2025-08-12T06:43:35.321Z
+  '@jridgewell/resolve-uri@3.1.2': 2024-02-14T19:32:38.143Z
+  '@jridgewell/sourcemap-codec@1.5.5': 2025-08-12T06:43:59.139Z
+  '@jridgewell/trace-mapping@0.3.31': 2025-09-10T20:12:49.468Z
+  '@js-sdsl/ordered-map@4.4.2': 2023-07-21T13:31:10.634Z
+  '@levischuck/tiny-cbor@0.2.11': 2025-02-08T19:57:57.777Z
+  '@lezer/common@1.5.2': 2026-04-08T12:22:15.312Z
+  '@lezer/css@1.3.3': 2026-03-23T14:07:41.604Z
+  '@lezer/highlight@1.2.3': 2025-10-26T09:39:05.764Z
+  '@lezer/html@1.3.13': 2025-12-22T15:39:08.646Z
+  '@lezer/javascript@1.5.4': 2025-09-18T12:15:48.892Z
+  '@lezer/lr@1.4.10': 2026-04-18T11:07:09.833Z
+  '@lezer/markdown@1.6.3': 2026-01-06T16:29:35.744Z
+  '@marijn/find-cluster-break@1.0.2': 2024-12-09T16:15:31.824Z
+  '@modelcontextprotocol/sdk@1.29.0': 2026-03-30T16:50:42.718Z
+  '@mongodb-js/saslprep@1.4.11': 2026-05-03T16:53:24.822Z
+  '@napi-rs/nice-darwin-arm64@1.1.1': 2025-08-14T02:37:07.141Z
+  '@napi-rs/nice-linux-arm64-gnu@1.1.1': 2025-08-14T02:37:26.262Z
+  '@napi-rs/nice-linux-arm64-musl@1.1.1': 2025-08-14T02:37:47.196Z
+  '@napi-rs/nice-linux-x64-gnu@1.1.1': 2025-08-14T02:37:11.076Z
+  '@napi-rs/nice-linux-x64-musl@1.1.1': 2025-08-14T02:37:21.433Z
+  '@napi-rs/nice-win32-arm64-msvc@1.1.1': 2025-08-14T02:37:56.575Z
+  '@napi-rs/nice-win32-x64-msvc@1.1.1': 2025-08-14T02:37:16.261Z
+  '@napi-rs/nice@1.1.1': 2025-08-14T02:38:17.810Z
+  '@noble/ciphers@2.2.0': 2026-04-11T21:34:50.735Z
+  '@noble/hashes@1.8.0': 2025-04-21T21:24:05.654Z
+  '@noble/hashes@2.2.0': 2026-04-11T17:09:41.131Z
+  '@octokit/auth-token@2.5.0': 2021-09-16T17:27:53.834Z
+  '@octokit/auth-token@6.0.0': 2025-05-20T06:25:24.426Z
+  '@octokit/core@3.6.0': 2022-03-13T18:00:39.149Z
+  '@octokit/core@7.0.6': 2025-10-31T00:26:10.155Z
+  '@octokit/endpoint@11.0.3': 2026-02-18T21:20:20.117Z
+  '@octokit/endpoint@6.0.12': 2021-06-11T18:05:58.305Z
+  '@octokit/graphql@4.8.0': 2021-08-31T17:39:12.686Z
+  '@octokit/graphql@9.0.3': 2025-10-31T00:04:07.797Z
+  '@octokit/openapi-types@12.11.0': 2022-07-27T16:46:33.779Z
+  '@octokit/openapi-types@26.0.0': 2025-09-16T02:19:09.520Z
+  '@octokit/openapi-types@27.0.0': 2025-10-30T21:46:34.069Z
+  '@octokit/plugin-paginate-rest@13.2.1': 2025-10-20T19:41:14.130Z
+  '@octokit/plugin-paginate-rest@2.21.3': 2022-07-21T22:29:27.339Z
+  '@octokit/plugin-request-log@1.0.4': 2021-06-11T18:13:59.531Z
+  '@octokit/plugin-rest-endpoint-methods@5.16.2': 2022-07-05T16:41:19.247Z
+  '@octokit/plugin-retry@8.1.0': 2026-02-18T19:36:20.146Z
+  '@octokit/plugin-throttling@11.0.3': 2025-10-31T02:20:30.518Z
+  '@octokit/request-error@2.1.0': 2021-06-11T23:18:10.818Z
+  '@octokit/request-error@7.1.0': 2025-11-13T18:32:02.043Z
+  '@octokit/request@10.0.9': 2026-05-12T19:45:09.488Z
+  '@octokit/request@5.6.3': 2022-01-22T22:01:10.702Z
+  '@octokit/rest@18.12.0': 2021-10-07T19:45:37.921Z
+  '@octokit/types@15.0.2': 2025-10-29T19:29:46.967Z
+  '@octokit/types@16.0.0': 2025-10-30T21:58:24.702Z
+  '@octokit/types@6.41.0': 2022-07-27T17:03:56.645Z
+  '@opentelemetry/api-logs@0.208.0': 2025-11-06T15:56:56.785Z
+  '@opentelemetry/api@1.9.1': 2026-03-25T15:53:54.092Z
+  '@opentelemetry/context-async-hooks@2.7.1': 2026-04-29T18:21:23.793Z
+  '@opentelemetry/core@2.2.0': 2025-10-21T13:19:49.157Z
+  '@opentelemetry/core@2.7.1': 2026-04-29T18:21:30.396Z
+  '@opentelemetry/instrumentation-amqplib@0.55.0': 2025-11-06T18:01:08.695Z
+  '@opentelemetry/instrumentation-connect@0.52.0': 2025-11-06T18:00:56.654Z
+  '@opentelemetry/instrumentation-dataloader@0.26.0': 2025-11-06T18:01:12.520Z
+  '@opentelemetry/instrumentation-express@0.57.0': 2025-11-06T18:01:12.878Z
+  '@opentelemetry/instrumentation-fs@0.28.0': 2025-11-06T18:00:59.985Z
+  '@opentelemetry/instrumentation-generic-pool@0.52.0': 2025-11-06T18:00:59.684Z
+  '@opentelemetry/instrumentation-graphql@0.56.0': 2025-11-06T18:01:00.199Z
+  '@opentelemetry/instrumentation-hapi@0.55.0': 2025-11-06T18:01:14.650Z
+  '@opentelemetry/instrumentation-http@0.208.0': 2025-11-06T15:57:28.499Z
+  '@opentelemetry/instrumentation-ioredis@0.56.0': 2025-11-06T18:01:15.408Z
+  '@opentelemetry/instrumentation-kafkajs@0.18.0': 2025-11-06T18:01:15.821Z
+  '@opentelemetry/instrumentation-knex@0.53.0': 2025-11-06T18:01:02.200Z
+  '@opentelemetry/instrumentation-koa@0.57.0': 2025-11-06T18:01:17.539Z
+  '@opentelemetry/instrumentation-lru-memoizer@0.53.0': 2025-11-06T18:01:17.533Z
+  '@opentelemetry/instrumentation-mongodb@0.61.0': 2025-11-06T18:01:18.624Z
+  '@opentelemetry/instrumentation-mongoose@0.55.0': 2025-11-06T18:01:20.338Z
+  '@opentelemetry/instrumentation-mysql2@0.55.0': 2025-11-06T18:01:21.560Z
+  '@opentelemetry/instrumentation-mysql@0.54.0': 2025-11-06T18:01:20.584Z
+  '@opentelemetry/instrumentation-pg@0.61.0': 2025-11-06T18:01:23.601Z
+  '@opentelemetry/instrumentation-redis@0.57.0': 2025-11-06T18:01:24.565Z
+  '@opentelemetry/instrumentation-tedious@0.27.0': 2025-11-06T18:01:26.711Z
+  '@opentelemetry/instrumentation-undici@0.19.0': 2025-11-06T18:01:06.139Z
+  '@opentelemetry/instrumentation@0.208.0': 2025-11-06T15:57:15.083Z
+  '@opentelemetry/redis-common@0.38.3': 2026-04-17T14:41:43.146Z
+  '@opentelemetry/resources@2.7.1': 2026-04-29T18:21:45.181Z
+  '@opentelemetry/sdk-trace-base@2.7.1': 2026-04-29T18:22:03.383Z
+  '@opentelemetry/semantic-conventions@1.41.1': 2026-05-12T17:14:33.427Z
+  '@opentelemetry/sql-common@0.41.2': 2025-09-29T19:41:11.868Z
+  '@paralleldrive/cuid2@2.3.1': 2025-10-24T23:50:11.664Z
+  '@peculiar/asn1-android@2.7.0': 2026-05-01T12:15:57.440Z
+  '@peculiar/asn1-cms@2.7.0': 2026-05-01T12:16:09.348Z
+  '@peculiar/asn1-csr@2.7.0': 2026-05-01T12:16:17.249Z
+  '@peculiar/asn1-ecc@2.7.0': 2026-05-01T12:16:20.814Z
+  '@peculiar/asn1-pfx@2.7.0': 2026-05-01T12:16:40.762Z
+  '@peculiar/asn1-pkcs8@2.7.0': 2026-05-01T12:16:44.242Z
+  '@peculiar/asn1-pkcs9@2.7.0': 2026-05-01T12:16:47.648Z
+  '@peculiar/asn1-rsa@2.7.0': 2026-05-01T12:16:59.379Z
+  '@peculiar/asn1-schema@2.7.0': 2026-05-01T12:17:02.553Z
+  '@peculiar/asn1-x509-attr@2.7.0': 2026-05-01T12:17:09.959Z
+  '@peculiar/asn1-x509@2.7.0': 2026-05-01T12:17:40.432Z
+  '@peculiar/utils@2.0.3': 2026-05-01T19:05:19.014Z
+  '@peculiar/x509@1.14.3': 2026-01-12T09:34:14.180Z
+  '@pgtyped/cli@2.4.3': 2025-03-15T01:13:22.332Z
+  '@pgtyped/parser@2.4.2': 2025-02-10T00:04:26.225Z
+  '@pgtyped/query@2.4.2': 2025-02-10T00:04:29.648Z
+  '@pgtyped/runtime@2.4.2': 2025-02-10T00:04:28.013Z
+  '@pgtyped/wire@2.4.2': 2025-02-10T00:04:26.167Z
+  '@pinojs/redact@0.4.0': 2025-10-14T13:24:56.394Z
+  '@pkgjs/parseargs@0.11.0': 2022-10-10T14:18:44.810Z
+  '@playwright/test@1.57.0': 2025-11-25T11:17:19.637Z
+  '@pnpm/config.env-replace@1.1.0': 2023-04-04T18:59:45.025Z
+  '@pnpm/network.ca-file@1.0.2': 2022-11-21T01:38:40.763Z
+  '@pnpm/npm-conf@3.0.2': 2025-12-30T15:57:33.442Z
+  '@polka/url@1.0.0-next.29': 2025-04-09T18:41:21.389Z
+  '@prisma/instrumentation@6.19.0': 2025-11-05T12:55:13.730Z
+  '@protobufjs/aspromise@1.1.2': 2017-04-24T10:38:32.963Z
+  '@protobufjs/base64@1.1.2': 2017-06-09T09:32:02.078Z
+  '@protobufjs/codegen@2.0.5': 2026-04-27T20:30:11.789Z
+  '@protobufjs/eventemitter@1.1.1': 2026-05-22T02:33:03.279Z
+  '@protobufjs/fetch@1.1.1': 2026-05-17T12:41:02.731Z
+  '@protobufjs/float@1.0.2': 2017-04-02T10:45:42.854Z
+  '@protobufjs/inquire@1.1.2': 2026-05-17T15:18:44.530Z
+  '@protobufjs/path@1.1.2': 2017-02-23T16:54:18.933Z
+  '@protobufjs/pool@1.1.0': 2017-01-25T18:13:19.548Z
+  '@protobufjs/utf8@1.1.1': 2026-04-27T20:31:28.490Z
+  '@rollup/rollup-darwin-arm64@4.60.4': 2026-05-14T17:52:48.719Z
+  '@rollup/rollup-linux-arm64-gnu@4.60.4': 2026-05-14T17:53:04.840Z
+  '@rollup/rollup-linux-arm64-musl@4.60.4': 2026-05-14T17:53:09.471Z
+  '@rollup/rollup-linux-x64-gnu@4.60.4': 2026-05-14T17:54:16.327Z
+  '@rollup/rollup-linux-x64-musl@4.60.4': 2026-05-14T17:54:20.425Z
+  '@rollup/rollup-win32-arm64-msvc@4.60.4': 2026-05-14T17:52:56.488Z
+  '@rollup/rollup-win32-x64-gnu@4.60.4': 2026-05-14T17:54:03.430Z
+  '@rollup/rollup-win32-x64-msvc@4.60.4': 2026-05-14T17:54:07.579Z
+  '@scarf/scarf@1.4.0': 2024-11-06T15:42:35.043Z
+  '@sec-ant/readable-stream@0.4.1': 2024-03-16T03:01:29.447Z
+  '@semantic-release/changelog@6.0.3': 2023-03-23T22:40:48.802Z
+  '@semantic-release/commit-analyzer@13.0.1': 2025-01-03T04:09:19.945Z
+  '@semantic-release/error@3.0.0': 2021-09-17T19:54:43.722Z
+  '@semantic-release/error@4.0.0': 2023-06-07T21:03:35.736Z
+  '@semantic-release/exec@7.0.3': 2025-02-03T03:04:49.990Z
+  '@semantic-release/git@10.0.1': 2021-10-30T05:27:04.269Z
+  '@semantic-release/github@11.0.6': 2025-09-11T04:21:26.976Z
+  '@semantic-release/npm@12.0.2': 2025-06-26T11:48:17.676Z
+  '@semantic-release/release-notes-generator@14.1.1': 2026-05-08T20:45:47.222Z
+  '@sentry-internal/browser-utils@10.32.1': 2025-12-19T11:00:41.883Z
+  '@sentry-internal/feedback@10.32.1': 2025-12-19T11:00:49.115Z
+  '@sentry-internal/replay-canvas@10.32.1': 2025-12-19T11:00:51.887Z
+  '@sentry-internal/replay@10.32.1': 2025-12-19T11:00:44.163Z
+  '@sentry/babel-plugin-component-annotate@4.9.1': 2026-02-10T14:46:04.727Z
+  '@sentry/browser@10.32.1': 2025-12-19T11:00:55.272Z
+  '@sentry/bundler-plugin-core@4.9.1': 2026-02-10T14:46:07.160Z
+  '@sentry/cli-darwin@2.58.6': 2026-05-21T14:46:29.855Z
+  '@sentry/cli-linux-arm64@2.58.6': 2026-05-21T14:46:37.160Z
+  '@sentry/cli-linux-x64@2.58.6': 2026-05-21T14:46:43.580Z
+  '@sentry/cli-win32-arm64@2.58.6': 2026-05-21T14:46:51.190Z
+  '@sentry/cli-win32-x64@2.58.6': 2026-05-21T14:46:48.893Z
+  '@sentry/cli@2.58.6': 2026-05-21T14:46:52.479Z
+  '@sentry/cloudflare@10.32.1': 2025-12-19T11:01:21.780Z
+  '@sentry/core@10.32.1': 2025-12-19T11:00:34.696Z
+  '@sentry/node-core@10.32.1': 2025-12-19T11:00:39.490Z
+  '@sentry/node@10.32.1': 2025-12-19T11:00:58.344Z
+  '@sentry/opentelemetry@10.32.1': 2025-12-19T11:00:46.603Z
+  '@sentry/svelte@10.32.1': 2025-12-19T11:01:13.329Z
+  '@sentry/sveltekit@10.32.1': 2025-12-19T11:01:44.038Z
+  '@sentry/vite-plugin@4.9.1': 2026-02-10T14:46:10.576Z
+  '@simple-libs/child-process-utils@1.0.2': 2026-03-01T18:37:07.082Z
+  '@simple-libs/stream-utils@1.2.0': 2026-03-01T18:37:03.322Z
+  '@simplewebauthn/browser@13.3.0': 2026-03-10T05:55:51.036Z
+  '@simplewebauthn/server@13.3.0': 2026-03-10T05:56:08.098Z
+  '@sindresorhus/is@4.6.0': 2022-02-27T09:06:19.413Z
+  '@sindresorhus/merge-streams@4.0.0': 2024-05-04T19:40:43.039Z
+  '@standard-schema/spec@1.1.0': 2025-12-15T20:49:46.431Z
+  '@sveltejs/acorn-typescript@1.0.10': 2026-05-20T09:31:55.261Z
+  '@sveltejs/adapter-static@3.0.8': 2024-12-21T18:33:37.611Z
+  '@sveltejs/kit@2.49.2': 2025-12-08T22:33:05.908Z
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2': 2026-01-06T14:16:21.379Z
+  '@sveltejs/vite-plugin-svelte@6.2.1': 2025-09-24T13:16:28.132Z
+  '@tailwindcss/node@4.1.18': 2025-12-11T16:40:57.935Z
+  '@tailwindcss/oxide-darwin-arm64@4.1.18': 2025-12-11T16:40:08.407Z
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18': 2025-12-11T16:40:23.885Z
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18': 2025-12-11T16:40:27.531Z
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18': 2025-12-11T16:40:31.394Z
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18': 2025-12-11T16:40:35.244Z
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18': 2025-12-11T16:40:39.008Z
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18': 2025-12-11T16:40:43.238Z
+  '@tailwindcss/oxide@4.1.18': 2025-12-11T16:40:46.409Z
+  '@tailwindcss/postcss@4.1.18': 2025-12-11T16:41:04.783Z
+  '@testcontainers/postgresql@11.10.0': 2025-12-09T21:09:41.800Z
+  '@testing-library/dom@10.4.1': 2025-07-27T13:23:37.151Z
+  '@testing-library/svelte-core@1.0.0': 2025-12-23T06:13:57.343Z
+  '@testing-library/svelte@5.3.0': 2025-12-23T06:16:02.344Z
+  '@tootallnate/once@2.0.1': 2026-05-03T18:05:21.169Z
+  '@types/aria-query@5.0.4': 2023-11-06T23:21:27.739Z
+  '@types/bcrypt@6.0.0': 2025-07-19T00:04:40.213Z
+  '@types/chai@5.2.3': 2025-10-20T23:32:43.277Z
+  '@types/connect@3.4.38': 2023-11-07T00:57:34.681Z
+  '@types/cookie@0.6.0': 2023-11-26T22:07:02.296Z
+  '@types/cookiejar@2.1.5': 2023-11-20T23:53:57.789Z
+  '@types/d3-array@3.2.2': 2025-09-12T20:02:36.152Z
+  '@types/d3-axis@3.0.6': 2023-11-07T19:52:59.521Z
+  '@types/d3-brush@3.0.6': 2023-11-07T19:53:09.057Z
+  '@types/d3-chord@3.0.6': 2023-11-07T19:53:18.896Z
+  '@types/d3-color@3.1.3': 2023-11-07T19:53:28.546Z
+  '@types/d3-contour@3.0.6': 2023-11-07T19:53:37.946Z
+  '@types/d3-delaunay@6.0.4': 2023-11-07T19:53:47.744Z
+  '@types/d3-dispatch@3.0.7': 2025-07-30T13:15:13.772Z
+  '@types/d3-drag@3.0.7': 2023-11-07T19:54:06.512Z
+  '@types/d3-dsv@3.0.7': 2023-11-07T19:54:17.990Z
+  '@types/d3-ease@3.0.2': 2023-11-07T19:54:31.301Z
+  '@types/d3-fetch@3.0.7': 2023-11-07T19:54:40.598Z
+  '@types/d3-force@3.0.10': 2024-06-17T20:08:32.766Z
+  '@types/d3-format@3.0.4': 2023-11-07T19:55:03.445Z
+  '@types/d3-geo@3.1.0': 2023-11-12T19:07:05.450Z
+  '@types/d3-hierarchy@3.1.7': 2024-03-18T18:36:07.295Z
+  '@types/d3-interpolate@3.0.4': 2023-11-07T19:55:36.521Z
+  '@types/d3-path@3.1.1': 2025-02-04T22:02:38.070Z
+  '@types/d3-polygon@3.0.2': 2023-11-07T19:56:06.355Z
+  '@types/d3-quadtree@3.0.6': 2023-11-22T00:56:08.684Z
+  '@types/d3-random@3.0.3': 2023-11-07T19:56:27.288Z
+  '@types/d3-scale-chromatic@3.1.0': 2024-11-27T21:33:24.203Z
+  '@types/d3-scale@4.0.9': 2025-02-05T00:46:59.854Z
+  '@types/d3-selection@3.0.11': 2024-10-07T22:39:17.069Z
+  '@types/d3-shape@3.1.8': 2026-01-12T09:42:38.759Z
+  '@types/d3-time-format@4.0.3': 2023-11-07T19:57:40.287Z
+  '@types/d3-time@3.0.4': 2024-11-25T10:02:27.849Z
+  '@types/d3-timer@3.0.2': 2023-11-07T19:57:54.045Z
+  '@types/d3-transition@3.0.9': 2024-10-07T22:39:31.369Z
+  '@types/d3-zoom@3.0.8': 2023-11-07T19:58:16.097Z
+  '@types/d3@7.4.3': 2023-11-07T19:52:29.365Z
+  '@types/deep-eql@4.0.2': 2023-11-07T01:34:12.026Z
+  '@types/docker-modem@3.0.6': 2023-11-07T01:51:28.554Z
+  '@types/dockerode@3.3.47': 2025-11-19T09:02:29.035Z
+  '@types/estree@1.0.8': 2025-06-06T00:04:34.692Z
+  '@types/estree@1.0.9': 2026-05-06T21:01:00.975Z
+  '@types/geojson@7946.0.16': 2025-01-23T18:37:01.847Z
+  '@types/jsonwebtoken@9.0.10': 2025-06-16T07:36:00.187Z
+  '@types/leaflet@1.9.21': 2025-10-11T01:29:59.238Z
+  '@types/linkify-it@5.0.0': 2024-05-01T18:07:46.092Z
+  '@types/markdown-it@14.1.2': 2024-07-25T05:07:30.523Z
+  '@types/mdurl@2.0.0': 2024-05-01T18:08:10.612Z
+  '@types/methods@1.1.4': 2023-11-07T11:06:07.240Z
+  '@types/ms@2.1.0': 2025-01-16T21:02:46.181Z
+  '@types/mysql@2.15.27': 2025-03-26T09:02:18.284Z
+  '@types/node-cron@3.0.11': 2023-11-07T20:28:34.513Z
+  '@types/node@18.19.130': 2025-10-09T17:35:38.540Z
+  '@types/node@25.0.3': 2025-12-16T21:35:20.092Z
+  '@types/normalize-package-data@2.4.4': 2023-11-07T12:04:03.711Z
+  '@types/pg-pool@2.0.6': 2023-11-07T12:57:10.692Z
+  '@types/pg@8.15.6': 2025-10-27T23:32:24.778Z
+  '@types/pg@8.16.0': 2025-12-10T20:02:12.407Z
+  '@types/sharp@0.32.0': 2023-04-26T21:33:22.965Z
+  '@types/ssh2-streams@0.1.13': 2025-10-24T04:32:05.282Z
+  '@types/ssh2@0.5.52': 2022-03-29T00:32:14.633Z
+  '@types/ssh2@1.15.5': 2025-04-02T14:36:17.207Z
+  '@types/superagent@8.1.10': 2026-05-20T08:10:38.113Z
+  '@types/supertest@6.0.3': 2025-03-24T14:36:46.140Z
+  '@types/tedious@4.0.14': 2023-11-07T17:42:31.655Z
+  '@types/trusted-types@2.0.7': 2023-11-21T01:13:25.434Z
+  '@types/webidl-conversions@7.0.3': 2023-11-07T19:01:40.929Z
+  '@types/whatwg-url@13.0.0': 2024-11-12T00:46:37.942Z
+  '@vitest/expect@4.0.16': 2025-12-16T15:08:40.007Z
+  '@vitest/mocker@4.0.16': 2025-12-16T15:08:30.726Z
+  '@vitest/pretty-format@4.0.16': 2025-12-16T15:08:20.752Z
+  '@vitest/runner@4.0.16': 2025-12-16T15:08:33.815Z
+  '@vitest/snapshot@4.0.16': 2025-12-16T15:08:36.902Z
+  '@vitest/spy@4.0.16': 2025-12-16T15:08:23.814Z
+  '@vitest/utils@4.0.16': 2025-12-16T15:08:27.533Z
+  a-sync-waterfall@1.0.1: 2018-08-31T07:10:17.505Z
+  abort-controller@3.0.0: 2019-03-30T09:15:32.384Z
+  accepts@2.0.0: 2024-08-31T15:50:05.694Z
+  acorn-import-attributes@1.9.5: 2024-03-29T09:47:27.508Z
+  acorn@8.16.0: 2026-02-19T15:06:28.070Z
+  agent-base@6.0.2: 2020-10-23T19:33:15.354Z
+  agent-base@7.1.4: 2025-07-07T17:44:01.356Z
+  aggregate-error@3.1.0: 2020-08-21T22:29:47.896Z
+  aggregate-error@5.0.0: 2023-09-14T06:53:27.142Z
+  ajv-formats@3.0.1: 2024-03-30T11:30:26.728Z
+  ajv@8.20.0: 2026-04-24T15:22:16.529Z
+  ansi-escapes@7.3.0: 2026-02-04T16:21:10.230Z
+  ansi-regex@5.0.1: 2021-09-14T15:55:19.540Z
+  ansi-regex@6.2.2: 2025-09-08T14:48:14.264Z
+  ansi-styles@3.2.1: 2018-03-02T09:40:00.702Z
+  ansi-styles@4.3.0: 2020-10-04T19:18:25.986Z
+  ansi-styles@5.2.0: 2021-03-31T07:15:34.766Z
+  ansi-styles@6.2.3: 2025-09-08T14:52:15.705Z
+  antlr4ts@0.5.0-alpha.4: 2021-01-01T21:47:55.344Z
+  any-promise@1.3.0: 2016-05-08T12:15:06.060Z
+  anymatch@3.1.3: 2022-11-21T18:21:37.586Z
+  archiver-utils@5.0.2: 2024-03-10T02:33:44.373Z
+  archiver@7.0.1: 2024-03-10T03:23:53.397Z
+  argparse@2.0.1: 2020-08-28T21:14:26.713Z
+  argv-formatter@1.0.0: 2014-11-23T18:16:21.898Z
+  aria-query@5.3.0: 2023-06-24T20:48:55.075Z
+  aria-query@5.3.2: 2024-09-20T19:54:28.364Z
+  arkregex@0.0.5: 2025-12-13T04:38:01.831Z
+  arktype@2.1.29: 2025-12-13T04:38:13.061Z
+  array-ify@1.0.0: 2015-06-14T23:27:57.755Z
+  asap@2.0.6: 2017-07-10T15:21:36.791Z
+  asn1@0.2.6: 2021-11-04T00:46:28.017Z
+  asn1js@3.0.10: 2026-04-20T15:15:24.005Z
+  assertion-error@2.0.1: 2023-10-18T18:04:13.507Z
+  ast-types@0.16.1: 2022-12-13T23:46:34.033Z
+  async-function@1.0.0: 2025-01-23T03:15:54.266Z
+  async-generator-function@1.0.0: 2025-02-14T18:35:17.106Z
+  async-lock@1.4.1: 2023-12-22T19:44:34.520Z
+  async-retry@1.2.3: 2018-09-07T12:54:47.822Z
+  async@3.2.6: 2024-08-19T23:24:23.363Z
+  asynckit@0.4.0: 2016-06-14T18:29:05.418Z
+  atomic-sleep@1.0.0: 2020-03-09T18:56:01.508Z
+  autoprefixer@10.4.23: 2025-12-14T17:25:24.999Z
+  axobject-query@4.1.0: 2024-07-15T19:08:33.508Z
+  b4a@1.8.1: 2026-04-30T19:49:39.694Z
+  balanced-match@1.0.2: 2021-04-06T12:51:09.276Z
+  balanced-match@4.0.4: 2026-02-22T11:38:25.951Z
+  bare-events@2.8.3: 2026-05-14T07:27:01.789Z
+  bare-fs@4.7.1: 2026-04-15T06:41:07.285Z
+  bare-os@3.9.1: 2026-05-01T09:52:30.546Z
+  bare-path@3.0.0: 2024-09-11T07:51:14.404Z
+  bare-stream@2.13.1: 2026-04-28T08:06:17.565Z
+  bare-url@2.4.3: 2026-05-05T10:07:29.573Z
+  base64-js@1.5.1: 2020-11-11T19:33:48.234Z
+  baseline-browser-mapping@2.10.32: 2026-05-22T16:14:31.369Z
+  bcrypt-pbkdf@1.0.2: 2018-06-29T00:33:59.042Z
+  bcrypt@6.0.0: 2025-05-11T18:06:24.247Z
+  before-after-hook@2.2.3: 2022-10-04T00:19:26.570Z
+  before-after-hook@4.0.0: 2025-05-12T22:37:33.860Z
+  better-auth@1.5.5: 2026-03-11T19:35:36.949Z
+  better-call@1.3.2: 2026-02-12T09:17:47.879Z
+  bidi-js@1.0.3: 2023-07-31T17:15:17.072Z
+  binary-extensions@2.3.0: 2024-03-14T18:10:39.723Z
+  bl@4.1.0: 2021-02-09T10:37:35.452Z
+  body-parser@2.2.2: 2026-01-07T09:38:34.589Z
+  bottleneck@2.19.5: 2019-08-03T17:14:39.035Z
+  brace-expansion@2.1.0: 2026-04-11T13:26:14.359Z
+  brace-expansion@5.0.6: 2026-05-08T05:41:43.205Z
+  braces@3.0.3: 2024-05-21T08:59:11.390Z
+  browserslist@4.28.2: 2026-03-31T10:24:52.545Z
+  bson@7.2.0: 2026-02-03T19:22:27.139Z
+  buffer-crc32@1.0.0: 2024-02-06T17:58:06.898Z
+  buffer-equal-constant-time@1.0.1: 2013-12-16T20:12:17.799Z
+  buffer@5.7.1: 2020-11-04T21:51:35.578Z
+  buffer@6.0.3: 2020-11-23T02:51:27.107Z
+  buildcheck@0.0.7: 2025-11-25T23:02:15.827Z
+  byline@5.0.0: 2016-07-21T06:51:35.650Z
+  bytes@3.1.2: 2022-01-28T05:02:37.661Z
+  call-bind-apply-helpers@1.0.2: 2025-02-12T19:24:56.950Z
+  call-bound@1.0.4: 2025-03-03T17:50:03.505Z
+  callsites@3.1.0: 2019-04-06T11:57:30.657Z
+  camel-case@5.0.0: 2023-09-30T01:29:03.555Z
+  caniuse-lite@1.0.30001793: 2026-05-17T05:33:15.670Z
+  chai@6.2.2: 2025-12-22T21:26:03.989Z
+  chalk@2.4.2: 2019-01-05T15:45:52.349Z
+  chalk@4.1.2: 2021-07-30T12:02:52.839Z
+  chalk@5.6.2: 2025-09-08T14:47:54.486Z
+  char-regex@1.0.2: 2020-02-18T09:51:29.803Z
+  chokidar@3.6.0: 2024-02-06T22:57:34.159Z
+  chokidar@4.0.3: 2024-12-18T22:21:34.451Z
+  chownr@1.1.4: 2020-02-12T02:30:54.444Z
+  cjs-module-lexer@2.2.0: 2026-01-02T19:40:27.050Z
+  clean-stack@2.2.0: 2019-07-31T15:24:56.235Z
+  clean-stack@5.3.0: 2025-09-15T22:12:56.166Z
+  cli-highlight@2.1.11: 2021-03-28T18:09:23.896Z
+  cli-table3@0.6.5: 2024-05-12T16:36:50.079Z
+  cliui@7.0.4: 2020-11-09T00:00:00.351Z
+  cliui@8.0.1: 2022-10-01T01:16:14.782Z
+  clsx@2.1.1: 2024-04-23T05:26:04.645Z
+  color-convert@1.9.3: 2018-08-28T05:32:39.014Z
+  color-convert@2.0.1: 2019-08-19T21:05:36.605Z
+  color-name@1.1.3: 2017-07-15T22:17:08.140Z
+  color-name@1.1.4: 2018-09-21T10:48:56.546Z
+  colorette@2.0.20: 2023-04-16T15:34:09.905Z
+  colors@1.4.0: 2019-09-22T23:46:07.522Z
+  combined-stream@1.0.8: 2019-05-12T17:49:45.337Z
+  commander@2.20.3: 2019-10-11T05:40:24.166Z
+  commander@5.1.0: 2020-04-25T02:29:21.964Z
+  commander@7.2.0: 2021-03-21T21:56:16.053Z
+  compare-func@2.0.0: 2020-05-15T13:35:21.878Z
+  component-emitter@1.3.1: 2023-11-16T20:57:12.372Z
+  compress-commons@6.0.2: 2024-03-10T01:37:13.533Z
+  config-chain@1.1.13: 2021-06-03T18:35:56.312Z
+  content-disposition@1.1.0: 2026-04-07T21:07:53.748Z
+  content-type@1.0.5: 2023-01-29T19:25:59.622Z
+  content-type@2.0.0: 2026-05-11T17:22:08.801Z
+  conventional-changelog-angular@8.3.1: 2026-03-29T15:46:30.754Z
+  conventional-changelog-conventionalcommits@7.0.2: 2023-09-08T22:46:41.024Z
+  conventional-changelog-conventionalcommits@8.0.0: 2024-05-03T22:56:19.030Z
+  conventional-changelog-writer@8.4.0: 2026-03-04T22:08:16.722Z
+  conventional-commits-filter@5.0.0: 2024-05-03T22:56:53.508Z
+  conventional-commits-parser@6.4.0: 2026-03-29T15:46:39.187Z
+  convert-hrtime@5.0.0: 2021-04-14T07:31:22.271Z
+  convert-source-map@2.0.0: 2022-10-17T22:06:48.628Z
+  cookie-signature@1.2.2: 2024-10-29T19:39:47.642Z
+  cookie@0.6.0: 2023-11-07T05:01:09.857Z
+  cookie@0.7.2: 2024-10-07T03:41:28.828Z
+  cookiejar@2.1.4: 2023-01-13T02:08:09.520Z
+  core-js@3.49.0: 2026-03-16T21:13:03.395Z
+  core-util-is@1.0.3: 2021-08-31T14:35:36.995Z
+  cors@2.8.6: 2026-01-22T14:41:30.223Z
+  cosmiconfig-typescript-loader@6.3.0: 2026-04-09T02:43:02.427Z
+  cosmiconfig@9.0.1: 2026-03-02T13:27:31.848Z
+  cpu-features@0.0.10: 2024-05-03T04:57:36.042Z
+  crc-32@1.2.2: 2022-04-04T23:05:52.784Z
+  crc32-stream@6.0.0: 2024-02-29T00:27:39.613Z
+  crelt@1.0.6: 2023-05-17T12:31:21.128Z
+  cross-spawn@7.0.6: 2024-11-18T13:59:52.129Z
+  crypto-random-string@4.0.0: 2021-04-05T08:12:23.306Z
+  css-tree@3.2.1: 2026-03-05T14:12:36.884Z
+  cssstyle@5.3.7: 2026-01-06T03:19:29.159Z
+  d3-array@3.2.4: 2023-05-30T21:53:24.048Z
+  d3-axis@3.0.0: 2021-06-09T03:35:37.066Z
+  d3-brush@3.0.0: 2021-06-10T00:04:10.328Z
+  d3-chord@3.0.1: 2021-06-05T18:26:14.475Z
+  d3-color@3.1.0: 2022-03-28T22:46:28.202Z
+  d3-contour@4.0.2: 2023-01-11T16:36:10.656Z
+  d3-delaunay@6.0.4: 2023-04-01T02:39:11.886Z
+  d3-dispatch@3.0.1: 2021-06-05T18:30:49.693Z
+  d3-drag@3.0.0: 2021-06-09T16:00:59.516Z
+  d3-dsv@3.0.1: 2021-06-05T18:32:05.522Z
+  d3-ease@3.0.1: 2021-06-05T18:33:15.216Z
+  d3-fetch@3.0.1: 2021-06-05T18:34:14.207Z
+  d3-force@3.0.0: 2021-06-05T19:11:01.836Z
+  d3-format@3.1.2: 2026-01-14T18:36:25.869Z
+  d3-geo@3.1.1: 2024-03-12T22:06:03.888Z
+  d3-hierarchy@3.1.2: 2022-04-02T22:20:25.115Z
+  d3-interpolate@3.0.1: 2021-06-05T18:38:34.549Z
+  d3-path@3.1.0: 2022-12-19T21:50:21.362Z
+  d3-polygon@3.0.1: 2021-06-05T18:39:45.950Z
+  d3-quadtree@3.0.1: 2021-06-05T18:40:52.989Z
+  d3-random@3.0.1: 2021-06-05T18:41:51.228Z
+  d3-scale-chromatic@3.1.0: 2024-03-12T21:00:11.077Z
+  d3-scale@4.0.2: 2021-09-24T17:43:03.930Z
+  d3-selection@3.0.0: 2021-06-07T17:40:48.511Z
+  d3-shape@3.2.0: 2022-12-20T23:39:17.478Z
+  d3-time-format@4.1.0: 2021-12-04T17:02:51.666Z
+  d3-time@3.1.0: 2022-12-02T23:58:08.483Z
+  d3-timer@3.0.1: 2021-06-05T18:43:06.805Z
+  d3-transition@3.0.1: 2021-06-09T23:50:41.294Z
+  d3-zoom@3.0.0: 2021-06-10T00:49:18.125Z
+  d3@7.9.0: 2024-03-12T22:15:07.703Z
+  danger@12.3.3: 2024-06-20T12:28:01.527Z
+  data-urls@6.0.1: 2026-01-20T03:18:12.611Z
+  dateformat@4.6.3: 2021-09-21T06:35:53.160Z
+  debug@4.4.3: 2025-09-13T17:25:19.732Z
+  decimal.js@10.6.0: 2025-07-06T22:50:38.844Z
+  deep-extend@0.6.0: 2018-05-22T18:13:17.476Z
+  deepmerge@4.3.1: 2023-03-16T22:58:56.511Z
+  defu@6.1.7: 2026-04-07T09:28:09.388Z
+  delaunator@5.1.0: 2026-03-23T09:53:23.813Z
+  delayed-stream@1.0.0: 2015-04-30T22:10:29.726Z
+  depd@2.0.0: 2018-10-26T17:52:55.936Z
+  deprecation@2.3.1: 2019-06-13T17:45:59.689Z
+  dequal@2.0.3: 2022-07-11T23:29:04.965Z
+  detect-libc@2.1.2: 2025-10-05T12:46:33.077Z
+  devalue@5.8.1: 2026-05-14T18:46:14.320Z
+  dezalgo@1.0.4: 2022-04-06T16:04:42.572Z
+  dir-glob@3.0.1: 2019-06-29T16:22:06.207Z
+  docker-compose@1.4.2: 2026-03-31T16:36:31.982Z
+  docker-modem@5.0.7: 2026-03-20T19:57:09.444Z
+  dockerode@4.0.12: 2026-04-23T22:55:33.918Z
+  dom-accessibility-api@0.5.16: 2023-01-18T20:03:50.833Z
+  dompurify@3.4.5: 2026-05-18T07:46:30.210Z
+  dot-prop@5.3.0: 2020-09-06T14:14:50.395Z
+  dotenv@16.6.1: 2025-06-27T16:45:01.088Z
+  dunder-proto@1.0.1: 2024-12-17T02:12:47.047Z
+  duplexer2@0.1.4: 2015-11-08T08:07:39.098Z
+  eastasianwidth@0.2.0: 2018-01-01T09:26:07.460Z
+  ecdsa-sig-formatter@1.0.11: 2019-01-25T21:32:13.447Z
+  ee-first@1.1.1: 2015-05-25T19:18:28.732Z
+  electron-to-chromium@1.5.361: 2026-05-22T02:02:50.329Z
+  emoji-regex@8.0.0: 2019-03-05T18:58:23.040Z
+  emoji-regex@9.2.2: 2021-03-02T10:58:09.319Z
+  emojilib@2.4.0: 2018-11-20T23:34:06.435Z
+  encodeurl@2.0.0: 2024-03-29T00:03:42.135Z
+  end-of-stream@1.4.5: 2025-06-16T13:29:00.574Z
+  enhanced-resolve@5.22.0: 2026-05-22T09:38:59.793Z
+  entities@4.5.0: 2023-04-13T17:57:56.308Z
+  entities@8.0.0: 2026-03-17T11:47:45.464Z
+  env-ci@11.2.0: 2025-09-01T15:33:26.382Z
+  env-paths@2.2.1: 2021-03-08T12:31:06.769Z
+  environment@1.1.0: 2024-05-14T07:02:20.386Z
+  error-ex@1.3.4: 2025-09-15T14:58:41.266Z
+  es-define-property@1.0.1: 2024-12-06T18:16:02.148Z
+  es-errors@1.3.0: 2024-02-05T08:05:51.479Z
+  es-module-lexer@1.7.0: 2025-04-22T22:22:07.934Z
+  es-object-atoms@1.1.2: 2026-05-22T14:40:03.961Z
+  es-set-tostringtag@2.1.0: 2025-01-02T04:44:14.435Z
+  es-toolkit@1.46.1: 2026-04-29T09:42:09.686Z
+  esbuild@0.27.7: 2026-04-02T16:43:44.831Z
+  escalade@3.2.0: 2024-08-29T22:59:36.690Z
+  escape-html@1.0.3: 2015-09-01T04:47:22.713Z
+  escape-string-regexp@1.0.5: 2016-02-21T12:55:17.074Z
+  escape-string-regexp@5.0.0: 2021-04-17T15:45:50.334Z
+  esm-env@1.2.2: 2025-01-08T20:32:34.154Z
+  esprima@4.0.1: 2018-07-13T08:39:14.711Z
+  esrap@2.2.9: 2026-05-15T20:44:39.448Z
+  estree-walker@3.0.3: 2023-01-20T02:27:12.467Z
+  etag@1.8.1: 2017-09-13T02:43:44.422Z
+  event-target-shim@5.0.1: 2019-02-19T06:00:52.075Z
+  events-universal@1.0.1: 2025-09-23T07:10:20.770Z
+  events@3.3.0: 2021-02-27T16:51:27.318Z
+  eventsource-parser@3.0.8: 2026-04-19T17:45:17.687Z
+  eventsource@3.0.7: 2025-05-09T10:32:51.243Z
+  execa@5.1.1: 2021-06-04T16:38:11.620Z
+  execa@8.0.1: 2023-08-19T15:43:49.166Z
+  execa@9.6.1: 2025-11-29T20:53:46.888Z
+  expand-tilde@2.0.2: 2016-12-08T05:29:17.146Z
+  expect-type@1.3.0: 2025-12-08T13:04:58.798Z
+  express-rate-limit@8.5.2: 2026-05-14T10:15:31.523Z
+  express@5.2.1: 2025-12-01T20:49:43.268Z
+  extend-shallow@2.0.1: 2015-07-16T23:28:36.775Z
+  fast-content-type-parse@3.0.0: 2025-03-08T16:33:03.786Z
+  fast-copy@4.0.3: 2026-04-10T08:16:35.103Z
+  fast-deep-equal@3.1.3: 2020-06-08T07:27:28.474Z
+  fast-fifo@1.3.2: 2023-08-21T14:21:02.140Z
+  fast-json-patch@3.1.1: 2022-03-24T18:44:40.272Z
+  fast-safe-stringify@2.1.1: 2021-09-08T07:19:16.545Z
+  fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
+  fdir@6.5.0: 2025-08-14T16:56:03.948Z
+  figures@2.0.0: 2016-10-18T03:59:00.091Z
+  figures@6.1.0: 2024-03-04T19:16:04.779Z
+  fill-range@7.1.1: 2024-05-21T08:45:51.224Z
+  finalhandler@2.1.1: 2025-12-01T16:05:02.140Z
+  find-up-simple@1.0.1: 2025-03-01T09:15:33.098Z
+  find-up@2.1.0: 2016-12-02T13:21:51.615Z
+  find-up@5.0.0: 2020-08-11T18:44:24.748Z
+  find-versions@6.0.0: 2024-04-03T08:12:28.929Z
+  foreground-child@3.3.1: 2025-02-24T16:47:52.413Z
+  form-data@4.0.5: 2025-11-17T04:16:07.493Z
+  formidable@3.5.4: 2025-04-23T01:58:45.608Z
+  forwarded-parse@2.1.2: 2021-11-03T19:55:06.517Z
+  forwarded@0.2.0: 2021-05-31T23:23:02.495Z
+  fp-ts@2.16.11: 2025-08-18T14:00:30.062Z
+  fraction.js@5.3.4: 2025-08-22T11:44:45.549Z
+  fresh@2.0.0: 2024-09-04T23:24:48.361Z
+  fs-constants@1.0.0: 2018-04-26T14:42:32.817Z
+  fs-exists-sync@0.1.0: 2016-04-09T11:40:26.287Z
+  fs-extra@11.3.5: 2026-05-06T19:35:56.296Z
+  fsevents@2.3.2: 2021-02-05T14:46:33.925Z
+  fsevents@2.3.3: 2023-08-21T16:24:22.854Z
+  function-bind@1.1.2: 2023-10-12T19:08:19.687Z
+  function-timeout@1.0.2: 2024-05-17T17:30:03.940Z
+  generator-function@2.0.1: 2025-09-30T18:23:33.207Z
+  gensync@1.0.0-beta.2: 2020-10-27T20:43:40.443Z
+  get-caller-file@2.0.5: 2019-03-09T21:48:30.527Z
+  get-intrinsic@1.3.1: 2025-09-29T23:20:07.570Z
+  get-port@7.2.0: 2026-03-22T05:52:49.076Z
+  get-proto@1.0.1: 2025-01-02T20:08:02.949Z
+  get-stdin@6.0.0: 2018-03-02T18:17:34.787Z
+  get-stream@6.0.1: 2021-04-15T04:56:42.936Z
+  get-stream@8.0.1: 2023-08-17T15:33:46.835Z
+  get-stream@9.0.1: 2024-03-16T18:05:50.308Z
+  get-tsconfig@4.14.0: 2026-04-15T02:51:47.332Z
+  git-config-path@1.0.1: 2016-10-26T10:21:43.694Z
+  git-log-parser@1.2.1: 2024-07-01T15:13:23.372Z
+  git-raw-commits@5.0.1: 2026-03-01T19:45:19.915Z
+  glob-parent@5.1.2: 2021-03-06T21:21:44.487Z
+  glob@10.5.0: 2025-11-18T01:34:51.120Z
+  glob@11.1.0: 2025-11-17T17:02:17.700Z
+  global-directory@5.0.0: 2026-02-02T17:04:24.387Z
+  globalyzer@0.1.0: 2018-04-15T06:42:05.827Z
+  globrex@0.1.2: 2018-12-16T15:34:52.391Z
+  gopd@1.2.0: 2024-12-04T16:21:52.727Z
+  graceful-fs@4.2.10: 2022-04-04T17:10:00.270Z
+  graceful-fs@4.2.11: 2023-03-16T19:30:19.323Z
+  handlebars@4.7.9: 2026-03-26T20:46:39.280Z
+  has-flag@2.0.0: 2016-04-11T15:47:58.270Z
+  has-flag@3.0.0: 2018-01-02T19:21:56.098Z
+  has-flag@4.0.0: 2019-04-06T15:49:21.907Z
+  has-symbols@1.1.0: 2024-12-02T16:34:17.679Z
+  has-tostringtag@1.0.2: 2024-02-01T21:44:00.130Z
+  hasown@2.0.3: 2026-04-17T22:12:06.275Z
+  help-me@5.0.0: 2023-12-13T10:30:49.578Z
+  highlight.js@10.7.3: 2021-06-04T01:40:39.747Z
+  homedir-polyfill@1.0.3: 2019-02-21T18:42:07.345Z
+  hono@4.11.1: 2025-12-14T22:14:21.820Z
+  hono@4.12.22: 2026-05-22T09:15:53.204Z
+  hook-std@3.0.0: 2021-09-17T18:37:09.042Z
+  hosted-git-info@7.0.2: 2024-05-04T01:10:57.235Z
+  hosted-git-info@8.1.0: 2025-04-14T18:31:45.932Z
+  html-encoding-sniffer@4.0.0: 2023-11-12T07:38:15.637Z
+  html-encoding-sniffer@6.0.0: 2025-12-26T03:54:44.115Z
+  http-errors@2.0.1: 2025-11-20T19:12:22.755Z
+  http-proxy-agent@5.0.0: 2021-09-23T00:35:50.066Z
+  http-proxy-agent@7.0.2: 2024-02-15T19:14:20.532Z
+  https-proxy-agent@5.0.1: 2022-04-14T18:42:00.761Z
+  https-proxy-agent@7.0.6: 2024-12-07T03:32:09.302Z
+  human-signals@2.1.0: 2020-03-14T15:10:37.036Z
+  human-signals@5.0.0: 2023-05-13T23:49:52.964Z
+  human-signals@8.0.1: 2025-03-29T02:43:46.398Z
+  hyperlinker@1.0.0: 2017-11-28T03:33:04.128Z
+  i18next-browser-languagedetector@8.2.0: 2025-06-11T05:28:48.567Z
+  i18next@25.7.4: 2026-01-07T17:53:14.693Z
+  iconv-lite@0.6.3: 2021-05-24T03:00:17.928Z
+  iconv-lite@0.7.2: 2026-01-08T16:49:11.167Z
+  ieee754@1.2.1: 2020-10-27T23:06:07.424Z
+  import-fresh@3.3.1: 2025-02-02T09:45:41.743Z
+  import-from-esm@2.0.0: 2024-12-31T00:47:15.316Z
+  import-in-the-middle@2.0.6: 2026-01-27T22:52:37.528Z
+  import-meta-resolve@4.2.0: 2025-08-29T18:46:15.488Z
+  indent-string@4.0.0: 2019-04-17T07:31:13.363Z
+  indent-string@5.0.0: 2021-04-17T17:10:20.469Z
+  index-to-position@1.2.0: 2025-09-25T04:03:35.523Z
+  inherits@2.0.4: 2019-06-19T20:18:52.465Z
+  ini@1.3.8: 2020-12-11T19:57:57.208Z
+  ini@6.0.0: 2025-10-22T15:24:55.354Z
+  internmap@2.0.3: 2021-09-20T03:11:43.688Z
+  io-ts-reporters@2.0.1: 2022-02-07T13:28:12.820Z
+  io-ts@2.2.22: 2024-12-10T11:52:16.138Z
+  ip-address@10.2.0: 2026-05-01T06:34:05.804Z
+  ipaddr.js@1.9.1: 2019-07-17T02:28:19.618Z
+  is-arrayish@0.2.1: 2015-08-31T23:02:50.373Z
+  is-binary-path@2.1.0: 2019-04-19T04:42:45.772Z
+  is-extendable@0.1.1: 2015-07-04T22:50:11.330Z
+  is-extglob@2.1.1: 2016-12-11T04:04:24.390Z
+  is-fullwidth-code-point@3.0.0: 2019-03-18T08:09:05.035Z
+  is-glob@4.0.3: 2021-09-29T16:52:47.977Z
+  is-number@7.0.0: 2018-07-04T15:08:58.238Z
+  is-obj@2.0.0: 2019-04-19T15:37:37.870Z
+  is-plain-obj@4.1.0: 2022-06-15T15:47:13.746Z
+  is-plain-object@5.0.0: 2020-09-09T16:30:03.627Z
+  is-potential-custom-element-name@1.0.1: 2021-04-07T07:43:00.708Z
+  is-promise@4.0.0: 2020-04-27T15:34:23.345Z
+  is-reference@3.0.3: 2024-11-12T14:51:44.271Z
+  is-stream@2.0.1: 2021-07-26T10:51:04.495Z
+  is-stream@3.0.0: 2021-08-10T10:52:14.251Z
+  is-stream@4.0.1: 2024-02-19T19:14:12.256Z
+  is-unicode-supported@2.1.0: 2024-09-09T06:26:03.073Z
+  isarray@1.0.0: 2015-12-10T10:05:07.067Z
+  isexe@2.0.0: 2017-03-23T00:53:16.356Z
+  isomorphic-dompurify@2.35.0: 2025-12-27T10:15:28.913Z
+  issue-parser@7.0.2: 2026-05-01T19:42:07.151Z
+  jackspeak@3.4.3: 2024-07-10T15:50:20.040Z
+  jackspeak@4.2.3: 2026-02-07T05:11:22.509Z
+  java-properties@1.0.2: 2019-07-12T00:54:23.618Z
+  jiti@2.6.1: 2025-10-01T07:34:07.746Z
+  jiti@2.7.0: 2026-05-05T21:02:47.918Z
+  jose@6.2.3: 2026-04-27T15:23:35.019Z
+  joycon@3.1.1: 2021-12-01T18:56:12.607Z
+  js-tokens@4.0.0: 2018-01-28T11:58:58.170Z
+  js-yaml@4.1.1: 2025-11-12T15:18:03.524Z
+  jsdom@27.3.0: 2025-12-08T13:29:00.448Z
+  jsdom@27.4.0: 2025-12-26T10:56:39.553Z
+  jsesc@3.1.0: 2024-12-11T08:24:34.551Z
+  json-parse-better-errors@1.0.2: 2018-03-30T15:08:03.275Z
+  json-parse-even-better-errors@2.3.1: 2020-09-02T16:37:58.371Z
+  json-schema-traverse@1.0.0: 2020-12-13T10:56:54.719Z
+  json-schema-typed@8.0.2: 2025-11-17T20:30:24.942Z
+  json-with-bigint@3.5.8: 2026-03-19T19:58:42.290Z
+  json5@2.2.3: 2022-12-31T17:11:32.047Z
+  jsonfile@6.2.1: 2026-04-20T15:28:28.409Z
+  jsonpointer@5.0.1: 2022-07-13T12:46:10.798Z
+  jsonwebtoken@9.0.3: 2025-12-04T10:27:57.257Z
+  jwa@2.0.1: 2025-05-07T11:42:50.147Z
+  jws@4.0.1: 2025-12-04T08:52:29.218Z
+  kleur@4.1.5: 2022-06-26T18:50:12.559Z
+  kysely@0.28.17: 2026-05-03T01:05:34.179Z
+  lazystream@1.0.1: 2021-10-23T09:04:15.234Z
+  leaflet@1.9.4: 2023-05-18T11:04:11.088Z
+  libphonenumber-js@1.12.33: 2025-12-19T10:40:54.796Z
+  lightningcss-darwin-arm64@1.30.2: 2025-09-29T18:13:45.539Z
+  lightningcss-linux-arm64-gnu@1.30.2: 2025-09-29T18:13:57.433Z
+  lightningcss-linux-arm64-musl@1.30.2: 2025-09-29T18:14:00.834Z
+  lightningcss-linux-x64-gnu@1.30.2: 2025-09-29T18:14:03.989Z
+  lightningcss-linux-x64-musl@1.30.2: 2025-09-29T18:14:06.823Z
+  lightningcss-win32-arm64-msvc@1.30.2: 2025-09-29T18:14:09.286Z
+  lightningcss-win32-x64-msvc@1.30.2: 2025-09-29T18:14:12.644Z
+  lightningcss@1.30.2: 2025-09-29T18:14:25.197Z
+  lines-and-columns@1.2.4: 2021-11-21T03:31:07.871Z
+  linkify-it@5.0.1: 2026-05-23T13:17:46.516Z
+  load-json-file@4.0.0: 2017-11-04T07:57:09.197Z
+  locate-character@3.0.0: 2023-06-15T16:16:42.915Z
+  locate-path@2.0.0: 2016-11-28T05:27:33.711Z
+  locate-path@6.0.0: 2020-08-10T17:49:10.766Z
+  lodash-es@4.18.1: 2026-04-01T21:04:15.518Z
+  lodash.camelcase@4.3.0: 2016-08-13T17:37:03.141Z
+  lodash.capitalize@4.2.1: 2016-08-13T17:37:07.150Z
+  lodash.escaperegexp@4.1.2: 2016-07-25T14:43:16.424Z
+  lodash.find@4.6.0: 2016-08-13T17:38:23.274Z
+  lodash.includes@4.3.0: 2016-08-13T17:39:40.778Z
+  lodash.isboolean@3.0.3: 2016-02-03T07:28:20.290Z
+  lodash.isinteger@4.0.4: 2016-08-13T17:40:41.538Z
+  lodash.isnumber@3.0.3: 2016-02-03T07:28:49.514Z
+  lodash.isobject@3.0.2: 2015-05-19T19:52:16.503Z
+  lodash.isplainobject@4.0.6: 2016-08-13T17:41:07.730Z
+  lodash.isstring@4.0.1: 2016-02-03T07:28:59.695Z
+  lodash.keys@4.2.0: 2016-08-13T17:41:34.259Z
+  lodash.mapvalues@4.6.0: 2016-08-13T17:42:00.143Z
+  lodash.memoize@4.1.2: 2016-08-13T17:42:08.922Z
+  lodash.merge@4.6.2: 2019-07-10T00:19:41.667Z
+  lodash.once@4.1.1: 2016-08-13T17:42:47.106Z
+  lodash.uniq@4.5.0: 2016-08-13T17:46:41.962Z
+  lodash.uniqby@4.7.0: 2016-08-13T17:46:46.042Z
+  lodash@4.18.1: 2026-04-01T21:01:20.458Z
+  long@5.3.2: 2025-04-17T17:32:06.060Z
+  lru-cache@10.4.3: 2024-07-09T17:20:52.211Z
+  lru-cache@11.2.4: 2025-11-30T23:29:17.076Z
+  lru-cache@11.5.0: 2026-05-19T23:13:36.156Z
+  lru-cache@5.1.1: 2018-11-21T01:44:45.407Z
+  lz-string@1.5.0: 2023-03-04T08:24:59.879Z
+  magic-string@0.30.21: 2025-10-24T00:59:47.122Z
+  magic-string@0.30.7: 2024-02-05T17:08:28.888Z
+  magic-string@0.30.8: 2024-03-03T21:59:01.229Z
+  make-asynchronous@1.1.0: 2026-02-24T15:29:34.637Z
+  markdown-it@14.2.0: 2026-05-23T23:23:51.513Z
+  marked-terminal@7.3.0: 2025-01-28T19:31:18.655Z
+  marked@15.0.12: 2025-05-20T05:03:10.728Z
+  math-intrinsics@1.1.0: 2024-12-19T05:58:09.877Z
+  mdn-data@2.27.1: 2026-02-13T22:41:03.295Z
+  mdurl@2.0.0: 2023-12-01T05:03:40.542Z
+  media-typer@1.1.0: 2019-04-25T03:16:05.379Z
+  memfs-or-file-map-to-github-branch@1.3.0: 2025-03-12T08:41:42.762Z
+  memory-pager@1.5.0: 2019-01-09T15:38:24.901Z
+  meow@13.2.0: 2024-02-06T10:06:22.005Z
+  merge-descriptors@2.0.0: 2023-11-16T18:49:20.714Z
+  merge-stream@2.0.0: 2019-05-23T13:36:45.932Z
+  methods@1.1.2: 2016-01-18T02:53:56.364Z
+  micromatch@4.0.8: 2024-08-23T16:31:18.748Z
+  mime-db@1.52.0: 2022-02-21T19:41:51.123Z
+  mime-db@1.54.0: 2025-03-18T15:06:44.354Z
+  mime-types@2.1.35: 2022-03-12T18:04:43.042Z
+  mime-types@3.0.2: 2025-11-20T11:12:29.693Z
+  mime@2.6.0: 2021-11-02T18:00:20.963Z
+  mime@4.1.0: 2025-09-12T17:53:01.376Z
+  mimic-fn@2.1.0: 2019-03-31T17:53:34.125Z
+  mimic-fn@4.0.0: 2021-04-07T19:23:42.197Z
+  minimatch@10.2.5: 2026-03-30T18:08:07.247Z
+  minimatch@5.1.9: 2026-02-25T17:16:47.801Z
+  minimatch@9.0.9: 2026-02-26T19:32:47.083Z
+  minimist@1.2.8: 2023-02-09T20:59:49.233Z
+  minipass@7.1.3: 2026-02-19T00:34:33.886Z
+  mkdirp-classic@0.5.3: 2020-05-04T09:56:03.432Z
+  mkdirp@1.0.4: 2020-04-03T17:03:08.825Z
+  module-details-from-path@1.0.4: 2025-04-29T16:59:53.775Z
+  mongodb-connection-string-url@7.0.1: 2026-01-26T18:25:24.735Z
+  mongodb-uri@0.9.7: 2014-06-11T22:15:12.326Z
+  mongodb@7.2.0: 2026-04-20T15:29:30.008Z
+  mri@1.2.0: 2021-09-12T22:35:52.359Z
+  mrmime@2.0.1: 2025-02-17T18:17:05.137Z
+  ms@2.1.3: 2020-12-08T13:54:35.223Z
+  mz@2.7.0: 2017-09-13T17:57:36.315Z
+  nan@2.27.0: 2026-05-12T14:35:36.043Z
+  nanoid@3.3.12: 2026-04-30T22:04:14.515Z
+  nanostores@1.3.0: 2026-04-17T22:40:22.861Z
+  negotiator@1.0.0: 2024-08-31T15:42:18.280Z
+  neo-async@2.6.2: 2020-07-09T18:23:53.065Z
+  nerf-dart@1.0.0: 2015-08-20T12:22:17.009Z
+  no-case@4.0.0: 2023-09-30T01:23:08.053Z
+  node-addon-api@8.8.0: 2026-05-22T14:21:10.523Z
+  node-cleanup@2.1.2: 2017-01-01T07:04:02.019Z
+  node-cron@4.2.1: 2025-07-10T19:02:48.799Z
+  node-emoji@2.2.0: 2024-12-03T18:36:47.634Z
+  node-fetch@2.7.0: 2023-08-23T17:18:39.396Z
+  node-gyp-build@4.8.4: 2024-11-19T14:43:46.572Z
+  node-pg-migrate@8.0.4: 2025-12-11T08:05:46.916Z
+  node-releases@2.0.46: 2026-05-22T04:31:33.369Z
+  normalize-package-data@6.0.2: 2024-06-25T20:15:02.964Z
+  normalize-path@3.0.0: 2018-04-19T14:54:47.609Z
+  normalize-url@8.1.1: 2026-01-01T20:02:11.129Z
+  npm-run-path@4.0.1: 2019-12-22T22:04:32.828Z
+  npm-run-path@5.3.0: 2024-02-23T02:38:07.190Z
+  npm-run-path@6.0.0: 2024-08-26T08:40:09.814Z
+  npm@10.9.8: 2026-03-27T16:03:31.463Z
+  nunjucks@3.2.4: 2023-04-13T14:43:06.314Z
+  object-assign@4.1.1: 2017-01-16T15:35:15.282Z
+  object-inspect@1.13.4: 2025-02-05T01:26:10.272Z
+  obug@2.1.1: 2025-11-22T09:31:55.146Z
+  on-exit-leak-free@2.1.2: 2023-10-03T14:42:06.031Z
+  on-finished@2.4.1: 2022-02-22T16:10:48.714Z
+  once@1.4.0: 2016-09-06T21:11:09.367Z
+  onetime@5.1.2: 2020-08-09T20:29:04.963Z
+  onetime@6.0.0: 2021-04-08T13:48:04.866Z
+  override-require@1.1.1: 2016-11-10T23:22:20.445Z
+  p-each-series@3.0.0: 2021-04-09T05:36:15.993Z
+  p-event@6.0.1: 2024-03-02T06:25:36.581Z
+  p-filter@4.1.0: 2023-12-27T16:02:56.291Z
+  p-limit@1.3.0: 2018-06-06T16:01:38.768Z
+  p-limit@2.3.0: 2020-04-05T15:40:45.137Z
+  p-limit@3.1.0: 2020-11-25T07:42:37.364Z
+  p-locate@2.0.0: 2016-11-28T05:25:21.460Z
+  p-locate@5.0.0: 2020-08-10T17:42:34.692Z
+  p-map@7.0.4: 2025-11-11T06:28:53.483Z
+  p-reduce@2.1.0: 2019-04-04T04:57:45.948Z
+  p-reduce@3.0.0: 2021-04-08T18:18:57.037Z
+  p-timeout@6.1.4: 2025-01-01T13:07:05.386Z
+  p-try@1.0.0: 2016-10-21T06:16:43.459Z
+  p-try@2.2.0: 2019-03-31T12:34:35.198Z
+  package-json-from-dist@1.0.1: 2024-09-26T18:59:08.941Z
+  parent-module@1.0.1: 2019-03-28T11:33:52.331Z
+  parse-diff@0.7.1: 2020-09-11T12:08:11.038Z
+  parse-git-config@2.0.3: 2018-08-19T15:41:46.155Z
+  parse-github-url@1.0.4: 2026-04-02T00:24:29.431Z
+  parse-json@4.0.0: 2017-11-04T07:53:50.125Z
+  parse-json@5.2.0: 2021-01-18T11:15:13.459Z
+  parse-json@8.3.0: 2025-04-09T09:02:03.317Z
+  parse-link-header@2.0.0: 2021-12-16T15:35:03.127Z
+  parse-ms@4.0.0: 2024-01-07T14:14:09.614Z
+  parse-passwd@1.0.0: 2016-10-19T17:43:46.626Z
+  parse5-htmlparser2-tree-adapter@6.0.1: 2020-07-24T15:17:56.065Z
+  parse5@5.1.1: 2019-11-06T10:38:27.963Z
+  parse5@6.0.1: 2020-07-24T15:17:51.325Z
+  parse5@8.0.1: 2026-04-19T20:16:16.612Z
+  parseurl@1.3.3: 2019-04-16T04:16:26.547Z
+  pascal-case@4.0.0: 2023-09-30T01:32:20.229Z
+  path-exists@3.0.0: 2016-05-01T11:44:53.762Z
+  path-exists@4.0.0: 2019-04-04T03:29:16.887Z
+  path-key@3.1.1: 2019-11-22T16:47:18.153Z
+  path-key@4.0.0: 2021-04-09T12:04:51.822Z
+  path-scurry@1.11.1: 2024-05-12T02:47:20.787Z
+  path-scurry@2.0.2: 2026-02-19T17:20:00.211Z
+  path-to-regexp@8.4.2: 2026-04-01T21:17:05.201Z
+  path-type@4.0.0: 2019-03-12T09:25:18.333Z
+  pathe@2.0.3: 2025-02-11T19:47:35.862Z
+  pg-cloudflare@1.4.0: 2026-05-18T12:00:18.454Z
+  pg-connection-string@2.13.0: 2026-05-18T12:00:18.428Z
+  pg-int8@1.0.1: 2017-11-14T22:39:49.993Z
+  pg-pool@3.14.0: 2026-05-18T12:00:18.362Z
+  pg-protocol@1.14.0: 2026-05-18T12:00:18.334Z
+  pg-types@2.2.0: 2019-08-07T01:15:33.099Z
+  pg@8.16.3: 2025-06-27T14:52:44.894Z
+  pgpass@1.0.5: 2021-12-19T11:51:52.599Z
+  picocolors@1.1.1: 2024-10-16T18:20:03.921Z
+  picomatch@2.3.2: 2026-03-23T20:39:08.118Z
+  picomatch@4.0.4: 2026-03-23T20:39:47.960Z
+  pify@3.0.0: 2017-05-28T06:25:28.083Z
+  pino-abstract-transport@2.0.0: 2024-09-03T07:14:18.315Z
+  pino-abstract-transport@3.0.0: 2025-10-06T12:21:06.579Z
+  pino-http@11.0.0: 2025-10-04T15:03:47.740Z
+  pino-pretty@13.1.3: 2025-12-01T12:07:03.440Z
+  pino-std-serializers@7.1.0: 2026-01-13T12:50:19.626Z
+  pino@10.1.0: 2025-10-18T11:39:51.488Z
+  pinpoint@1.1.0: 2013-09-21T09:56:46.195Z
+  piscina@4.9.2: 2025-03-18T16:02:46.043Z
+  pkce-challenge@5.0.1: 2025-11-23T03:54:38.460Z
+  pkg-conf@2.1.0: 2017-12-27T09:21:06.593Z
+  playwright-core@1.57.0: 2025-11-25T11:17:14.914Z
+  playwright@1.57.0: 2025-11-25T11:17:08.230Z
+  postcss-value-parser@4.2.0: 2021-11-29T11:32:56.985Z
+  postcss@8.5.6: 2025-06-16T13:58:02.262Z
+  postgres-array@2.0.0: 2018-10-22T18:12:08.067Z
+  postgres-bytea@1.0.1: 2025-12-17T04:53:23.864Z
+  postgres-date@1.0.7: 2020-08-28T21:29:03.410Z
+  postgres-interval@1.2.0: 2019-02-23T00:06:51.959Z
+  pretty-format@27.5.1: 2022-02-08T10:52:12.132Z
+  pretty-ms@9.3.0: 2025-09-15T10:58:51.548Z
+  prettyjson@1.2.5: 2022-01-11T10:23:58.214Z
+  process-nextick-args@2.0.1: 2019-06-19T20:34:39.252Z
+  process-warning@5.0.0: 2025-03-03T17:27:10.377Z
+  process@0.11.10: 2017-04-26T12:34:27.448Z
+  progress@2.0.3: 2018-12-05T16:57:58.058Z
+  proper-lockfile@4.1.2: 2021-01-25T18:55:18.544Z
+  properties-reader@2.3.0: 2023-08-23T08:34:28.584Z
+  proto-list@1.2.4: 2015-05-21T00:58:33.471Z
+  protobufjs@7.6.1: 2026-05-22T02:52:20.599Z
+  proxy-addr@2.0.7: 2021-06-01T00:57:28.507Z
+  proxy-from-env@1.1.0: 2020-03-04T03:35:19.815Z
+  pump@3.0.4: 2026-02-28T13:31:05.855Z
+  punycode.js@2.3.1: 2023-10-30T18:28:36.491Z
+  punycode@2.3.1: 2023-10-30T18:28:32.512Z
+  pvtsutils@1.3.6: 2024-11-22T12:58:55.915Z
+  pvutils@1.1.5: 2025-10-24T16:35:37.839Z
+  qs@6.15.2: 2026-05-16T23:19:19.539Z
+  quick-format-unescaped@4.0.4: 2021-09-21T14:18:38.724Z
+  range-parser@1.2.1: 2019-05-11T00:27:37.805Z
+  rate-limiter-flexible@9.0.1: 2025-12-13T10:18:19.977Z
+  raw-body@3.0.2: 2025-11-21T20:47:27.523Z
+  rc@1.2.8: 2018-05-26T23:43:53.976Z
+  react-is@17.0.2: 2021-03-22T21:56:47.976Z
+  read-package-up@11.0.0: 2023-11-04T09:30:03.983Z
+  read-pkg@9.0.1: 2023-11-16T08:39:25.244Z
+  readable-stream@2.3.8: 2023-02-23T10:04:06.163Z
+  readable-stream@3.6.2: 2023-03-10T09:02:34.449Z
+  readable-stream@4.7.0: 2025-01-07T09:15:38.877Z
+  readdir-glob@1.1.3: 2023-04-05T19:13:06.840Z
+  readdirp@3.6.0: 2021-03-14T10:22:31.129Z
+  readdirp@4.1.2: 2025-02-14T17:27:21.994Z
+  readline-sync@1.4.10: 2019-07-27T13:00:08.630Z
+  real-require@0.2.0: 2022-07-25T10:14:38.061Z
+  recast@0.23.11: 2025-03-03T01:50:27.103Z
+  reflect-metadata@0.2.2: 2024-03-29T01:38:46.117Z
+  regenerator-runtime@0.13.11: 2022-11-14T18:15:22.830Z
+  registry-auth-token@5.1.1: 2026-01-16T02:08:51.175Z
+  require-directory@2.1.1: 2015-05-28T08:31:04.702Z
+  require-from-string@2.0.2: 2018-04-09T09:49:47.301Z
+  require-in-the-middle@8.0.1: 2025-10-20T12:27:21.478Z
+  resolve-from@4.0.0: 2017-09-23T09:48:16.876Z
+  resolve-from@5.0.0: 2019-04-15T04:06:25.601Z
+  resolve-pkg-maps@1.0.0: 2022-12-14T15:37:46.218Z
+  retry@0.12.0: 2018-04-09T09:35:27.678Z
+  robust-predicates@3.0.3: 2026-03-22T10:28:19.122Z
+  rollup@4.60.4: 2026-05-14T17:54:33.337Z
+  rou3@0.7.12: 2025-12-15T16:41:55.162Z
+  router@2.2.0: 2025-03-27T00:38:18.615Z
+  rw@1.3.3: 2017-01-20T17:13:07.806Z
+  sade@1.8.1: 2022-01-06T17:09:33.711Z
+  safe-buffer@5.1.2: 2018-04-25T20:10:24.706Z
+  safe-buffer@5.2.1: 2020-05-10T16:37:30.776Z
+  safe-stable-stringify@2.5.0: 2024-08-24T21:31:17.456Z
+  safer-buffer@2.1.2: 2018-04-08T10:42:42.130Z
+  saxes@6.0.0: 2021-11-07T19:06:31.264Z
+  secure-json-parse@4.1.0: 2025-10-05T12:41:31.433Z
+  semantic-release@24.2.5: 2025-05-23T21:59:26.519Z
+  semver-diff@4.0.0: 2021-05-03T12:27:52.842Z
+  semver-regex@4.0.5: 2022-06-08T10:09:33.718Z
+  semver@6.3.1: 2023-07-10T22:38:41.428Z
+  semver@7.8.1: 2026-05-21T18:28:15.649Z
+  send@1.2.1: 2025-12-15T19:36:11.862Z
+  serve-static@2.2.1: 2025-12-15T19:17:31.514Z
+  set-cookie-parser@2.7.2: 2025-10-27T19:50:59.587Z
+  set-cookie-parser@3.1.0: 2026-03-20T16:53:03.470Z
+  setprototypeof@1.2.0: 2019-07-18T04:49:56.614Z
+  sharp@0.34.5: 2025-11-06T14:19:40.989Z
+  shebang-command@2.0.0: 2019-09-06T14:53:25.901Z
+  shebang-regex@3.0.0: 2019-04-27T10:46:19.256Z
+  side-channel-list@1.0.1: 2026-04-08T16:55:13.603Z
+  side-channel-map@1.0.1: 2024-12-11T04:53:18.943Z
+  side-channel-weakmap@1.0.2: 2024-12-11T05:39:11.495Z
+  side-channel@1.1.0: 2024-12-11T17:00:33.553Z
+  siginfo@2.0.0: 2020-06-16T20:30:23.515Z
+  signal-exit@3.0.7: 2022-02-03T21:05:34.544Z
+  signal-exit@4.1.0: 2023-07-29T05:44:56.721Z
+  signale@1.4.0: 2019-02-26T23:48:06.889Z
+  sirv@3.0.2: 2025-09-03T22:05:27.662Z
+  skin-tone@2.0.0: 2019-04-28T14:28:24.619Z
+  sonic-boom@4.2.1: 2026-02-10T13:59:29.724Z
+  sorcery@1.0.0: 2024-06-12T13:31:11.118Z
+  source-map-js@1.2.1: 2024-09-08T16:22:55.645Z
+  source-map@0.6.1: 2017-09-29T14:42:30.948Z
+  sparse-bitfield@3.0.3: 2017-03-05T00:17:45.769Z
+  spawn-error-forwarder@1.0.0: 2014-11-23T20:19:26.090Z
+  spdx-correct@3.2.0: 2023-03-07T01:53:18.381Z
+  spdx-exceptions@2.5.0: 2024-02-15T03:06:38.111Z
+  spdx-expression-parse@3.0.1: 2020-05-13T16:12:46.317Z
+  spdx-license-ids@3.0.23: 2026-02-20T23:02:57.930Z
+  split-ca@1.0.1: 2016-03-01T18:08:07.407Z
+  split2@1.0.0: 2015-06-13T16:14:10.562Z
+  split2@4.2.0: 2023-03-26T08:33:02.359Z
+  ssh-remote-port-forward@1.0.4: 2021-09-23T08:47:52.990Z
+  ssh2@1.17.0: 2025-08-20T17:45:52.006Z
+  stackback@0.0.2: 2012-10-20T00:56:54.591Z
+  statuses@2.0.2: 2025-06-06T19:56:01.385Z
+  std-env@3.10.0: 2025-10-14T09:23:46.812Z
+  stream-combiner2@1.1.1: 2015-10-16T23:03:58.486Z
+  streamx@2.25.0: 2026-03-19T10:48:17.367Z
+  string-width-cjs@4.2.3: 2021-09-23T17:17:21.341Z
+  string-width@4.2.3: 2021-09-23T17:17:21.341Z
+  string-width@5.1.2: 2022-02-28T08:22:05.036Z
+  string_decoder@1.1.1: 2018-03-30T08:14:15.043Z
+  string_decoder@1.3.0: 2019-08-07T09:20:36.634Z
+  strip-ansi-cjs@6.0.1: 2021-09-23T16:34:41.798Z
+  strip-ansi@6.0.1: 2021-09-23T16:34:41.798Z
+  strip-ansi@7.2.0: 2026-02-26T13:51:11.099Z
+  strip-bom@3.0.0: 2016-04-30T16:02:44.907Z
+  strip-final-newline@2.0.0: 2018-10-28T08:36:42.180Z
+  strip-final-newline@3.0.0: 2021-05-03T12:51:11.608Z
+  strip-final-newline@4.0.0: 2023-12-13T19:31:50.243Z
+  strip-json-comments@2.0.1: 2016-02-09T08:30:06.455Z
+  strip-json-comments@5.0.3: 2025-08-08T14:14:05.044Z
+  style-mod@4.1.3: 2025-10-17T13:24:18.045Z
+  super-regex@1.1.0: 2025-11-04T09:30:12.779Z
+  superagent@10.3.0: 2026-01-06T07:45:00.582Z
+  supertest@7.1.4: 2025-07-22T23:22:04.554Z
+  supports-color@5.5.0: 2018-08-20T04:37:37.309Z
+  supports-color@7.2.0: 2020-08-28T11:17:34.870Z
+  supports-hyperlinks@1.0.1: 2017-11-28T01:50:58.193Z
+  supports-hyperlinks@3.2.0: 2025-02-02T06:53:09.656Z
+  svelte-check@4.3.5: 2025-12-20T06:59:47.111Z
+  svelte-easy-crop@5.0.0: 2025-09-05T14:02:02.604Z
+  svelte-heros-v2@3.0.1: 2025-12-05T08:29:35.498Z
+  svelte-i18next@2.2.2: 2023-10-19T07:46:00.728Z
+  svelte@5.46.1: 2025-12-24T08:10:43.445Z
+  symbol-tree@3.2.4: 2019-06-12T18:10:21.305Z
+  tailwindcss@4.1.18: 2025-12-11T16:40:50.445Z
+  tapable@2.3.3: 2026-04-21T13:37:30.215Z
+  tar-fs@2.1.4: 2025-09-16T15:05:08.323Z
+  tar-fs@3.1.2: 2026-03-04T22:55:50.260Z
+  tar-stream@2.2.0: 2020-12-29T10:22:57.508Z
+  tar-stream@3.2.0: 2026-04-29T11:19:01.950Z
+  teex@1.0.1: 2022-09-12T08:39:15.285Z
+  temp-dir@3.0.0: 2022-09-26T05:28:19.727Z
+  tempy@3.2.0: 2026-02-02T16:12:54.512Z
+  testcontainers@11.10.0: 2025-12-09T21:08:58.734Z
+  text-decoder@1.2.7: 2026-02-16T10:20:59.609Z
+  thenify-all@1.6.0: 2015-01-10T17:24:24.668Z
+  thenify@3.3.1: 2020-06-17T17:30:57.152Z
+  thread-stream@3.1.0: 2024-06-13T15:39:11.962Z
+  through2@2.0.5: 2018-11-06T22:03:11.711Z
+  time-span@5.1.0: 2022-06-26T14:03:19.734Z
+  tiny-glob@0.2.9: 2021-05-14T17:53:46.189Z
+  tiny-invariant@1.3.3: 2024-02-23T21:50:05.584Z
+  tinybench@2.9.0: 2024-08-02T15:09:44.961Z
+  tinyexec@1.2.2: 2026-05-23T16:12:08.123Z
+  tinyglobby@0.2.16: 2026-04-07T23:37:03.457Z
+  tinypool@1.1.1: 2025-06-16T17:17:44.588Z
+  tinyrainbow@3.1.0: 2026-03-12T09:21:01.296Z
+  tldts-core@7.1.0: 2026-05-23T22:12:47.858Z
+  tldts@7.1.0: 2026-05-23T22:12:53.877Z
+  tmp@0.2.5: 2025-08-08T21:22:08.916Z
+  to-regex-range@5.0.1: 2019-04-07T06:04:37.030Z
+  toidentifier@1.0.1: 2021-11-14T22:19:09.631Z
+  totalist@3.0.1: 2023-04-03T18:36:39.508Z
+  tough-cookie@6.0.1: 2026-03-12T18:39:28.318Z
+  tr46@0.0.3: 2016-01-20T02:08:54.875Z
+  tr46@5.1.1: 2025-04-17T00:47:38.158Z
+  tr46@6.0.0: 2025-09-18T00:42:31.639Z
+  traverse@0.6.8: 2023-12-20T23:55:50.353Z
+  ts-parse-database-url@1.0.3: 2018-07-25T17:19:01.527Z
+  tsconfck@3.1.6: 2025-05-20T18:00:16.921Z
+  tslib@1.14.1: 2020-10-09T23:34:42.516Z
+  tslib@2.8.1: 2024-10-31T22:42:48.624Z
+  tsx@4.21.0: 2025-11-30T15:56:09.488Z
+  tsyringe@4.10.0: 2025-04-16T02:47:14.328Z
+  tweetnacl@0.14.5: 2016-12-13T11:11:56.945Z
+  type-fest@1.4.0: 2021-08-05T12:18:37.443Z
+  type-fest@2.19.0: 2022-08-22T17:20:40.104Z
+  type-fest@4.41.0: 2025-05-06T07:20:19.356Z
+  type-is@2.1.0: 2026-05-13T15:30:24.508Z
+  typescript@5.9.3: 2025-09-30T21:19:38.784Z
+  uc.micro@2.1.0: 2024-03-02T17:44:53.816Z
+  uglify-js@3.19.3: 2024-08-29T13:49:01.316Z
+  undici-types@5.26.5: 2023-10-23T07:27:24.774Z
+  undici-types@7.16.0: 2025-09-09T17:07:27.610Z
+  undici@7.25.0: 2026-04-13T13:27:40.320Z
+  unicode-emoji-modifier-base@1.0.0: 2016-06-23T12:18:06.920Z
+  unicorn-magic@0.1.0: 2023-11-09T15:54:05.533Z
+  unicorn-magic@0.3.0: 2024-07-25T16:24:34.405Z
+  unique-string@3.0.0: 2021-04-05T08:20:51.892Z
+  universal-user-agent@6.0.1: 2023-11-04T22:29:03.740Z
+  universal-user-agent@7.0.3: 2025-05-12T03:35:01.466Z
+  universalify@2.0.1: 2023-11-01T17:12:45.392Z
+  unpipe@1.0.0: 2015-06-14T20:30:19.934Z
+  unplugin@1.0.1: 2022-12-12T08:55:03.826Z
+  update-browserslist-db@1.2.3: 2025-12-16T15:17:57.962Z
+  url-join@5.0.0: 2022-03-23T21:03:24.801Z
+  util-deprecate@1.0.2: 2015-10-07T18:37:40.665Z
+  uuid@10.0.0: 2024-06-09T13:42:04.366Z
+  validate-npm-package-license@3.0.4: 2018-08-05T16:59:03.230Z
+  vary@1.1.2: 2017-09-24T01:47:11.325Z
+  vite-tsconfig-paths@6.0.3: 2025-12-18T11:03:40.919Z
+  vite@7.3.0: 2025-12-15T08:53:07.190Z
+  vitefu@1.1.3: 2026-04-01T02:55:28.273Z
+  vitest@4.0.16: 2025-12-16T15:08:51.179Z
+  w3c-keyname@2.2.8: 2023-06-07T07:41:28.542Z
+  w3c-xmlserializer@5.0.0: 2023-11-12T07:59:26.966Z
+  web-worker@1.5.0: 2025-01-31T18:09:36.457Z
+  webidl-conversions@3.0.1: 2016-01-04T06:08:05.108Z
+  webidl-conversions@7.0.0: 2021-09-12T01:03:06.782Z
+  webidl-conversions@8.0.1: 2026-01-02T12:56:45.580Z
+  webpack-sources@3.5.0: 2026-05-22T08:56:53.561Z
+  webpack-virtual-modules@0.5.0: 2022-12-11T19:46:54.836Z
+  whatwg-encoding@3.1.1: 2023-11-12T07:29:21.747Z
+  whatwg-mimetype@4.0.0: 2023-11-11T07:43:44.007Z
+  whatwg-mimetype@5.0.0: 2026-01-20T03:04:38.058Z
+  whatwg-url@14.2.0: 2025-03-15T07:12:41.904Z
+  whatwg-url@15.1.0: 2025-09-18T00:51:00.815Z
+  whatwg-url@5.0.0: 2017-05-26T20:56:41.955Z
+  which@2.0.2: 2019-11-18T22:26:15.325Z
+  why-is-node-running@2.3.0: 2024-07-08T12:57:23.951Z
+  wordwrap@1.0.0: 2015-05-07T17:07:25.416Z
+  wrap-ansi-cjs@7.0.0: 2020-04-22T16:53:23.889Z
+  wrap-ansi@7.0.0: 2020-04-22T16:53:23.889Z
+  wrap-ansi@8.1.0: 2023-01-23T10:13:24.890Z
+  wrappy@1.0.2: 2016-05-17T23:30:52.415Z
+  ws@8.21.0: 2026-05-22T17:59:59.453Z
+  xcase@2.0.1: 2017-02-08T14:56:35.098Z
+  xml-name-validator@5.0.0: 2023-11-12T05:38:09.927Z
+  xmlchars@2.2.0: 2019-09-06T16:38:51.976Z
+  xtend@4.0.2: 2019-07-08T13:35:45.491Z
+  y18n@5.0.8: 2021-04-07T18:57:33.969Z
+  yallist@3.1.1: 2019-09-30T20:07:18.343Z
+  yaml@2.9.0: 2026-05-11T10:16:24.045Z
+  yargs-parser@20.2.9: 2021-06-20T23:54:31.941Z
+  yargs-parser@21.1.1: 2022-08-04T21:13:43.411Z
+  yargs@16.2.0: 2020-12-05T23:09:55.514Z
+  yargs@17.7.2: 2023-04-27T19:59:02.861Z
+  yocto-queue@0.1.0: 2020-11-24T06:05:35.875Z
+  yoctocolors@2.1.2: 2025-08-19T15:19:23.680Z
+  zimmerframe@1.1.4: 2025-09-09T17:55:31.852Z
+  zip-stream@6.0.1: 2024-03-10T02:03:34.117Z
+  zod-to-json-schema@3.25.2: 2026-03-27T07:09:39.645Z
+  zod@3.25.76: 2025-07-08T09:10:18.684Z
+  zod@4.4.3: 2026-05-04T07:06:40.819Z
+
 importers:
 
   .:
     dependencies:
+      '@octokit/core':
+        specifier: '>=2'
+        version: 3.6.0
+      '@types/node':
+        specifier: '*'
+        version: 25.0.3
+      conventional-commits-filter:
+        specifier: ^5.0.0
+        version: 5.0.0
+      conventional-commits-parser:
+        specifier: ^6.4.0
+        version: 6.4.0
+      cosmiconfig:
+        specifier: '>=9'
+        version: 9.0.1(typescript@5.9.3)
+      marked:
+        specifier: '>=1 <16'
+        version: 15.0.12
       node-pg-migrate:
         specifier: 8.0.4
         version: 8.0.4(@types/pg@8.16.0)(pg@8.16.3)
+      picomatch:
+        specifier: ^3 || ^4
+        version: 4.0.4
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.10
         version: 2.3.10
       '@commitlint/cli':
         specifier: 20.2.0
-        version: 20.2.0(typescript@5.9.3)
+        version: 20.2.0
       '@commitlint/config-conventional':
         specifier: 20.2.0
         version: 20.2.0
       '@semantic-release/changelog':
         specifier: 6.0.3
-        version: 6.0.3(semantic-release@24.2.5(typescript@5.9.3))
+        version: 6.0.3(semantic-release@24.2.5)
       '@semantic-release/exec':
         specifier: 7.0.3
-        version: 7.0.3(semantic-release@24.2.5(typescript@5.9.3))
+        version: 7.0.3(semantic-release@24.2.5)
       '@semantic-release/git':
         specifier: 10.0.1
-        version: 10.0.1(semantic-release@24.2.5(typescript@5.9.3))
+        version: 10.0.1(semantic-release@24.2.5)
       '@types/pg':
         specifier: 8.16.0
         version: 8.16.0
@@ -44,7 +1257,7 @@ importers:
         version: 8.16.3
       semantic-release:
         specifier: 24.2.5
-        version: 24.2.5(typescript@5.9.3)
+        version: 24.2.5
       sharp:
         specifier: 0.34.5
         version: 0.34.5
@@ -54,45 +1267,135 @@ importers:
 
   apps/backend:
     dependencies:
+      '@better-auth/core':
+        specifier: 1.5.5
+        version: 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/passkey':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0)))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
+      '@better-auth/utils':
+        specifier: 0.3.1
+        version: 0.3.1
+      '@better-fetch/fetch':
+        specifier: 1.1.21
+        version: 1.1.21
+      '@csstools/css-parser-algorithms':
+        specifier: ^4.0.0
+        version: 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@freundebuch/shared':
         specifier: workspace:*
-        version: link:../../packages/shared
+        version: 2.73.0
       '@hono/node-server':
         specifier: 1.19.7
         version: 1.19.7(hono@4.11.1)
+      '@noble/hashes':
+        specifier: ^1.8.0 || ^2.0.0
+        version: 2.2.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: '>=0.57.1 <1'
+        version: 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.37.0
+        version: 1.41.1
       '@pgtyped/runtime':
         specifier: 2.4.2
         version: 2.4.2
       '@sentry/node':
         specifier: 10.32.1
         version: 10.32.1
+      '@sveltejs/kit':
+        specifier: ^2.0.0
+        version: 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
+        version: 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+      acorn:
+        specifier: ^8
+        version: 8.16.0
       arktype:
         specifier: 2.1.29
         version: 2.1.29
+      bare-events:
+        specifier: '*'
+        version: 2.8.3
       bcrypt:
         specifier: 6.0.0
         version: 6.0.0
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0))
+      better-call:
+        specifier: 1.3.2
+        version: 1.3.2(zod@4.4.3)
+      chokidar:
+        specifier: ^3.3.0
+        version: 4.0.3
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
+      fp-ts:
+        specifier: ^2.5.0
+        version: 2.16.11
       hono:
         specifier: 4.11.1
         version: 4.11.1
+      io-ts:
+        specifier: ^2.2.16
+        version: 2.2.22(fp-ts@2.16.11)
+      jiti:
+        specifier: '>=1.21.0'
+        version: 2.7.0
+      jose:
+        specifier: ^6.1.0
+        version: 6.2.3
+      jsdom:
+        specifier: '*'
+        version: 27.4.0
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
+      kysely:
+        specifier: ^0.28.5
+        version: 0.28.17
+      lightningcss:
+        specifier: ^1.21.0
+        version: 1.30.2
       lru-cache:
         specifier: 11.2.4
         version: 11.2.4
+      mongodb:
+        specifier: ^6.0.0 || ^7.0.0
+        version: 7.2.0
+      nanostores:
+        specifier: ^1.0.1
+        version: 1.3.0
       node-cron:
         specifier: 4.2.1
         version: 4.2.1
       pg:
         specifier: 8.16.3
         version: 8.16.3
+      picomatch:
+        specifier: ^3 || ^4
+        version: 4.0.4
       pino:
         specifier: 10.1.0
         version: 10.1.0
@@ -108,6 +1411,18 @@ importers:
       sharp:
         specifier: 0.34.5
         version: 0.34.5
+      svelte:
+        specifier: ^4.0.0 || ^5.0.0
+        version: 5.46.1
+      vite:
+        specifier: '*'
+        version: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.4.2
+        version: 2.9.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@pgtyped/cli':
         specifier: 2.4.3
@@ -150,28 +1465,109 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
-        version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 6.0.3(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.4.0)
 
   apps/frontend:
     dependencies:
+      '@babel/core':
+        specifier: ^7.0.0
+        version: 7.29.0
+      '@better-auth/core':
+        specifier: 1.5.5
+        version: 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/passkey':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0)))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
+      '@better-auth/utils':
+        specifier: 0.3.1
+        version: 0.3.1
+      '@better-fetch/fetch':
+        specifier: 1.1.21
+        version: 1.1.21
+      '@codemirror/commands':
+        specifier: 6.10.3
+        version: 6.10.3
+      '@codemirror/lang-markdown':
+        specifier: 6.5.0
+        version: 6.5.0
+      '@codemirror/language':
+        specifier: 6.12.3
+        version: 6.12.3
+      '@codemirror/state':
+        specifier: 6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: 6.43.0
+        version: 6.43.0
+      '@csstools/css-parser-algorithms':
+        specifier: ^4.0.0
+        version: 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer':
+        specifier: ^4.0.0
+        version: 4.0.0
+      '@lezer/common':
+        specifier: 1.5.2
+        version: 1.5.2
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
+      '@noble/hashes':
+        specifier: ^1.8.0 || ^2.0.0
+        version: 2.2.0
+      '@opentelemetry/api':
+        specifier: ^1.0.0
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: '>=0.57.1 <1'
+        version: 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.1 || ^2.1.0 || ^2.2.0
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.37.0
+        version: 1.41.1
       '@sentry/sveltekit':
         specifier: 10.32.1
-        version: 10.32.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 10.32.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/node':
+        specifier: ^20.19.0 || >=22.12.0
+        version: 25.0.3
+      acorn:
+        specifier: ^8.9.0
+        version: 8.16.0
       arktype:
         specifier: 2.1.29
         version: 2.1.29
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0))
+      better-call:
+        specifier: 1.3.2
+        version: 1.3.2(zod@4.4.3)
+      browserslist:
+        specifier: '>= 4.21.0'
+        version: 4.28.2
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
       d3:
         specifier: 7.9.0
         version: 7.9.0
+      d3-selection:
+        specifier: 2 - 3
+        version: 3.0.0
       i18next:
         specifier: 25.7.4
         version: 25.7.4(typescript@5.9.3)
@@ -181,9 +1577,36 @@ importers:
       isomorphic-dompurify:
         specifier: 2.35.0
         version: 2.35.0
+      jiti:
+        specifier: '>=1.21.0'
+        version: 2.7.0
+      jose:
+        specifier: ^6.1.0
+        version: 6.2.3
+      kysely:
+        specifier: ^0.28.5
+        version: 0.28.17
       leaflet:
         specifier: 1.9.4
         version: 1.9.4
+      lightningcss:
+        specifier: ^1.21.0
+        version: 1.30.2
+      markdown-it:
+        specifier: 14.2.0
+        version: 14.2.0
+      mongodb:
+        specifier: ^6.0.0 || ^7.0.0
+        version: 7.2.0
+      nanostores:
+        specifier: ^1.0.1
+        version: 1.3.0
+      pg:
+        specifier: ^8.0.0
+        version: 8.16.3
+      picomatch:
+        specifier: ^3 || ^4
+        version: 4.0.4
       svelte-easy-crop:
         specifier: 5.0.0
         version: 5.0.0(svelte@5.46.1)
@@ -193,31 +1616,43 @@ importers:
       svelte-i18next:
         specifier: 2.2.2
         version: 2.2.2(i18next@25.7.4(typescript@5.9.3))(svelte@5.46.1)
+      tsx:
+        specifier: ^4.8.1
+        version: 4.21.0
+      yaml:
+        specifier: ^2.4.2
+        version: 2.9.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@playwright/test':
         specifier: 1.57.0
         version: 1.57.0
       '@sveltejs/adapter-static':
         specifier: 3.0.8
-        version: 3.0.8(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 3.0.8(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: 2.49.2
-        version: 2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.2.1
-        version: 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/postcss':
         specifier: 4.1.18
         version: 4.1.18
       '@testing-library/svelte':
         specifier: 5.3.0
-        version: 5.3.0(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.3.0(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0))
       '@types/d3':
         specifier: 7.4.3
         version: 7.4.3
       '@types/leaflet':
         specifier: 1.9.21
         version: 1.9.21
+      '@types/markdown-it':
+        specifier: 14.1.2
+        version: 14.1.2
       autoprefixer:
         specifier: 10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -232,7 +1667,7 @@ importers:
         version: 5.46.1
       svelte-check:
         specifier: 4.3.5
-        version: 4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.9.3)
+        version: 4.3.5(svelte@5.46.1)(typescript@5.9.3)
       tailwindcss:
         specifier: 4.1.18
         version: 4.1.18
@@ -244,40 +1679,85 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.0
-        version: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0)
 
   apps/mcp-server:
     dependencies:
+      '@csstools/css-parser-algorithms':
+        specifier: ^4.0.0
+        version: 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@freundebuch/backend':
         specifier: workspace:*
-        version: link:../backend
+        version: 2.73.0
       '@freundebuch/shared':
         specifier: workspace:*
-        version: link:../../packages/shared
+        version: 2.73.0
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@3.25.76)
+      '@noble/hashes':
+        specifier: ^1.8.0 || ^2.0.0
+        version: 2.2.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       '@pgtyped/runtime':
         specifier: 2.4.2
         version: 2.4.2
+      ajv:
+        specifier: ^8.0.0
+        version: 8.20.0
       arktype:
         specifier: 2.1.29
         version: 2.1.29
+      bare-events:
+        specifier: '*'
+        version: 2.8.3
       bcrypt:
         specifier: 6.0.0
         version: 6.0.0
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
+      express:
+        specifier: '>= 4.11'
+        version: 5.2.1
+      hono:
+        specifier: ^4
+        version: 4.11.1
+      jiti:
+        specifier: '>=1.21.0'
+        version: 2.7.0
+      jsdom:
+        specifier: '*'
+        version: 27.4.0
+      lightningcss:
+        specifier: ^1.21.0
+        version: 1.30.2
       pg:
         specifier: 8.16.3
         version: 8.16.3
+      picomatch:
+        specifier: ^3 || ^4
+        version: 4.0.4
       pino:
         specifier: 10.1.0
         version: 10.1.0
       pino-pretty:
         specifier: 13.1.3
         version: 13.1.3
+      vite:
+        specifier: '*'
+        version: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.4.2
+        version: 2.9.0
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -308,10 +1788,10 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.0.3
-        version: 6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 6.0.3(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.4.0)
 
   packages/danger:
     dependencies:
@@ -320,7 +1800,16 @@ importers:
         version: 20.2.0
       '@commitlint/load':
         specifier: 20.2.0
-        version: 20.2.0(@types/node@25.0.3)(typescript@5.9.3)
+        version: 20.2.0
+      '@octokit/core':
+        specifier: '>=2'
+        version: 3.6.0
+      '@types/node':
+        specifier: '*'
+        version: 25.0.3
+      cosmiconfig:
+        specifier: '>=9'
+        version: 9.0.1(typescript@5.9.3)
     devDependencies:
       danger:
         specifier: 12.3.3
@@ -331,24 +1820,63 @@ importers:
 
   packages/shared:
     dependencies:
+      '@csstools/css-parser-algorithms':
+        specifier: ^4.0.0
+        version: 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer':
+        specifier: ^4.0.0
+        version: 4.0.0
+      '@noble/hashes':
+        specifier: ^1.8.0 || ^2.0.0
+        version: 2.2.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@types/node':
+        specifier: ^20.0.0 || ^22.0.0 || >=24.0.0
+        version: 25.0.3
       arktype:
         specifier: 2.1.29
         version: 2.1.29
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
+      jiti:
+        specifier: '>=1.21.0'
+        version: 2.7.0
+      jsdom:
+        specifier: '*'
+        version: 27.4.0
       libphonenumber-js:
         specifier: 1.12.33
         version: 1.12.33
+      lightningcss:
+        specifier: ^1.21.0
+        version: 1.30.2
+      picomatch:
+        specifier: ^3 || ^4
+        version: 4.0.4
+      tsx:
+        specifier: ^4.8.1
+        version: 4.21.0
+      vite:
+        specifier: ^6.0.0 || ^7.0.0-0
+        version: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.4.2
+        version: 2.9.0
     devDependencies:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: 4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.4.0)
 
 packages:
 
-  '@acemir/cssom@0.9.30':
-    resolution: {integrity: sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg==}
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -366,55 +1894,51 @@ packages:
   '@ark/util@0.56.0':
     resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
-  '@asamuzakjp/css-color@4.1.1':
-    resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
 
-  '@asamuzakjp/dom-selector@6.7.6':
-    resolution: {integrity: sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==}
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -425,8 +1949,8 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.26.9':
@@ -434,25 +1958,25 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@balena/dockerignore@1.0.2':
@@ -544,54 +2068,96 @@ packages:
   '@biomejs/cli-darwin-arm64@2.3.10':
     resolution: {integrity: sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@biomejs/cli-darwin-x64@2.3.10':
-    resolution: {integrity: sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [darwin]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@biomejs/cli-linux-arm64-musl@2.3.10':
     resolution: {integrity: sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@biomejs/cli-linux-arm64@2.3.10':
     resolution: {integrity: sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@biomejs/cli-linux-x64-musl@2.3.10':
     resolution: {integrity: sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@biomejs/cli-linux-x64@2.3.10':
     resolution: {integrity: sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@biomejs/cli-win32-arm64@2.3.10':
     resolution: {integrity: sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@biomejs/cli-win32-x64@2.3.10':
     resolution: {integrity: sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
+
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -606,24 +2172,24 @@ packages:
     resolution: {integrity: sha512-MsRac+yNIbTB4Q/psstKK4/ciVzACHicSwz+04Sxve+4DW+PiJeTjU0JnS4m/oOnulrXYN+yBPlKaBSGemRfgQ==}
     engines: {node: '>=v18'}
 
-  '@commitlint/config-validator@20.2.0':
-    resolution: {integrity: sha512-SQCBGsL9MFk8utWNSthdxd9iOD1pIVZSHxGBwYIGfd67RTjxqzFOSAYeQVXOu3IxRC3YrTOH37ThnTLjUlyF2w==}
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
     engines: {node: '>=v18'}
 
-  '@commitlint/ensure@20.2.0':
-    resolution: {integrity: sha512-+8TgIGv89rOWyt3eC6lcR1H7hqChAKkpawytlq9P1i/HYugFRVqgoKJ8dhd89fMnlrQTLjA5E97/4sF09QwdoA==}
+  '@commitlint/ensure@20.5.3':
+    resolution: {integrity: sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==}
     engines: {node: '>=v18'}
 
   '@commitlint/execute-rule@20.0.0':
     resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
     engines: {node: '>=v18'}
 
-  '@commitlint/format@20.2.0':
-    resolution: {integrity: sha512-PhNoLNhxpfIBlW/i90uZ3yG3hwSSYx7n4d9Yc+2FAorAHS0D9btYRK4ZZXX+Gm3W5tDtu911ow/eWRfcRVgNWg==}
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
     engines: {node: '>=v18'}
 
-  '@commitlint/is-ignored@20.2.0':
-    resolution: {integrity: sha512-Lz0OGeZCo/QHUDLx5LmZc0EocwanneYJUM8z0bfWexArk62HKMLfLIodwXuKTO5y0s6ddXaTexrYHs7v96EOmw==}
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
     engines: {node: '>=v18'}
 
   '@commitlint/lint@20.2.0':
@@ -634,236 +2200,133 @@ packages:
     resolution: {integrity: sha512-iAK2GaBM8sPFTSwtagI67HrLKHIUxQc2BgpgNc/UMNme6LfmtHpIxQoN1TbP+X1iz58jq32HL1GbrFTCzcMi6g==}
     engines: {node: '>=v18'}
 
-  '@commitlint/message@20.0.0':
-    resolution: {integrity: sha512-gLX4YmKnZqSwkmSB9OckQUrI5VyXEYiv3J5JKZRxIp8jOQsWjZgHSG/OgEfMQBK9ibdclEdAyIPYggwXoFGXjQ==}
+  '@commitlint/message@20.4.3':
+    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
     engines: {node: '>=v18'}
 
-  '@commitlint/parse@20.2.0':
-    resolution: {integrity: sha512-LXStagGU1ivh07X7sM+hnEr4BvzFYn1iBJ6DRg2QsIN8lBfSzyvkUcVCDwok9Ia4PWiEgei5HQjju6xfJ1YaSQ==}
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
     engines: {node: '>=v18'}
 
-  '@commitlint/read@20.2.0':
-    resolution: {integrity: sha512-+SjF9mxm5JCbe+8grOpXCXMMRzAnE0WWijhhtasdrpJoAFJYd5UgRTj/oCq5W3HJTwbvTOsijEJ0SUGImECD7Q==}
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
     engines: {node: '>=v18'}
 
-  '@commitlint/resolve-extends@20.2.0':
-    resolution: {integrity: sha512-KVoLDi9BEuqeq+G0wRABn4azLRiCC22/YHR2aCquwx6bzCHAIN8hMt3Nuf1VFxq/c8ai6s8qBxE8+ZD4HeFTlQ==}
+  '@commitlint/resolve-extends@20.5.3':
+    resolution: {integrity: sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==}
     engines: {node: '>=v18'}
 
-  '@commitlint/rules@20.2.0':
-    resolution: {integrity: sha512-27rHGpeAjnYl/A+qUUiYDa7Yn1WIjof/dFJjYW4gA1Ug+LUGa1P0AexzGZ5NBxTbAlmDgaxSZkLLxtLVqtg8PQ==}
+  '@commitlint/rules@20.5.3':
+    resolution: {integrity: sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==}
     engines: {node: '>=v18'}
 
   '@commitlint/to-lines@20.0.0':
     resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
     engines: {node: '>=v18'}
 
-  '@commitlint/top-level@20.0.0':
-    resolution: {integrity: sha512-drXaPSP2EcopukrUXvUXmsQMu3Ey/FuJDc/5oiW4heoCfoE5BdLQyuc7veGeE3aoQaTVqZnh4D5WTWe2vefYKg==}
+  '@commitlint/top-level@20.4.3':
+    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
     engines: {node: '>=v18'}
 
-  '@commitlint/types@20.2.0':
-    resolution: {integrity: sha512-KTy0OqRDLR5y/zZMnizyx09z/rPlPC/zKhYgH8o/q6PuAjoQAKlRfY4zzv0M64yybQ//6//4H1n14pxaLZfUnA==}
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
     engines: {node: '>=v18'}
 
-  '@csstools/color-helpers@5.1.0':
-    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
-    engines: {node: '>=18'}
-
-  '@csstools/css-calc@2.1.4':
-    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+  '@conventional-changelog/git-client@2.7.0':
+    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
 
-  '@csstools/css-color-parser@3.1.0':
-    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
-    engines: {node: '>=18'}
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-parser-algorithms@3.0.5':
-    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
-    engines: {node: '>=18'}
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.22':
-    resolution: {integrity: sha512-qBcx6zYlhleiFfdtzkRgwNC7VVoAwfK76Vmsw5t+PbvtdknO9StgRk7ROvq9so1iqbdW4uLIDAsXRsTfUrIoOw==}
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
+    os:
+    - darwin
+    cpu:
+    - arm64
 
-  '@csstools/css-tokenizer@3.0.4':
-    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
+    os:
+    - linux
+    cpu:
+    - arm64
 
-  '@emnapi/runtime@1.7.1':
-    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
-
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
+    os:
+    - linux
+    cpu:
+    - x64
 
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
+    os:
+    - win32
+    cpu:
+    - arm64
 
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
+    os:
+    - win32
+    cpu:
+    - x64
 
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@exodus/bytes@1.8.0':
-    resolution: {integrity: sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==}
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@exodus/crypto': ^1.0.0-rc.4
+      '@noble/hashes': ^1.8.0 || ^2.0.0
     peerDependenciesMeta:
-      '@exodus/crypto':
+      '@noble/hashes':
         optional: true
 
   '@gitbeaker/core@38.12.1':
@@ -878,8 +2341,8 @@ packages:
     resolution: {integrity: sha512-9KMSDtJ/sIov+5pcH+CAfiJXSiuYgN0KLKQFg0HHWR2DwcjGYkcbmhoZcWsaOWOqq4kihN1l7wX91UoRxxKKTQ==}
     engines: {node: '>=18.0.0'}
 
-  '@grpc/grpc-js@1.14.0':
-    resolution: {integrity: sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.7.15':
@@ -887,8 +2350,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@grpc/proto-loader@0.8.0':
-    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -907,170 +2370,124 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1094,6 +2511,30 @@ packages:
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -1103,133 +2544,89 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+      zod: {}
 
-  '@mongodb-js/saslprep@1.4.6':
-    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
-
-  '@napi-rs/nice-android-arm-eabi@1.1.1':
-    resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [android]
-
-  '@napi-rs/nice-android-arm64@1.1.1':
-    resolution: {integrity: sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
 
   '@napi-rs/nice-darwin-arm64@1.1.1':
     resolution: {integrity: sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/nice-darwin-x64@1.1.1':
-    resolution: {integrity: sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/nice-freebsd-x64@1.1.1':
-    resolution: {integrity: sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@napi-rs/nice-linux-arm-gnueabihf@1.1.1':
-    resolution: {integrity: sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@napi-rs/nice-linux-arm64-gnu@1.1.1':
     resolution: {integrity: sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
-    resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
-    engines: {node: '>= 10'}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
-    resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/nice-linux-s390x-gnu@1.1.1':
-    resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
-    engines: {node: '>= 10'}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@napi-rs/nice-openharmony-arm64@1.1.1':
-    resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [openharmony]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@napi-rs/nice-win32-arm64-msvc@1.1.1':
     resolution: {integrity: sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/nice-win32-ia32-msvc@1.1.1':
-    resolution: {integrity: sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@napi-rs/nice-win32-x64-msvc@1.1.1':
     resolution: {integrity: sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@napi-rs/nice@1.1.1':
     resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
     engines: {node: '>= 10'}
 
-  '@noble/ciphers@2.1.1':
-    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@noble/hashes@2.0.1':
-    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
   '@octokit/auth-token@2.5.0':
@@ -1246,8 +2643,8 @@ packages:
     resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
     engines: {node: '>= 20'}
 
-  '@octokit/endpoint@11.0.2':
-    resolution: {integrity: sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
     engines: {node: '>= 20'}
 
   '@octokit/endpoint@6.0.12':
@@ -1290,8 +2687,8 @@ packages:
     peerDependencies:
       '@octokit/core': '>=3'
 
-  '@octokit/plugin-retry@8.0.3':
-    resolution: {integrity: sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==}
+  '@octokit/plugin-retry@8.1.0':
+    resolution: {integrity: sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=7'
@@ -1309,8 +2706,8 @@ packages:
     resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.7':
-    resolution: {integrity: sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==}
+  '@octokit/request@10.0.9':
+    resolution: {integrity: sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==}
     engines: {node: '>= 20'}
 
   '@octokit/request@5.6.3':
@@ -1332,18 +2729,24 @@ packages:
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/context-async-hooks@2.2.0':
-    resolution: {integrity: sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==}
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/core@2.2.0':
     resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1486,24 +2889,24 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/redis-common@0.38.2':
-    resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
+  '@opentelemetry/redis-common@0.38.3':
+    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
     engines: {node: ^18.19.0 || >=20.6.0}
 
-  '@opentelemetry/resources@2.2.0':
-    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.2.0':
-    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/semantic-conventions@1.38.0':
-    resolution: {integrity: sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==}
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
   '@opentelemetry/sql-common@0.41.2':
@@ -1512,41 +2915,44 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@paralleldrive/cuid2@2.2.2':
-    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
-  '@peculiar/asn1-android@2.6.0':
-    resolution: {integrity: sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==}
+  '@peculiar/asn1-android@2.7.0':
+    resolution: {integrity: sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==}
 
-  '@peculiar/asn1-cms@2.6.1':
-    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
+  '@peculiar/asn1-cms@2.7.0':
+    resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
 
-  '@peculiar/asn1-csr@2.6.1':
-    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
+  '@peculiar/asn1-csr@2.7.0':
+    resolution: {integrity: sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==}
 
-  '@peculiar/asn1-ecc@2.6.1':
-    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
+  '@peculiar/asn1-ecc@2.7.0':
+    resolution: {integrity: sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==}
 
-  '@peculiar/asn1-pfx@2.6.1':
-    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
+  '@peculiar/asn1-pfx@2.7.0':
+    resolution: {integrity: sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==}
 
-  '@peculiar/asn1-pkcs8@2.6.1':
-    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
+  '@peculiar/asn1-pkcs8@2.7.0':
+    resolution: {integrity: sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==}
 
-  '@peculiar/asn1-pkcs9@2.6.1':
-    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
+  '@peculiar/asn1-pkcs9@2.7.0':
+    resolution: {integrity: sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==}
 
-  '@peculiar/asn1-rsa@2.6.1':
-    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
+  '@peculiar/asn1-rsa@2.7.0':
+    resolution: {integrity: sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==}
 
-  '@peculiar/asn1-schema@2.6.0':
-    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+  '@peculiar/asn1-schema@2.7.0':
+    resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
 
-  '@peculiar/asn1-x509-attr@2.6.1':
-    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
+  '@peculiar/asn1-x509-attr@2.7.0':
+    resolution: {integrity: sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==}
 
-  '@peculiar/asn1-x509@2.6.1':
-    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
+  '@peculiar/asn1-x509@2.7.0':
+    resolution: {integrity: sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
 
   '@peculiar/x509@1.14.3':
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
@@ -1594,8 +3000,8 @@ packages:
     resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
     engines: {node: '>=12.22.0'}
 
-  '@pnpm/npm-conf@2.3.1':
-    resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
+  '@pnpm/npm-conf@3.0.2':
+    resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
   '@polka/url@1.0.0-next.29':
@@ -1612,20 +3018,20 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -1633,129 +3039,72 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
-    resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
-    cpu: [arm]
-    os: [android]
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    os:
+    - darwin
+    cpu:
+    - arm64
 
-  '@rollup/rollup-android-arm64@4.52.5':
-    resolution: {integrity: sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==}
-    cpu: [arm64]
-    os: [android]
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
-    resolution: {integrity: sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==}
-    cpu: [arm64]
-    os: [darwin]
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
-  '@rollup/rollup-darwin-x64@4.52.5':
-    resolution: {integrity: sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==}
-    cpu: [x64]
-    os: [darwin]
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
-    resolution: {integrity: sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==}
-    cpu: [arm64]
-    os: [freebsd]
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
-  '@rollup/rollup-freebsd-x64@4.52.5':
-    resolution: {integrity: sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==}
-    cpu: [x64]
-    os: [freebsd]
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    os:
+    - win32
+    cpu:
+    - arm64
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
-    resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    os:
+    - win32
+    cpu:
+    - x64
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
-    resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
-    resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
-    resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
-    resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
-    resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
-    resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.52.5':
-    resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
-    resolution: {integrity: sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    resolution: {integrity: sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
-    resolution: {integrity: sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==}
-    cpu: [x64]
-    os: [win32]
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -1807,8 +3156,8 @@ packages:
     peerDependencies:
       semantic-release: '>=20.1.0'
 
-  '@semantic-release/release-notes-generator@14.1.0':
-    resolution: {integrity: sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==}
+  '@semantic-release/release-notes-generator@14.1.1':
+    resolution: {integrity: sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==}
     engines: {node: '>=20.8.1'}
     peerDependencies:
       semantic-release: '>=20.1.0'
@@ -1829,67 +3178,62 @@ packages:
     resolution: {integrity: sha512-KKmLUgIaLRM0VjrMA1ByQTawZyRDYSkG2evvEOVpEtR9F0sumidAQdi7UY71QEKE1RYe/Jcp/3WoaqsMh8tbnQ==}
     engines: {node: '>=18'}
 
-  '@sentry/babel-plugin-component-annotate@4.6.1':
-    resolution: {integrity: sha512-aSIk0vgBqv7PhX6/Eov+vlI4puCE0bRXzUG5HdCsHBpAfeMkI8Hva6kSOusnzKqs8bf04hU7s3Sf0XxGTj/1AA==}
+  '@sentry/babel-plugin-component-annotate@4.9.1':
+    resolution: {integrity: sha512-0gEoi2Lb54MFYPOmdTfxlNKxI7kCOvNV7gP8lxMXJ7nCazF5OqOOZIVshfWjDLrc0QrSV6XdVvwPV9GDn4wBMg==}
     engines: {node: '>= 14'}
 
   '@sentry/browser@10.32.1':
     resolution: {integrity: sha512-NPNCXTZ05ZGTFyJdKNqjykpFm+urem0ebosILQiw3C4BxNVNGH4vfYZexyl6prRhmg91oB6GjVNiVDuJiap1gg==}
     engines: {node: '>=18'}
 
-  '@sentry/bundler-plugin-core@4.6.1':
-    resolution: {integrity: sha512-WPeRbnMXm927m4Kr69NTArPfI+p5/34FHftdCRI3LFPMyhZDzz6J3wLy4hzaVUgmMf10eLzmq2HGEMvpQmdynA==}
+  '@sentry/bundler-plugin-core@4.9.1':
+    resolution: {integrity: sha512-moii+w7N8k8WdvkX7qCDY9iRBlhgHlhTHTUQwF2FNMhBHuqlNpVcSJJqJMjFUQcjYMBDrZgxhfKV18bt5ixwlQ==}
     engines: {node: '>= 14'}
 
-  '@sentry/cli-darwin@2.58.4':
-    resolution: {integrity: sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==}
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
     engines: {node: '>=10'}
-    os: [darwin]
+    os:
+    - darwin
 
-  '@sentry/cli-linux-arm64@2.58.4':
-    resolution: {integrity: sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==}
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
     engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux, freebsd, android]
+    os:
+    - linux
+    - freebsd
+    - android
+    cpu:
+    - arm64
 
-  '@sentry/cli-linux-arm@2.58.4':
-    resolution: {integrity: sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==}
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
     engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux, freebsd, android]
+    os:
+    - linux
+    - freebsd
+    - android
+    cpu:
+    - x64
 
-  '@sentry/cli-linux-i686@2.58.4':
-    resolution: {integrity: sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==}
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
     engines: {node: '>=10'}
-    cpu: [x86, ia32]
-    os: [linux, freebsd, android]
+    os:
+    - win32
+    cpu:
+    - arm64
 
-  '@sentry/cli-linux-x64@2.58.4':
-    resolution: {integrity: sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==}
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
     engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux, freebsd, android]
+    os:
+    - win32
+    cpu:
+    - x64
 
-  '@sentry/cli-win32-arm64@2.58.4':
-    resolution: {integrity: sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@sentry/cli-win32-i686@2.58.4':
-    resolution: {integrity: sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==}
-    engines: {node: '>=10'}
-    cpu: [x86, ia32]
-    os: [win32]
-
-  '@sentry/cli-win32-x64@2.58.4':
-    resolution: {integrity: sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@sentry/cli@2.58.4':
-    resolution: {integrity: sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==}
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -1948,9 +3292,17 @@ packages:
       vite:
         optional: true
 
-  '@sentry/vite-plugin@4.6.1':
-    resolution: {integrity: sha512-Qvys1y3o8/bfL3ikrHnJS9zxdjt0z3POshdBl3967UcflrTqBmnGNkcVk53SlmtJWIfh85fgmrLvGYwZ2YiqNg==}
+  '@sentry/vite-plugin@4.9.1':
+    resolution: {integrity: sha512-Tlyg2cyFYp/icX58GWvfpvZr9NLdLs2/xyFVyS8pQ0faZWmoXic3FMzoXYHV1gsdMbL1Yy5WQvGJy8j1rS8LGA==}
     engines: {node: '>= 14'}
+
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
 
   '@simplewebauthn/browser@13.3.0':
     resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
@@ -1970,8 +3322,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@sveltejs/acorn-typescript@1.0.8':
-    resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -1993,8 +3345,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.1':
-    resolution: {integrity: sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA==}
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
+    resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
@@ -2011,87 +3363,69 @@ packages:
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
 
-  '@tailwindcss/oxide-android-arm64@4.1.18':
-    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
   '@tailwindcss/oxide-darwin-arm64@4.1.18':
     resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-darwin-x64@4.1.18':
-    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-freebsd-x64@4.1.18':
-    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
-    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
     resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
-    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-    bundledDependencies:
-      - '@napi-rs/wasm-runtime'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@tybys/wasm-util'
-      - '@emnapi/wasi-threads'
-      - tslib
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
     resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
     resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
     engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@tailwindcss/oxide@4.1.18':
     resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
@@ -2126,8 +3460,8 @@ packages:
       vitest:
         optional: true
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
   '@types/aria-query@5.0.4':
@@ -2141,9 +3475,6 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
-  '@types/conventional-commits-parser@5.0.1':
-    resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -2256,6 +3587,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -2264,6 +3598,15 @@ packages:
 
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -2297,7 +3640,6 @@ packages:
 
   '@types/sharp@0.32.0':
     resolution: {integrity: sha512-OOi3kL+FZDnPhVzsfD37J88FNeZh6gQsGcLc95NbeURRGvmSjeXiDcyWzF2o3yh/gQAUn2uhh/e+CPCa5nwAxw==}
-    deprecated: This is a stub types definition. sharp provides its own type definitions, so you do not need this installed.
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -2308,8 +3650,8 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
-  '@types/superagent@8.1.9':
-    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+  '@types/superagent@8.1.10':
+    resolution: {integrity: sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==}
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
@@ -2355,10 +3697,6 @@ packages:
   '@vitest/utils@4.0.16':
     resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
 
-  JSONStream@1.3.5:
-    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
-    hasBin: true
-
   a-sync-waterfall@1.0.1:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
 
@@ -2375,8 +3713,8 @@ packages:
     peerDependencies:
       acorn: ^8
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2404,11 +3742,11 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  ansi-escapes@7.2.0:
-    resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
@@ -2481,8 +3819,8 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
-  asn1js@3.0.7:
-    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
@@ -2492,6 +3830,14 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  async-generator-function@1.0.0:
+    resolution: {integrity: sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==}
+    engines: {node: '>= 0.4'}
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
@@ -2520,8 +3866,8 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  b4a@1.7.3:
-    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
       react-native-b4a: '*'
     peerDependenciesMeta:
@@ -2531,16 +3877,20 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  bare-events@2.8.1:
-    resolution: {integrity: sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.3:
+    resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
     peerDependencies:
       bare-abort-controller: '*'
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
 
-  bare-fs@4.5.0:
-    resolution: {integrity: sha512-GljgCjeupKZJNetTqxKaQArLK10vpmK28or0+RwWjEl5Rk+/xG3wkpmkv+WrcBm3q1BwHKlnhXzR8O37kcvkXQ==}
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
     engines: {bare: '>=1.16.0'}
     peerDependencies:
       bare-buffer: '*'
@@ -2548,32 +3898,36 @@ packages:
       bare-buffer:
         optional: true
 
-  bare-os@3.6.2:
-    resolution: {integrity: sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==}
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
     engines: {bare: '>=1.14.0'}
 
   bare-path@3.0.0:
     resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
 
-  bare-stream@2.7.0:
-    resolution: {integrity: sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==}
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
     peerDependencies:
+      bare-abort-controller: '*'
       bare-buffer: '*'
       bare-events: '*'
     peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
       bare-buffer:
         optional: true
       bare-events:
         optional: true
 
-  bare-url@2.3.1:
-    resolution: {integrity: sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==}
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.9.11:
-    resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   bcrypt-pbkdf@1.0.2:
@@ -2676,15 +4030,19 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2705,8 +4063,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  buildcheck@0.0.6:
-    resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
     engines: {node: '>=10.0.0'}
 
   byline@5.0.0:
@@ -2731,10 +4089,9 @@ packages:
 
   camel-case@5.0.0:
     resolution: {integrity: sha512-AKcwhlfnTqKiYjkjZ0CSRjIGgUDEZQHqBBkdwrSxFPzRQDriAUxXNn+rFN7Qvb5nkPg6Hxncp44G1/zz88M5xw==}
-    deprecated: Use `change-case`
 
-  caniuse-lite@1.0.30001761:
-    resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -2767,8 +4124,8 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -2854,12 +4211,12 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
-  conventional-changelog-angular@7.0.0:
-    resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
-    engines: {node: '>=16'}
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
-  conventional-changelog-angular@8.1.0:
-    resolution: {integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==}
+  conventional-changelog-angular@8.3.1:
+    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
 
   conventional-changelog-conventionalcommits@7.0.2:
@@ -2870,8 +4227,8 @@ packages:
     resolution: {integrity: sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==}
     engines: {node: '>=18'}
 
-  conventional-changelog-writer@8.2.0:
-    resolution: {integrity: sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==}
+  conventional-changelog-writer@8.4.0:
+    resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2879,13 +4236,8 @@ packages:
     resolution: {integrity: sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==}
     engines: {node: '>=18'}
 
-  conventional-commits-parser@5.0.0:
-    resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  conventional-commits-parser@6.2.1:
-    resolution: {integrity: sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==}
+  conventional-commits-parser@6.4.0:
+    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2921,16 +4273,16 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
-  cosmiconfig-typescript-loader@6.1.0:
-    resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
     peerDependencies:
       '@types/node': '*'
       cosmiconfig: '>=9'
       typescript: '>=5'
 
-  cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -2951,6 +4303,9 @@ packages:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2959,12 +4314,12 @@ packages:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
 
-  css-tree@3.1.0:
-    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  cssstyle@5.3.5:
-    resolution: {integrity: sha512-GlsEptulso7Jg0VaOZ8BXQi3AkYM5BOJKEO/rjMidSCq70FkIC5y0eawrCXeYzxgt3OCf4Ls+eoxN+/05vN0Ag==}
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
     engines: {node: '>=20'}
 
   d3-array@3.2.4:
@@ -3099,22 +4454,17 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  dargs@8.1.0:
-    resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
-    engines: {node: '>=12'}
-
-  data-urls@6.0.0:
-    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    engines: {node: '*'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -3130,11 +4480,11 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  delaunator@5.0.1:
-    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3155,11 +4505,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  devalue@5.3.2:
-    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
-
-  devalue@5.6.1:
-    resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -3168,23 +4515,23 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  docker-compose@1.3.0:
-    resolution: {integrity: sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g==}
+  docker-compose@1.4.2:
+    resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
     engines: {node: '>= 6.0.0'}
 
-  docker-modem@5.0.6:
-    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
 
-  dockerode@4.0.9:
-    resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
     engines: {node: '>= 8.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.4.5:
+    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -3210,8 +4557,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.267:
-    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+  electron-to-chromium@1.5.361:
+    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3229,13 +4576,17 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.18.4:
-    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+  enhanced-resolve@5.22.0:
+    resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-ci@11.2.0:
     resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
@@ -3263,16 +4614,19 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3299,8 +4653,13 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  esrap@2.2.1:
-    resolution: {integrity: sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==}
+  esrap@2.2.9:
+    resolution: {integrity: sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -3320,8 +4679,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -3344,12 +4703,12 @@ packages:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -3365,8 +4724,8 @@ packages:
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
-  fast-copy@4.0.2:
-    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3380,8 +4739,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3420,10 +4779,6 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  find-up@7.0.0:
-    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
-    engines: {node: '>=18'}
-
   find-versions@6.0.0:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
@@ -3432,8 +4787,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -3452,13 +4807,11 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+    engines: {node: '*'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
-
-  from2@2.3.0:
-    resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -3467,19 +4820,21 @@ packages:
     resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
     engines: {node: '>=0.10.0'}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
+    os:
+    - darwin
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
+    os:
+    - darwin
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3487,6 +4842,10 @@ packages:
   function-timeout@1.0.2:
     resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
     engines: {node: '>=18'}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3496,12 +4855,12 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+  get-intrinsic@1.3.1:
+    resolution: {integrity: sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==}
     engines: {node: '>= 0.4'}
 
-  get-port@7.1.0:
-    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
     engines: {node: '>=16'}
 
   get-proto@1.0.1:
@@ -3516,10 +4875,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@7.0.1:
-    resolution: {integrity: sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==}
-    engines: {node: '>=16'}
-
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
@@ -3528,8 +4883,8 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-config-path@1.0.1:
     resolution: {integrity: sha512-KcJ2dlrrP5DbBnYIZ2nlikALfRhKzNSX0stvv3ImJ+fvC4hXKoV+U+74SV0upg+jlQZbrtQzc0bu6/Zh+7aQbg==}
@@ -3538,10 +4893,9 @@ packages:
   git-log-parser@1.2.1:
     resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
 
-  git-raw-commits@4.0.0:
-    resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
-    engines: {node: '>=16'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+  git-raw-commits@5.0.1:
+    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   glob-parent@5.1.2:
@@ -3550,24 +4904,16 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  global-directory@4.0.1:
-    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
-    engines: {node: '>=18'}
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   globalyzer@0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
@@ -3585,8 +4931,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -3610,8 +4956,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   help-me@5.0.0:
@@ -3619,6 +4965,7 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    engines: {node: '*'}
 
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -3628,8 +4975,8 @@ packages:
     resolution: {integrity: sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
   hook-std@3.0.0:
@@ -3718,8 +5065,8 @@ packages:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
 
-  import-in-the-middle@2.0.1:
-    resolution: {integrity: sha512-bruMpJ7xz+9jwGzrwEhWgvRrlKRYCRDBrfU+ur3FcasYXLJDxTruJ//8g2Noj+QFyRBeqbpj8Bhn4Fbw6HjvhA==}
+  import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -3742,16 +5089,12 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
-
-  into-stream@7.0.0:
-    resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
   io-ts-reporters@2.0.1:
@@ -3765,8 +5108,8 @@ packages:
     peerDependencies:
       fp-ts: ^2.5.0
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3833,10 +5176,6 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
-  is-text-path@2.0.0:
-    resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
-    engines: {node: '>=8'}
-
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -3851,15 +5190,15 @@ packages:
     resolution: {integrity: sha512-a9+LQqylQCU8f1zmsYmg2tfrbdY2YS/Hc+xntcq/mDI2MY3Q108nq8K23BWDIg6YGC5JsUMC15fj2ZMqCzt/+A==}
     engines: {node: '>=20.19.5'}
 
-  issue-parser@7.0.1:
-    resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
+  issue-parser@7.0.2:
+    resolution: {integrity: sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==}
     engines: {node: ^18.17 || >=20.6.1}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.1:
-    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
 
   java-properties@1.0.2:
@@ -3870,8 +5209,12 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.2.1:
-    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -3880,8 +5223,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsdom@27.3.0:
@@ -3919,17 +5262,16 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jsonparse@1.3.1:
-    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
-    engines: {'0': node >= 0.2.0}
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
@@ -3949,8 +5291,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  kysely@0.28.11:
-    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
   lazystream@1.0.1:
@@ -3963,75 +5305,69 @@ packages:
   libphonenumber-js@1.12.33:
     resolution: {integrity: sha512-r9kw4OA6oDO4dPXkOrXTkArQAafIKAU71hChInV4FxZ69dxCfbwQGDPzqR5/vea94wU705/3AZroEbSoeVWrQw==}
 
-  lightningcss-android-arm64@1.30.2:
-    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.30.2:
-    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  lightningcss-freebsd-x64@1.30.2:
-    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-linux-arm-gnueabihf@1.30.2:
-    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   lightningcss-win32-x64-msvc@1.30.2:
     resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
@@ -4039,6 +5375,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -4055,12 +5394,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  locate-path@7.2.0:
-    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  lodash-es@4.17.22:
-    resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -4095,9 +5430,6 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
-  lodash.kebabcase@4.1.1:
-    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
-
   lodash.keys@4.2.0:
     resolution: {integrity: sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==}
 
@@ -4110,17 +5442,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash.mergewith@4.6.2:
-    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
-
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-
-  lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-
-  lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -4128,11 +5451,8 @@ packages:
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
 
-  lodash.upperfirst@4.3.1:
-    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4142,6 +5462,10 @@ packages:
 
   lru-cache@11.2.4:
     resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -4162,9 +5486,13 @@ packages:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
 
-  make-asynchronous@1.0.1:
-    resolution: {integrity: sha512-T9BPOmEOhp6SmV25SwLVcHK4E6JyG/coH3C6F1NjNXSziv/fd4GmsqMk8YR6qpPOswfaOCApSNkZv6fxoaYFcQ==}
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
+
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
 
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
@@ -4181,8 +5509,11 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdn-data@2.12.2:
-    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -4193,10 +5524,6 @@ packages:
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
-
-  meow@12.1.1:
-    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
-    engines: {node: '>=16.10'}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
@@ -4251,27 +5578,23 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
-
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
@@ -4293,8 +5616,8 @@ packages:
     resolution: {integrity: sha512-s6BdnqNoEYfViPJgkH85X5Nw5NpzxN8hoflKLweNa7vBxt2V7kaS06d74pAtqDxde8fn4r9h4dNdLiFGoNV0KA==}
     engines: {node: '>= 0.6.0'}
 
-  mongodb@7.1.0:
-    resolution: {integrity: sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==}
+  mongodb@7.2.0:
+    resolution: {integrity: sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.806.0
@@ -4334,16 +5657,16 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nan@2.23.0:
-    resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
+  nan@2.27.0:
+    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanostores@1.1.1:
-    resolution: {integrity: sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==}
+  nanostores@1.3.0:
+    resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
   negotiator@1.0.0:
@@ -4358,10 +5681,9 @@ packages:
 
   no-case@4.0.0:
     resolution: {integrity: sha512-WmS3EUGw+vXHlTgiUPi3NzbZNwH6+uGX0QLGgqG+aFSJ5rkX/Ee0nuwHBJfZTfQwwR8lGO819NEIwQ7CGhkdEQ==}
-    deprecated: Use `change-case`
 
-  node-addon-api@8.5.0:
-    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+  node-addon-api@8.8.0:
+    resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
     engines: {node: ^18 || ^20 || >= 21}
 
   node-cleanup@2.1.2:
@@ -4399,8 +5721,9 @@ packages:
       '@types/pg':
         optional: true
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -4410,8 +5733,8 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  normalize-url@8.1.0:
-    resolution: {integrity: sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==}
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
     engines: {node: '>=14.16'}
 
   npm-run-path@4.0.1:
@@ -4426,79 +5749,10 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  npm@10.9.4:
-    resolution: {integrity: sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==}
+  npm@10.9.8:
+    resolution: {integrity: sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
 
   nunjucks@3.2.4:
     resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
@@ -4555,10 +5809,6 @@ packages:
     resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
     engines: {node: '>=18'}
 
-  p-is-promise@3.0.0:
-    resolution: {integrity: sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==}
-    engines: {node: '>=8'}
-
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
@@ -4571,10 +5821,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@4.0.0:
-    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -4582,10 +5828,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-locate@6.0.0:
-    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
@@ -4625,8 +5867,8 @@ packages:
     resolution: {integrity: sha512-Js7ueMZOVSZ3tP8C7E3KZiHv6QQl7lnJ+OkbxoaFazzSa2KyEHqApfGbU3XboUgUnq4ZuUmskUpYKTNx01fm5A==}
     engines: {node: '>=6'}
 
-  parse-github-url@1.0.3:
-    resolution: {integrity: sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==}
+  parse-github-url@1.0.4:
+    resolution: {integrity: sha512-CEtCOt55fHmd6DpBc/N7H5NC4vJpcquhzzs9Iw2mRj8bVxo1O5TQI5MXKOMO7+yBOqD+5dKCCRK4Kj1KskZc6Q==}
     engines: {node: '>= 0.10'}
     hasBin: true
 
@@ -4662,8 +5904,8 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
-  parse5@8.0.0:
-    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -4671,7 +5913,6 @@ packages:
 
   pascal-case@4.0.0:
     resolution: {integrity: sha512-DPrSBfN1ivlJ5WwTdcBfCfmOHZXjaeW+b8DMHXcUWiR8wmO92T6N8elBsJj/v3g+INObw8Zx/q6eFAjA1w071Q==}
-    deprecated: Use `change-case`
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -4680,10 +5921,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-exists@5.0.0:
-    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4697,9 +5934,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -4711,23 +5948,23 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pg-cloudflare@1.2.7:
-    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
 
-  pg-connection-string@2.9.1:
-    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-pool@3.10.1:
-    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
     peerDependencies:
       pg: '>=8.0'
 
-  pg-protocol@1.10.3:
-    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -4748,12 +5985,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@3.0.0:
@@ -4773,8 +6010,8 @@ packages:
     resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
     hasBin: true
 
-  pino-std-serializers@7.0.0:
-    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
   pino@10.1.0:
     resolution: {integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==}
@@ -4815,8 +6052,8 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
-  postgres-bytea@1.0.0:
-    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
 
   postgres-date@1.0.7:
@@ -4863,8 +6100,8 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -4874,8 +6111,12 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4888,12 +6129,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -4965,8 +6202,8 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  registry-auth-token@5.1.0:
-    resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
+  registry-auth-token@5.1.1:
+    resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
 
   require-directory@2.1.1:
@@ -4996,11 +6233,11 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
-  robust-predicates@3.0.2:
-    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
-  rollup@4.52.5:
-    resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -5055,8 +6292,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5068,11 +6305,11 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
-  set-cookie-parser@3.0.1:
-    resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -5089,8 +6326,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -5127,8 +6364,8 @@ packages:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
 
-  sonic-boom@4.2.0:
-    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   sorcery@1.0.0:
     resolution: {integrity: sha512-5ay9oJE+7sNmhzl3YNG18jEEEf4AOQCM/FAqR5wMmzqd1FtRorFbJXn3w3SKOhbiQaVgHM+Q1lszZspjri7bpA==}
@@ -5157,8 +6394,8 @@ packages:
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
-  spdx-license-ids@3.0.22:
-    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   split-ca@1.0.1:
     resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
@@ -5190,8 +6427,13 @@ packages:
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
 
-  streamx@2.23.0:
-    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
+  string-width-cjs@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    aliasOf: string-width
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5207,12 +6449,17 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  strip-ansi-cjs@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    aliasOf: strip-ansi
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom@3.0.0:
@@ -5239,12 +6486,15 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
     engines: {node: '>=18'}
 
-  superagent@10.2.3:
-    resolution: {integrity: sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==}
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
 
   supertest@7.1.4:
@@ -5301,40 +6551,39 @@ packages:
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
-  tar-fs@3.1.1:
-    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar-stream@3.1.7:
-    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
 
-  tempy@3.1.0:
-    resolution: {integrity: sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==}
+  tempy@3.2.0:
+    resolution: {integrity: sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==}
     engines: {node: '>=14.16'}
 
   testcontainers@11.10.0:
     resolution: {integrity: sha512-8hwK2EnrOZfrHPpDC7CPe03q7H8Vv8j3aXdcmFFyNV8dzpBzgZYmqyDtduJ8YQ5kbzj+A+jUXMQ6zI8B5U3z+g==}
 
-  text-decoder@1.2.3:
-    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
-
-  text-extensions@2.4.0:
-    resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
-    engines: {node: '>=8'}
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -5349,9 +6598,6 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
@@ -5365,27 +6611,27 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.16:
-    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+  tldts-core@7.1.0:
+    resolution: {integrity: sha512-Ou+YJ467tR700sk2mZBB1/uFah6LDeH/VKO0N4xfjFOXE0hJkZgiOgXj16gEi1wQ4L6334UTKjxF6gum8ftZzQ==}
 
-  tldts@7.0.16:
-    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+  tldts@7.1.0:
+    resolution: {integrity: sha512-Y+iRHtDrPOlNH9ZZpqpIogonv7jwSPHIt3Gpe+kRvYJlBaK+QGNXu+xooJY0QEmb62/ERo3GF3zCxRMbMtKEEA==}
     hasBin: true
 
   tmp@0.2.5:
@@ -5404,8 +6650,8 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  tough-cookie@6.0.0:
-    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
@@ -5466,14 +6712,17 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -5486,8 +6735,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.16.0:
-    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -5595,10 +6844,10 @@ packages:
       yaml:
         optional: true
 
-  vitefu@1.1.1:
-    resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -5637,12 +6886,15 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  web-worker@1.2.0:
-    resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5651,12 +6903,12 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webidl-conversions@8.0.0:
-    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  webpack-sources@3.3.3:
-    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.5.0:
@@ -5665,11 +6917,14 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
 
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
@@ -5695,6 +6950,11 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi-cjs@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    aliasOf: wrap-ansi
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -5706,8 +6966,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5739,8 +6999,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -5764,10 +7024,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yocto-queue@1.2.1:
-    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
-    engines: {node: '>=12.20'}
-
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
@@ -5787,12 +7043,12 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@acemir/cssom@0.9.30': {}
+  '@acemir/cssom@0.9.31': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -5803,8 +7059,6 @@ snapshots:
       '@apm-js-collab/code-transformer': 0.8.2
       debug: 4.4.3
       module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@ark/schema@0.56.0':
     dependencies:
@@ -5812,199 +7066,177 @@ snapshots:
 
   '@ark/util@0.56.0': {}
 
-  '@asamuzakjp/css-color@4.1.1':
+  '@asamuzakjp/css-color@4.1.2':
     dependencies:
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.4
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.0
 
-  '@asamuzakjp/dom-selector@6.7.6':
+  '@asamuzakjp/dom-selector@6.8.1':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.4
+      lru-cache: 11.5.0
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@babel/code-frame@7.27.1':
+  '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
+  '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.28.5':
+  '@babel/core@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
-  '@babel/generator@7.28.5':
+  '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.27.2':
+  '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.29.3
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/traverse': 7.29.0
 
   '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.28.4':
+  '@babel/helpers@7.29.2':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.26.9':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
-  '@babel/parser@7.28.5':
+  '@babel/parser@7.29.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
-  '@babel/runtime@7.28.4': {}
+  '@babel/runtime@7.29.2': {}
 
-  '@babel/template@7.27.2':
+  '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
-  '@babel/types@7.28.5':
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
   '@balena/dockerignore@1.0.2': {}
+  ? '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)'
 
-  '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)':
-    dependencies:
+  : dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.6)
-      jose: 6.2.1
-      kysely: 0.28.11
-      nanostores: 1.1.1
-      zod: 4.3.6
+      better-call: 1.3.2(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.28.17
+      nanostores: 1.3.0
+      zod: 4.4.3
+  ? '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)'
 
-  '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
+  ? '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(kysely@0.28.17)'
 
-  '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
-      kysely: 0.28.11
+      kysely: 0.28.17
+  ? '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)'
 
-  '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
+  ? '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(mongodb@7.2.0)'
 
-  '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
-      mongodb: 7.1.0
+      mongodb: 7.2.0
+  ? '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0)))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)'
 
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@simplewebauthn/browser': 13.3.0
-      '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
-      better-call: 1.3.2(zod@4.3.6)
-      nanostores: 1.1.1
-      zod: 4.3.6
-
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
-      better-call: 1.3.2(zod@4.3.6)
-      nanostores: 1.1.1
-      zod: 4.3.6
+      better-auth: 1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0))
+      better-call: 1.3.2(zod@4.4.3)
+      nanostores: 1.3.0
+      zod: 4.4.3
+  ? '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)'
 
-  '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
+  ? '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))'
 
-  '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -6015,7 +7247,6 @@ snapshots:
   '@biomejs/biome@2.3.10':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.3.10
-      '@biomejs/cli-darwin-x64': 2.3.10
       '@biomejs/cli-linux-arm64': 2.3.10
       '@biomejs/cli-linux-arm64-musl': 2.3.10
       '@biomejs/cli-linux-x64': 2.3.10
@@ -6023,259 +7254,257 @@ snapshots:
       '@biomejs/cli-win32-arm64': 2.3.10
       '@biomejs/cli-win32-x64': 2.3.10
 
-  '@biomejs/cli-darwin-arm64@2.3.10':
-    optional: true
+  '@biomejs/cli-darwin-arm64@2.3.10': {}
 
-  '@biomejs/cli-darwin-x64@2.3.10':
-    optional: true
+  '@biomejs/cli-linux-arm64-musl@2.3.10': {}
 
-  '@biomejs/cli-linux-arm64-musl@2.3.10':
-    optional: true
+  '@biomejs/cli-linux-arm64@2.3.10': {}
 
-  '@biomejs/cli-linux-arm64@2.3.10':
-    optional: true
+  '@biomejs/cli-linux-x64-musl@2.3.10': {}
 
-  '@biomejs/cli-linux-x64-musl@2.3.10':
-    optional: true
+  '@biomejs/cli-linux-x64@2.3.10': {}
 
-  '@biomejs/cli-linux-x64@2.3.10':
-    optional: true
+  '@biomejs/cli-win32-arm64@2.3.10': {}
 
-  '@biomejs/cli-win32-arm64@2.3.10':
-    optional: true
+  '@biomejs/cli-win32-x64@2.3.10': {}
 
-  '@biomejs/cli-win32-x64@2.3.10':
-    optional: true
-
-  '@colors/colors@1.5.0':
-    optional: true
-
-  '@commitlint/cli@20.2.0(typescript@5.9.3)':
+  '@codemirror/autocomplete@6.20.2':
     dependencies:
-      '@commitlint/format': 20.2.0
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.43.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@colors/colors@1.5.0': {}
+
+  '@commitlint/cli@20.2.0':
+    dependencies:
+      '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.2.0
-      '@commitlint/load': 20.2.0(@types/node@25.0.3)(typescript@5.9.3)
-      '@commitlint/read': 20.2.0
-      '@commitlint/types': 20.2.0
-      tinyexec: 1.0.2
+      '@commitlint/load': 20.2.0
+      '@commitlint/read': 20.5.0
+      '@commitlint/types': 20.5.0
+      tinyexec: 1.2.2
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - typescript
 
   '@commitlint/config-conventional@20.2.0':
     dependencies:
-      '@commitlint/types': 20.2.0
+      '@commitlint/types': 20.5.0
       conventional-changelog-conventionalcommits: 7.0.2
 
-  '@commitlint/config-validator@20.2.0':
+  '@commitlint/config-validator@20.5.0':
     dependencies:
-      '@commitlint/types': 20.2.0
-      ajv: 8.17.1
+      '@commitlint/types': 20.5.0
+      ajv: 8.20.0
 
-  '@commitlint/ensure@20.2.0':
+  '@commitlint/ensure@20.5.3':
     dependencies:
-      '@commitlint/types': 20.2.0
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      lodash.snakecase: 4.1.1
-      lodash.startcase: 4.4.0
-      lodash.upperfirst: 4.3.1
+      '@commitlint/types': 20.5.0
+      es-toolkit: 1.46.1
 
   '@commitlint/execute-rule@20.0.0': {}
 
-  '@commitlint/format@20.2.0':
+  '@commitlint/format@20.5.0':
     dependencies:
-      '@commitlint/types': 20.2.0
-      chalk: 5.6.2
+      '@commitlint/types': 20.5.0
+      picocolors: 1.1.1
 
-  '@commitlint/is-ignored@20.2.0':
+  '@commitlint/is-ignored@20.5.0':
     dependencies:
-      '@commitlint/types': 20.2.0
-      semver: 7.7.3
+      '@commitlint/types': 20.5.0
+      semver: 7.8.1
 
   '@commitlint/lint@20.2.0':
     dependencies:
-      '@commitlint/is-ignored': 20.2.0
-      '@commitlint/parse': 20.2.0
-      '@commitlint/rules': 20.2.0
-      '@commitlint/types': 20.2.0
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.3
+      '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.2.0(@types/node@25.0.3)(typescript@5.9.3)':
+  '@commitlint/load@20.2.0':
     dependencies:
-      '@commitlint/config-validator': 20.2.0
+      '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
-      '@commitlint/resolve-extends': 20.2.0
-      '@commitlint/types': 20.2.0
+      '@commitlint/resolve-extends': 20.5.3
+      '@commitlint/types': 20.5.0
       chalk: 5.6.2
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@25.0.3)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.0.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - typescript
 
-  '@commitlint/message@20.0.0': {}
+  '@commitlint/message@20.4.3': {}
 
-  '@commitlint/parse@20.2.0':
+  '@commitlint/parse@20.5.0':
     dependencies:
-      '@commitlint/types': 20.2.0
-      conventional-changelog-angular: 7.0.0
-      conventional-commits-parser: 5.0.0
+      '@commitlint/types': 20.5.0
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
 
-  '@commitlint/read@20.2.0':
+  '@commitlint/read@20.5.0':
     dependencies:
-      '@commitlint/top-level': 20.0.0
-      '@commitlint/types': 20.2.0
-      git-raw-commits: 4.0.0
+      '@commitlint/top-level': 20.4.3
+      '@commitlint/types': 20.5.0
+      git-raw-commits: 5.0.1
       minimist: 1.2.8
-      tinyexec: 1.0.2
+      tinyexec: 1.2.2
 
-  '@commitlint/resolve-extends@20.2.0':
+  '@commitlint/resolve-extends@20.5.3':
     dependencies:
-      '@commitlint/config-validator': 20.2.0
-      '@commitlint/types': 20.2.0
-      global-directory: 4.0.1
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
+      es-toolkit: 1.46.1
+      global-directory: 5.0.0
       import-meta-resolve: 4.2.0
-      lodash.mergewith: 4.6.2
       resolve-from: 5.0.0
 
-  '@commitlint/rules@20.2.0':
+  '@commitlint/rules@20.5.3':
     dependencies:
-      '@commitlint/ensure': 20.2.0
-      '@commitlint/message': 20.0.0
+      '@commitlint/ensure': 20.5.3
+      '@commitlint/message': 20.4.3
       '@commitlint/to-lines': 20.0.0
-      '@commitlint/types': 20.2.0
+      '@commitlint/types': 20.5.0
 
   '@commitlint/to-lines@20.0.0': {}
 
-  '@commitlint/top-level@20.0.0':
+  '@commitlint/top-level@20.4.3':
     dependencies:
-      find-up: 7.0.0
+      escalade: 3.2.0
 
-  '@commitlint/types@20.2.0':
+  '@commitlint/types@20.5.0':
     dependencies:
-      '@types/conventional-commits-parser': 5.0.1
-      chalk: 5.6.2
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
 
-  '@csstools/color-helpers@5.1.0': {}
-
-  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@conventional-changelog/git-client@2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)':
     dependencies:
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.4.0
+      semver: 7.8.1
 
-  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 5.1.0
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+  ? '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)'
 
-  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+  : dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.22': {}
-
-  '@csstools/css-tokenizer@3.0.4': {}
-
-  '@emnapi/runtime@1.7.1':
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
     dependencies:
-      tslib: 2.8.1
-    optional: true
+      css-tree: 3.2.1
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
+  '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/android-arm64@0.27.2':
-    optional: true
+  '@esbuild/darwin-arm64@0.27.7': {}
 
-  '@esbuild/android-arm@0.27.2':
-    optional: true
+  '@esbuild/linux-arm64@0.27.7': {}
 
-  '@esbuild/android-x64@0.27.2':
-    optional: true
+  '@esbuild/linux-x64@0.27.7': {}
 
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
+  '@esbuild/win32-arm64@0.27.7': {}
 
-  '@esbuild/darwin-x64@0.27.2':
-    optional: true
+  '@esbuild/win32-x64@0.27.7': {}
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
-    optional: true
-
-  '@exodus/bytes@1.8.0': {}
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    dependencies:
+      '@noble/hashes': 2.2.0
 
   '@gitbeaker/core@38.12.1':
     dependencies:
       '@gitbeaker/requester-utils': 38.12.1
-      qs: 6.15.1
+      qs: 6.15.2
       xcase: 2.0.1
 
   '@gitbeaker/requester-utils@38.12.1':
     dependencies:
-      qs: 6.15.1
+      qs: 6.15.2
       xcase: 2.0.1
 
   '@gitbeaker/rest@38.12.1':
@@ -6283,145 +7512,81 @@ snapshots:
       '@gitbeaker/core': 38.12.1
       '@gitbeaker/requester-utils': 38.12.1
 
-  '@grpc/grpc-js@1.14.0':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
-      '@grpc/proto-loader': 0.8.0
+      '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.1
       yargs: 17.7.2
 
-  '@grpc/proto-loader@0.8.0':
+  '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.1
       yargs: 17.7.2
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.14)':
+  '@hono/node-server@1.19.14(hono@4.12.22)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.22
 
   '@hono/node-server@1.19.7(hono@4.11.1)':
     dependencies:
       hono: 4.11.1
 
-  '@img/colour@1.0.0': {}
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
+  '@img/sharp-libvips-darwin-arm64@1.2.4': {}
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
+  '@img/sharp-libvips-linux-arm64@1.2.4': {}
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
+  '@img/sharp-libvips-linux-x64@1.2.4': {}
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4': {}
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4': {}
 
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
 
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
 
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.7.1
-    optional: true
+  '@img/sharp-win32-arm64@0.34.5': {}
 
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
+  '@img/sharp-win32-x64@0.34.5': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: strip-ansi@6.0.1
+      string-width-cjs: 4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: 6.0.1
       wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
+      wrap-ansi-cjs: 7.0.0
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6446,109 +7611,94 @@ snapshots:
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@marijn/find-cluster-break@1.0.2': {}
+
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.14
-      jose: 6.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.22
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
 
-  '@mongodb-js/saslprep@1.4.6':
+  '@mongodb-js/saslprep@1.4.11':
     dependencies:
       sparse-bitfield: 3.0.3
 
-  '@napi-rs/nice-android-arm-eabi@1.1.1':
-    optional: true
+  '@napi-rs/nice-darwin-arm64@1.1.1': {}
 
-  '@napi-rs/nice-android-arm64@1.1.1':
-    optional: true
+  '@napi-rs/nice-linux-arm64-gnu@1.1.1': {}
 
-  '@napi-rs/nice-darwin-arm64@1.1.1':
-    optional: true
+  '@napi-rs/nice-linux-arm64-musl@1.1.1': {}
 
-  '@napi-rs/nice-darwin-x64@1.1.1':
-    optional: true
+  '@napi-rs/nice-linux-x64-gnu@1.1.1': {}
 
-  '@napi-rs/nice-freebsd-x64@1.1.1':
-    optional: true
+  '@napi-rs/nice-linux-x64-musl@1.1.1': {}
 
-  '@napi-rs/nice-linux-arm-gnueabihf@1.1.1':
-    optional: true
+  '@napi-rs/nice-win32-arm64-msvc@1.1.1': {}
 
-  '@napi-rs/nice-linux-arm64-gnu@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-linux-arm64-musl@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-linux-s390x-gnu@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-linux-x64-gnu@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-linux-x64-musl@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-openharmony-arm64@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-win32-arm64-msvc@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-win32-ia32-msvc@1.1.1':
-    optional: true
-
-  '@napi-rs/nice-win32-x64-msvc@1.1.1':
-    optional: true
+  '@napi-rs/nice-win32-x64-msvc@1.1.1': {}
 
   '@napi-rs/nice@1.1.1':
     optionalDependencies:
-      '@napi-rs/nice-android-arm-eabi': 1.1.1
-      '@napi-rs/nice-android-arm64': 1.1.1
       '@napi-rs/nice-darwin-arm64': 1.1.1
-      '@napi-rs/nice-darwin-x64': 1.1.1
-      '@napi-rs/nice-freebsd-x64': 1.1.1
-      '@napi-rs/nice-linux-arm-gnueabihf': 1.1.1
       '@napi-rs/nice-linux-arm64-gnu': 1.1.1
       '@napi-rs/nice-linux-arm64-musl': 1.1.1
-      '@napi-rs/nice-linux-ppc64-gnu': 1.1.1
-      '@napi-rs/nice-linux-riscv64-gnu': 1.1.1
-      '@napi-rs/nice-linux-s390x-gnu': 1.1.1
       '@napi-rs/nice-linux-x64-gnu': 1.1.1
       '@napi-rs/nice-linux-x64-musl': 1.1.1
-      '@napi-rs/nice-openharmony-arm64': 1.1.1
       '@napi-rs/nice-win32-arm64-msvc': 1.1.1
-      '@napi-rs/nice-win32-ia32-msvc': 1.1.1
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
-    optional: true
 
-  '@noble/ciphers@2.1.1': {}
+  '@noble/ciphers@2.2.0': {}
 
   '@noble/hashes@1.8.0': {}
 
-  '@noble/hashes@2.0.1': {}
+  '@noble/hashes@2.2.0': {}
 
   '@octokit/auth-token@2.5.0':
     dependencies:
@@ -6565,20 +7715,18 @@ snapshots:
       '@octokit/types': 6.41.0
       before-after-hook: 2.2.3
       universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
 
   '@octokit/core@7.0.6':
     dependencies:
       '@octokit/auth-token': 6.0.0
       '@octokit/graphql': 9.0.3
-      '@octokit/request': 10.0.7
+      '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       before-after-hook: 4.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@11.0.2':
+  '@octokit/endpoint@11.0.3':
     dependencies:
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
@@ -6594,12 +7742,10 @@ snapshots:
       '@octokit/request': 5.6.3
       '@octokit/types': 6.41.0
       universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
 
   '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 10.0.7
+      '@octokit/request': 10.0.9
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
@@ -6629,7 +7775,7 @@ snapshots:
       '@octokit/types': 6.41.0
       deprecation: 2.3.1
 
-  '@octokit/plugin-retry@8.0.3(@octokit/core@7.0.6)':
+  '@octokit/plugin-retry@8.1.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/request-error': 7.1.0
@@ -6652,12 +7798,14 @@ snapshots:
     dependencies:
       '@octokit/types': 16.0.0
 
-  '@octokit/request@10.0.7':
+  '@octokit/request@10.0.9':
     dependencies:
-      '@octokit/endpoint': 11.0.2
+      '@octokit/endpoint': 11.0.3
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
+      content-type: 2.0.0
       fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
       universal-user-agent: 7.0.3
 
   '@octokit/request@5.6.3':
@@ -6668,8 +7816,6 @@ snapshots:
       is-plain-object: 5.0.0
       node-fetch: 2.7.0
       universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
 
   '@octokit/rest@18.12.0':
     dependencies:
@@ -6677,8 +7823,6 @@ snapshots:
       '@octokit/plugin-paginate-rest': 2.21.3(@octokit/core@3.6.0)
       '@octokit/plugin-request-log': 1.0.4(@octokit/core@3.6.0)
       '@octokit/plugin-rest-endpoint-methods': 5.16.2(@octokit/core@3.6.0)
-    transitivePeerDependencies:
-      - encoding
 
   '@octokit/types@15.0.2':
     dependencies:
@@ -6694,330 +7838,293 @@ snapshots:
 
   '@opentelemetry/api-logs@0.208.0':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/api@1.9.0': {}
+  '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.38.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-amqplib@0.55.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-connect@0.52.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-amqplib@0.55.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/instrumentation-connect@0.52.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@types/connect': 3.4.38
-    transitivePeerDependencies:
-      - supports-color
 
-  '@opentelemetry/instrumentation-dataloader@0.26.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-dataloader@0.26.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-express@0.57.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-express@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-fs@0.28.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-fs@0.28.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-generic-pool@0.52.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-generic-pool@0.52.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-graphql@0.56.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-graphql@0.56.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-hapi@0.55.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-hapi@0.55.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-http@0.208.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-http@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
       forwarded-parse: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.56.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-ioredis@0.56.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/redis-common': 0.38.2
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
 
-  '@opentelemetry/instrumentation-kafkajs@0.18.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-kafkajs@0.18.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-knex@0.53.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-knex@0.53.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-koa@0.57.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-koa@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-lru-memoizer@0.53.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-lru-memoizer@0.53.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-mongodb@0.61.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mongodb@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-mongoose@0.55.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mongoose@0.55.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-mysql2@0.55.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mysql2@0.55.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation-mysql@0.54.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mysql@0.54.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
       '@types/mysql': 2.15.27
-    transitivePeerDependencies:
-      - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.61.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-pg@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
       '@types/pg': 8.15.6
       '@types/pg-pool': 2.0.6
-    transitivePeerDependencies:
-      - supports-color
 
-  '@opentelemetry/instrumentation-redis@0.57.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-redis@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/redis-common': 0.38.2
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation-tedious@0.27.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-tedious@0.27.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
       '@types/tedious': 4.0.14
-    transitivePeerDependencies:
-      - supports-color
 
-  '@opentelemetry/instrumentation-undici@0.19.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-undici@0.19.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
-      import-in-the-middle: 2.0.1
+      import-in-the-middle: 2.0.6
       require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
 
-  '@opentelemetry/redis-common@0.38.2': {}
+  '@opentelemetry/redis-common@0.38.3': {}
 
-  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/semantic-conventions@1.38.0': {}
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
-  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@paralleldrive/cuid2@2.2.2':
+  '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@peculiar/asn1-android@2.6.0':
+  '@peculiar/asn1-android@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-cms@2.6.1':
+  '@peculiar/asn1-cms@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/asn1-x509-attr': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-csr@2.6.1':
+  '@peculiar/asn1-csr@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-ecc@2.6.1':
+  '@peculiar/asn1-ecc@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-pfx@2.6.1':
+  '@peculiar/asn1-pfx@2.7.0':
     dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-pkcs8@2.6.1':
+  '@peculiar/asn1-pkcs8@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-pkcs9@2.6.1':
+  '@peculiar/asn1-pkcs9@2.7.0':
     dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-pfx': 2.6.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/asn1-x509-attr': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pfx': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-rsa@2.6.1':
+  '@peculiar/asn1-rsa@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-schema@2.6.0':
+  '@peculiar/asn1-schema@2.7.0':
     dependencies:
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-x509-attr@2.6.1':
+  '@peculiar/asn1-x509-attr@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
-  '@peculiar/asn1-x509@2.6.1':
+  '@peculiar/asn1-x509@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
       tslib: 2.8.1
 
   '@peculiar/x509@1.14.3':
     dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-csr': 2.6.1
-      '@peculiar/asn1-ecc': 2.6.1
-      '@peculiar/asn1-pkcs9': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-csr': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-pkcs9': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       pvtsutils: 1.3.6
       reflect-metadata: 0.2.2
       tslib: 2.8.1
@@ -7033,28 +8140,24 @@ snapshots:
       chokidar: 4.0.3
       debug: 4.4.3
       fp-ts: 2.16.11
-      fs-extra: 11.3.2
-      glob: 11.0.3
+      fs-extra: 11.3.5
+      glob: 11.1.0
       io-ts: 2.2.22(fp-ts@2.16.11)
       io-ts-reporters: 2.0.1(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))
-      minimatch: 10.0.3
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      minimatch: 10.2.5
+      nunjucks: 3.2.4(chokidar@3.6.0)
       pascal-case: 4.0.0
       piscina: 4.9.2
       tinypool: 1.1.1
       ts-parse-database-url: 1.0.3
       typescript: 5.9.3
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@pgtyped/parser@2.4.2':
     dependencies:
       antlr4ts: 0.5.0-alpha.4
       chalk: 4.1.2
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@pgtyped/query@2.4.2':
     dependencies:
@@ -7062,27 +8165,20 @@ snapshots:
       '@pgtyped/wire': 2.4.2
       chalk: 4.1.2
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@pgtyped/runtime@2.4.2':
     dependencies:
       '@pgtyped/parser': 2.4.2
       chalk: 4.1.2
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@pgtyped/wire@2.4.2':
     dependencies:
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@pinojs/redact@0.4.0': {}
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
+  '@pkgjs/parseargs@0.11.0': {}
 
   '@playwright/test@1.57.0':
     dependencies:
@@ -7094,7 +8190,7 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.10
 
-  '@pnpm/npm-conf@2.3.1':
+  '@pnpm/npm-conf@3.0.2':
     dependencies:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
@@ -7102,163 +8198,104 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prisma/instrumentation@6.19.0(@opentelemetry/api@1.9.0)':
+  '@prisma/instrumentation@6.19.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
 
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
-    optional: true
+  '@rollup/rollup-darwin-arm64@4.60.4': {}
 
-  '@rollup/rollup-android-arm64@4.52.5':
-    optional: true
+  '@rollup/rollup-linux-arm64-gnu@4.60.4': {}
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
-    optional: true
+  '@rollup/rollup-linux-arm64-musl@4.60.4': {}
 
-  '@rollup/rollup-darwin-x64@4.52.5':
-    optional: true
+  '@rollup/rollup-linux-x64-gnu@4.60.4': {}
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
-    optional: true
+  '@rollup/rollup-linux-x64-musl@4.60.4': {}
 
-  '@rollup/rollup-freebsd-x64@4.52.5':
-    optional: true
+  '@rollup/rollup-win32-arm64-msvc@4.60.4': {}
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
-    optional: true
+  '@rollup/rollup-win32-x64-gnu@4.60.4': {}
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.52.5':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
-    optional: true
+  '@rollup/rollup-win32-x64-msvc@4.60.4': {}
 
   '@scarf/scarf@1.4.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/changelog@6.0.3(semantic-release@24.2.5)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      fs-extra: 11.3.2
-      lodash: 4.17.21
-      semantic-release: 24.2.5(typescript@5.9.3)
+      fs-extra: 11.3.5
+      lodash: 4.18.1
+      semantic-release: 24.2.5
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.5)':
     dependencies:
-      conventional-changelog-angular: 8.1.0
-      conventional-changelog-writer: 8.2.0
+      conventional-changelog-angular: 8.3.1
+      conventional-changelog-writer: 8.4.0
       conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.2.1
+      conventional-commits-parser: 6.4.0
       debug: 4.4.3
       import-from-esm: 2.0.0
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 24.2.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
+      semantic-release: 24.2.5
 
   '@semantic-release/error@3.0.0': {}
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.0.3(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/exec@7.0.3(semantic-release@24.2.5)':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
       debug: 4.4.3
       execa: 9.6.1
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
       parse-json: 8.3.0
-      semantic-release: 24.2.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
+      semantic-release: 24.2.5
 
-  '@semantic-release/git@10.0.1(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/git@10.0.1(semantic-release@24.2.5)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       debug: 4.4.3
       dir-glob: 3.0.1
       execa: 5.1.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 24.2.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
+      semantic-release: 24.2.5
 
-  '@semantic-release/github@11.0.6(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/github@11.0.6(semantic-release@24.2.5)':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 13.2.1(@octokit/core@7.0.6)
-      '@octokit/plugin-retry': 8.0.3(@octokit/core@7.0.6)
+      '@octokit/plugin-retry': 8.1.0(@octokit/core@7.0.6)
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
@@ -7266,48 +8303,42 @@ snapshots:
       dir-glob: 3.0.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      issue-parser: 7.0.1
-      lodash-es: 4.17.22
+      issue-parser: 7.0.2
+      lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 24.2.5(typescript@5.9.3)
-      tinyglobby: 0.2.15
+      semantic-release: 24.2.5
+      tinyglobby: 0.2.16
       url-join: 5.0.0
-    transitivePeerDependencies:
-      - supports-color
 
-  '@semantic-release/npm@12.0.2(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/npm@12.0.2(semantic-release@24.2.5)':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
       execa: 9.6.1
-      fs-extra: 11.3.2
-      lodash-es: 4.17.22
+      fs-extra: 11.3.5
+      lodash-es: 4.18.1
       nerf-dart: 1.0.0
-      normalize-url: 8.1.0
-      npm: 10.9.4
+      normalize-url: 8.1.1
+      npm: 10.9.8
       rc: 1.2.8
       read-pkg: 9.0.1
-      registry-auth-token: 5.1.0
-      semantic-release: 24.2.5(typescript@5.9.3)
-      semver: 7.7.3
-      tempy: 3.1.0
+      registry-auth-token: 5.1.1
+      semantic-release: 24.2.5
+      semver: 7.8.1
+      tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.0(semantic-release@24.2.5(typescript@5.9.3))':
+  '@semantic-release/release-notes-generator@14.1.1(semantic-release@24.2.5)':
     dependencies:
-      conventional-changelog-angular: 8.1.0
-      conventional-changelog-writer: 8.2.0
+      conventional-changelog-angular: 8.3.1
+      conventional-changelog-writer: 8.4.0
       conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.2.1
+      conventional-commits-parser: 6.4.0
       debug: 4.4.3
-      get-stream: 7.0.1
       import-from-esm: 2.0.0
-      into-stream: 7.0.0
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 24.2.5(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
+      semantic-release: 24.2.5
 
   '@sentry-internal/browser-utils@10.32.1':
     dependencies:
@@ -7327,7 +8358,7 @@ snapshots:
       '@sentry-internal/browser-utils': 10.32.1
       '@sentry/core': 10.32.1
 
-  '@sentry/babel-plugin-component-annotate@4.6.1': {}
+  '@sentry/babel-plugin-component-annotate@4.9.1': {}
 
   '@sentry/browser@10.32.1':
     dependencies:
@@ -7337,45 +8368,28 @@ snapshots:
       '@sentry-internal/replay-canvas': 10.32.1
       '@sentry/core': 10.32.1
 
-  '@sentry/bundler-plugin-core@4.6.1':
+  '@sentry/bundler-plugin-core@4.9.1':
     dependencies:
-      '@babel/core': 7.28.5
-      '@sentry/babel-plugin-component-annotate': 4.6.1
-      '@sentry/cli': 2.58.4
+      '@babel/core': 7.29.0
+      '@sentry/babel-plugin-component-annotate': 4.9.1
+      '@sentry/cli': 2.58.6
       dotenv: 16.6.1
       find-up: 5.0.0
       glob: 10.5.0
       magic-string: 0.30.8
       unplugin: 1.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
-  '@sentry/cli-darwin@2.58.4':
-    optional: true
+  '@sentry/cli-darwin@2.58.6': {}
 
-  '@sentry/cli-linux-arm64@2.58.4':
-    optional: true
+  '@sentry/cli-linux-arm64@2.58.6': {}
 
-  '@sentry/cli-linux-arm@2.58.4':
-    optional: true
+  '@sentry/cli-linux-x64@2.58.6': {}
 
-  '@sentry/cli-linux-i686@2.58.4':
-    optional: true
+  '@sentry/cli-win32-arm64@2.58.6': {}
 
-  '@sentry/cli-linux-x64@2.58.4':
-    optional: true
+  '@sentry/cli-win32-x64@2.58.6': {}
 
-  '@sentry/cli-win32-arm64@2.58.4':
-    optional: true
-
-  '@sentry/cli-win32-i686@2.58.4':
-    optional: true
-
-  '@sentry/cli-win32-x64@2.58.4':
-    optional: true
-
-  '@sentry/cli@2.58.4':
+  '@sentry/cli@2.58.6':
     dependencies:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
@@ -7383,88 +8397,78 @@ snapshots:
       proxy-from-env: 1.1.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 2.58.4
-      '@sentry/cli-linux-arm': 2.58.4
-      '@sentry/cli-linux-arm64': 2.58.4
-      '@sentry/cli-linux-i686': 2.58.4
-      '@sentry/cli-linux-x64': 2.58.4
-      '@sentry/cli-win32-arm64': 2.58.4
-      '@sentry/cli-win32-i686': 2.58.4
-      '@sentry/cli-win32-x64': 2.58.4
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
 
   '@sentry/cloudflare@10.32.1':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.32.1
 
   '@sentry/core@10.32.1': {}
+  ? '@sentry/node-core@10.32.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)'
 
-  '@sentry/node-core@10.32.1(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)':
-    dependencies:
+  : dependencies:
       '@apm-js-collab/tracing-hooks': 0.3.1
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.32.1
-      '@sentry/opentelemetry': 10.32.1(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
-      import-in-the-middle: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
+      '@sentry/opentelemetry': 10.32.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 2.0.6
 
   '@sentry/node@10.32.1':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-amqplib': 0.55.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-connect': 0.52.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-dataloader': 0.26.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-express': 0.57.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-fs': 0.28.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-generic-pool': 0.52.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-graphql': 0.56.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-hapi': 0.55.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-http': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-ioredis': 0.56.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-kafkajs': 0.18.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-knex': 0.53.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-koa': 0.57.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.53.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mongodb': 0.61.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mongoose': 0.55.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mysql': 0.54.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mysql2': 0.55.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-pg': 0.61.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-redis': 0.57.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-tedious': 0.27.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-undici': 0.19.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
-      '@prisma/instrumentation': 6.19.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.28.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.56.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.56.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.18.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.54.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.55.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.57.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.27.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.19.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@prisma/instrumentation': 6.19.0(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.32.1
-      '@sentry/node-core': 10.32.1(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
-      '@sentry/opentelemetry': 10.32.1(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
-      import-in-the-middle: 2.0.1
-      minimatch: 9.0.5
-    transitivePeerDependencies:
-      - supports-color
+      '@sentry/node-core': 10.32.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.32.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 2.0.6
+      minimatch: 9.0.9
+  ? '@sentry/opentelemetry@10.32.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)'
 
-  '@sentry/opentelemetry@10.32.1(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.38.0
+  : dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.32.1
 
   '@sentry/svelte@10.32.1(svelte@5.46.1)':
@@ -7473,34 +8477,31 @@ snapshots:
       '@sentry/core': 10.32.1
       magic-string: 0.30.21
       svelte: 5.46.1
+  ? '@sentry/sveltekit@10.32.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))'
 
-  '@sentry/sveltekit@10.32.1(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
+  : dependencies:
       '@babel/parser': 7.26.9
       '@sentry/cloudflare': 10.32.1
       '@sentry/core': 10.32.1
       '@sentry/node': 10.32.1
       '@sentry/svelte': 10.32.1(svelte@5.46.1)
-      '@sentry/vite-plugin': 4.6.1
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@sentry/vite-plugin': 4.9.1
+      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       magic-string: 0.30.7
       recast: 0.23.11
       sorcery: 1.0.0
-    optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - encoding
-      - supports-color
-      - svelte
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@sentry/vite-plugin@4.6.1':
+  '@sentry/vite-plugin@4.9.1':
     dependencies:
-      '@sentry/bundler-plugin-core': 4.6.1
+      '@sentry/bundler-plugin-core': 4.9.1
       unplugin: 1.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/stream-utils@1.2.0': {}
 
   '@simplewebauthn/browser@13.3.0': {}
 
@@ -7508,11 +8509,11 @@ snapshots:
     dependencies:
       '@hexagon/base64': 1.1.28
       '@levischuck/tiny-cbor': 0.2.11
-      '@peculiar/asn1-android': 2.6.0
-      '@peculiar/asn1-ecc': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-android': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       '@peculiar/x509': 1.14.3
 
   '@sindresorhus/is@4.6.0': {}
@@ -7521,114 +8522,82 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
+  ? '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))'
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))':
-    dependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+  : dependencies:
+      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+  ? '@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))'
 
-  '@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
+  : dependencies:
+      '@opentelemetry/api': 1.9.1
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@sveltejs/vite-plugin-svelte': 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
-      acorn: 8.15.0
+      acorn: 8.16.0
       cookie: 0.6.0
-      devalue: 5.3.2
+      devalue: 5.8.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
       mrmime: 2.0.1
       sade: 1.8.1
-      set-cookie-parser: 2.7.1
+      set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.46.1
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+  ? '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))'
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
-      debug: 4.4.3
+  : dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+      obug: 2.1.1
       svelte: 5.46.1
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+  ? '@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))'
 
-  '@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+  : dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       magic-string: 0.30.21
       svelte: 5.46.1
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
-    transitivePeerDependencies:
-      - supports-color
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
 
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.18.4
-      jiti: 2.6.1
+      enhanced-resolve: 5.22.0
+      jiti: 2.7.0
       lightningcss: 1.30.2
       magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.1.18
 
-  '@tailwindcss/oxide-android-arm64@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-darwin-arm64@4.1.18': {}
 
-  '@tailwindcss/oxide-darwin-arm64@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18': {}
 
-  '@tailwindcss/oxide-darwin-x64@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18': {}
 
-  '@tailwindcss/oxide-freebsd-x64@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18': {}
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18': {}
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18': {}
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
-    optional: true
-
-  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
-    optional: true
-
-  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
-    optional: true
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
-    optional: true
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18': {}
 
   '@tailwindcss/oxide@4.1.18':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.1.18
       '@tailwindcss/oxide-darwin-arm64': 4.1.18
-      '@tailwindcss/oxide-darwin-x64': 4.1.18
-      '@tailwindcss/oxide-freebsd-x64': 4.1.18
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
       '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
       '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
       '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
       '@tailwindcss/oxide-linux-x64-musl': 4.1.18
-      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
@@ -7643,16 +8612,11 @@ snapshots:
   '@testcontainers/postgresql@11.10.0':
     dependencies:
       testcontainers: 11.10.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -7663,17 +8627,16 @@ snapshots:
   '@testing-library/svelte-core@1.0.0(svelte@5.46.1)':
     dependencies:
       svelte: 5.46.1
+  ? '@testing-library/svelte@5.3.0(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0))'
 
-  '@testing-library/svelte@5.3.0(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
+  : dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.46.1)
       svelte: 5.46.1
-    optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0)
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@2.0.1': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -7687,10 +8650,6 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 25.0.3
-
-  '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 25.0.3
 
@@ -7830,6 +8789,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/geojson@7946.0.16': {}
 
   '@types/jsonwebtoken@9.0.10':
@@ -7840,6 +8801,15 @@ snapshots:
   '@types/leaflet@1.9.21':
     dependencies:
       '@types/geojson': 7946.0.16
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/methods@1.1.4': {}
 
@@ -7868,13 +8838,13 @@ snapshots:
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 25.0.3
-      pg-protocol: 1.10.3
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pg@8.16.0':
     dependencies:
       '@types/node': 25.0.3
-      pg-protocol: 1.10.3
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/sharp@0.32.0':
@@ -7894,24 +8864,23 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
-  '@types/superagent@8.1.9':
+  '@types/superagent@8.1.10':
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 25.0.3
-      form-data: 4.0.4
+      form-data: 4.0.5
 
   '@types/supertest@6.0.3':
     dependencies:
       '@types/methods': 1.1.4
-      '@types/superagent': 8.1.9
+      '@types/superagent': 8.1.10
 
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 25.0.3
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/webidl-conversions@7.0.3': {}
 
@@ -7926,19 +8895,18 @@ snapshots:
       '@vitest/spy': 4.0.16
       '@vitest/utils': 4.0.16
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@4.0.16':
     dependencies:
@@ -7956,12 +8924,7 @@ snapshots:
   '@vitest/utils@4.0.16':
     dependencies:
       '@vitest/pretty-format': 4.0.16
-      tinyrainbow: 3.0.3
-
-  JSONStream@1.3.5:
-    dependencies:
-      jsonparse: 1.3.1
-      through: 2.3.8
+      tinyrainbow: 3.1.0
 
   a-sync-waterfall@1.0.1: {}
 
@@ -7974,17 +8937,15 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.15.0):
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
-  acorn@8.15.0: {}
+  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -7998,18 +8959,18 @@ snapshots:
       clean-stack: 5.3.0
       indent-string: 5.0.0
 
-  ajv-formats@3.0.1(ajv@8.17.1):
-    optionalDependencies:
-      ajv: 8.17.1
+  ajv-formats@3.0.1(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-escapes@7.2.0:
+  ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
 
@@ -8036,7 +8997,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   archiver-utils@5.0.2:
     dependencies:
@@ -8044,7 +9005,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -8055,11 +9016,8 @@ snapshots:
       buffer-crc32: 1.0.0
       readable-stream: 4.7.0
       readdir-glob: 1.1.3
-      tar-stream: 3.1.7
+      tar-stream: 3.2.0
       zip-stream: 6.0.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   argparse@2.0.1: {}
 
@@ -8089,7 +9047,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  asn1js@3.0.7:
+  asn1js@3.0.10:
     dependencies:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
@@ -8100,6 +9058,10 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  async-function@1.0.0: {}
+
+  async-generator-function@1.0.0: {}
 
   async-lock@1.4.1: {}
 
@@ -8115,8 +9077,8 @@ snapshots:
 
   autoprefixer@10.4.23(postcss@8.5.6):
     dependencies:
-      browserslist: 4.28.1
-      caniuse-lite: 1.0.30001761
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.6
@@ -8124,50 +9086,41 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  b4a@1.7.3: {}
+  b4a@1.8.1: {}
 
   balanced-match@1.0.2: {}
 
-  bare-events@2.8.1: {}
+  balanced-match@4.0.4: {}
 
-  bare-fs@4.5.0:
+  bare-events@2.8.3: {}
+
+  bare-fs@4.7.1:
     dependencies:
-      bare-events: 2.8.1
+      bare-events: 2.8.3
       bare-path: 3.0.0
-      bare-stream: 2.7.0(bare-events@2.8.1)
-      bare-url: 2.3.1
+      bare-stream: 2.13.1(bare-events@2.8.3)
+      bare-url: 2.4.3
       fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
 
-  bare-os@3.6.2:
-    optional: true
+  bare-os@3.9.1: {}
 
   bare-path@3.0.0:
     dependencies:
-      bare-os: 3.6.2
-    optional: true
+      bare-os: 3.9.1
 
-  bare-stream@2.7.0(bare-events@2.8.1):
+  bare-stream@2.13.1(bare-events@2.8.3):
     dependencies:
-      streamx: 2.23.0
-    optionalDependencies:
-      bare-events: 2.8.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
+      bare-events: 2.8.3
+      streamx: 2.25.0
+      teex: 1.0.1
 
-  bare-url@2.3.1:
+  bare-url@2.4.3:
     dependencies:
       bare-path: 3.0.0
-    optional: true
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.9.11: {}
+  baseline-browser-mapping@2.10.32: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -8175,77 +9128,45 @@ snapshots:
 
   bcrypt@6.0.0:
     dependencies:
-      node-addon-api: 8.5.0
+      node-addon-api: 8.8.0
       node-gyp-build: 4.8.4
 
   before-after-hook@2.2.3: {}
 
   before-after-hook@4.0.0: {}
+  ? better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(mongodb@7.2.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0))
 
-  better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)):
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))
+  : dependencies:
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
+      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(mongodb@7.2.0)
+      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
-      defu: 6.1.4
-      jose: 6.2.1
-      kysely: 0.28.11
-      nanostores: 1.1.1
-      zod: 4.3.6
-    optionalDependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
-      mongodb: 7.1.0
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+      better-call: 1.3.2(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.28.17
+      mongodb: 7.2.0
+      nanostores: 1.3.0
       pg: 8.16.3
       svelte: 5.46.1
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
+      vitest: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0)
+      zod: 4.4.3
 
-  better-auth@1.5.5(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(mongodb@7.1.0)(pg@8.16.3)(svelte@5.46.1)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)):
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
-      defu: 6.1.4
-      jose: 6.2.1
-      kysely: 0.28.11
-      nanostores: 1.1.1
-      zod: 4.3.6
-    optionalDependencies:
-      '@sveltejs/kit': 2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)))(svelte@5.46.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
-      mongodb: 7.1.0
-      pg: 8.16.3
-      svelte: 5.46.1
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-
-  better-call@1.3.2(zod@4.3.6):
+  better-call@1.3.2(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
-      set-cookie-parser: 3.0.1
-    optionalDependencies:
-      zod: 4.3.6
+      set-cookie-parser: 3.1.0
+      zod: 4.4.3
 
   bidi-js@1.0.3:
     dependencies:
@@ -8267,29 +9188,31 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
+      type-is: 2.1.0
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
+  browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.9.11
-      caniuse-lite: 1.0.30001761
-      electron-to-chromium: 1.5.267
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.361
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bson@7.2.0: {}
 
@@ -8307,8 +9230,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  buildcheck@0.0.6:
-    optional: true
+  buildcheck@0.0.7: {}
 
   byline@5.0.0: {}
 
@@ -8322,7 +9244,7 @@ snapshots:
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
 
   callsites@3.1.0: {}
 
@@ -8330,7 +9252,7 @@ snapshots:
     dependencies:
       no-case: 4.0.0
 
-  caniuse-lite@1.0.30001761: {}
+  caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
 
@@ -8367,7 +9289,7 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  cjs-module-lexer@1.4.3: {}
+  cjs-module-lexer@2.2.0: {}
 
   clean-stack@2.2.0: {}
 
@@ -8454,11 +9376,9 @@ snapshots:
 
   content-type@1.0.5: {}
 
-  conventional-changelog-angular@7.0.0:
-    dependencies:
-      compare-func: 2.0.0
+  content-type@2.0.0: {}
 
-  conventional-changelog-angular@8.1.0:
+  conventional-changelog-angular@8.3.1:
     dependencies:
       compare-func: 2.0.0
 
@@ -8470,24 +9390,19 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-writer@8.2.0:
+  conventional-changelog-writer@8.4.0:
     dependencies:
+      '@simple-libs/stream-utils': 1.2.0
       conventional-commits-filter: 5.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       meow: 13.2.0
-      semver: 7.7.3
+      semver: 7.8.1
 
   conventional-commits-filter@5.0.0: {}
 
-  conventional-commits-parser@5.0.0:
+  conventional-commits-parser@6.4.0:
     dependencies:
-      JSONStream: 1.3.5
-      is-text-path: 2.0.0
-      meow: 12.1.1
-      split2: 4.2.0
-
-  conventional-commits-parser@6.2.1:
-    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
       meow: 13.2.0
 
   convert-hrtime@5.0.0: {}
@@ -8511,27 +9426,25 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@25.0.3)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.0.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@types/node': 25.0.3
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
 
-  cosmiconfig@9.0.0(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
-    optionalDependencies:
       typescript: 5.9.3
 
   cpu-features@0.0.10:
     dependencies:
-      buildcheck: 0.0.6
-      nan: 2.23.0
-    optional: true
+      buildcheck: 0.0.7
+      nan: 2.27.0
 
   crc-32@1.2.2: {}
 
@@ -8539,6 +9452,8 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8550,16 +9465,17 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-tree@3.1.0:
+  css-tree@3.2.1:
     dependencies:
-      mdn-data: 2.12.2
+      mdn-data: 2.27.1
       source-map-js: 1.2.1
 
-  cssstyle@5.3.5:
+  cssstyle@5.3.7:
     dependencies:
-      '@asamuzakjp/css-color': 4.1.1
-      '@csstools/css-syntax-patches-for-csstree': 1.0.22
-      css-tree: 3.1.0
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.2.4
 
   d3-array@3.2.4:
     dependencies:
@@ -8587,7 +9503,7 @@ snapshots:
 
   d3-delaunay@6.0.4:
     dependencies:
-      delaunator: 5.0.1
+      delaunator: 5.1.0
 
   d3-dispatch@3.0.1: {}
 
@@ -8744,7 +9660,7 @@ snapshots:
       p-limit: 2.3.0
       parse-diff: 0.7.1
       parse-git-config: 2.0.3
-      parse-github-url: 1.0.3
+      parse-github-url: 1.0.4
       parse-link-header: 2.0.0
       pinpoint: 1.1.0
       prettyjson: 1.2.5
@@ -8752,15 +9668,10 @@ snapshots:
       regenerator-runtime: 0.13.11
       require-from-string: 2.0.2
       supports-hyperlinks: 1.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
-  dargs@8.1.0: {}
-
-  data-urls@6.0.0:
+  data-urls@6.0.1:
     dependencies:
-      whatwg-mimetype: 4.0.0
+      whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
 
   dateformat@4.6.3: {}
@@ -8775,11 +9686,11 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
-  delaunator@5.0.1:
+  delaunator@5.1.0:
     dependencies:
-      robust-predicates: 3.0.2
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -8791,9 +9702,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  devalue@5.3.2: {}
-
-  devalue@5.6.1: {}
+  devalue@5.8.1: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -8804,34 +9713,30 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docker-compose@1.3.0:
+  docker-compose@1.4.2:
     dependencies:
-      yaml: 2.8.1
+      yaml: 2.9.0
 
-  docker-modem@5.0.6:
+  docker-modem@5.0.7:
     dependencies:
       debug: 4.4.3
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
-    transitivePeerDependencies:
-      - supports-color
 
-  dockerode@4.0.9:
+  dockerode@4.0.12:
     dependencies:
       '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.14.0
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.6
-      protobufjs: 7.5.4
+      docker-modem: 5.0.7
+      protobufjs: 7.6.1
       tar-fs: 2.1.4
       uuid: 10.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.3.1:
+  dompurify@3.4.5:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8859,7 +9764,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.267: {}
+  electron-to-chromium@1.5.361: {}
 
   emoji-regex@8.0.0: {}
 
@@ -8873,12 +9778,14 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.18.4:
+  enhanced-resolve@5.22.0:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
-  entities@6.0.1: {}
+  entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   env-ci@11.2.0:
     dependencies:
@@ -8899,45 +9806,26 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
   es-set-tostringtag@2.1.0:
     dependencies:
       es-errors: 1.3.0
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
-  esbuild@0.27.2:
+  es-toolkit@1.46.1: {}
+
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -8951,13 +9839,13 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  esrap@2.2.1:
+  esrap@2.2.9:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   etag@1.8.1: {}
 
@@ -8965,17 +9853,15 @@ snapshots:
 
   events-universal@1.0.1:
     dependencies:
-      bare-events: 2.8.1
-    transitivePeerDependencies:
-      - bare-abort-controller
+      bare-events: 2.8.3
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   execa@5.1.1:
     dependencies:
@@ -9020,12 +9906,12 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -9049,16 +9935,14 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -9066,7 +9950,7 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
-  fast-copy@4.0.2: {}
+  fast-copy@4.0.3: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -9076,11 +9960,11 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
+  fdir@6.5.0(picomatch@4.0.4):
+    dependencies:
+      picomatch: 4.0.4
 
   figures@2.0.0:
     dependencies:
@@ -9102,8 +9986,6 @@ snapshots:
       on-finished: 2.4.1
       parseurl: 1.3.3
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   find-up-simple@1.0.1: {}
 
@@ -9116,12 +9998,6 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  find-up@7.0.0:
-    dependencies:
-      locate-path: 7.2.0
-      path-exists: 5.0.0
-      unicorn-magic: 0.1.0
-
   find-versions@6.0.0:
     dependencies:
       semver-regex: 4.0.5
@@ -9132,17 +10008,17 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   formidable@3.5.4:
     dependencies:
-      '@paralleldrive/cuid2': 2.2.2
+      '@paralleldrive/cuid2': 2.3.1
       dezalgo: 1.0.4
       once: 1.4.0
 
@@ -9156,60 +10032,56 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  from2@2.3.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-
   fs-constants@1.0.0: {}
 
   fs-exists-sync@0.1.0: {}
 
-  fs-extra@11.3.2:
+  fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fsevents@2.3.2:
-    optional: true
+  fsevents@2.3.2: {}
 
-  fsevents@2.3.3:
-    optional: true
+  fsevents@2.3.3: {}
 
   function-bind@1.1.2: {}
 
   function-timeout@1.0.2: {}
 
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
-  get-intrinsic@1.3.0:
+  get-intrinsic@1.3.1:
     dependencies:
+      async-function: 1.0.0
+      async-generator-function: 1.0.0
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
+      generator-function: 2.0.1
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
-  get-port@7.1.0: {}
+  get-port@7.2.0: {}
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-stdin@6.0.0: {}
 
   get-stream@6.0.1: {}
-
-  get-stream@7.0.1: {}
 
   get-stream@8.0.1: {}
 
@@ -9218,7 +10090,7 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
-  get-tsconfig@4.13.0:
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -9237,11 +10109,10 @@ snapshots:
       through2: 2.0.5
       traverse: 0.6.8
 
-  git-raw-commits@4.0.0:
+  git-raw-commits@5.0.1:
     dependencies:
-      dargs: 8.1.0
-      meow: 12.1.1
-      split2: 4.2.0
+      '@conventional-changelog/git-client': 2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -9251,32 +10122,23 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
+      minimatch: 9.0.9
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@11.0.3:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.1.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
 
   glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.1.1
-      minipass: 7.1.2
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
+      path-scurry: 2.0.2
 
-  global-directory@4.0.1:
+  global-directory@5.0.0:
     dependencies:
-      ini: 4.1.1
+      ini: 6.0.0
 
   globalyzer@0.1.0: {}
 
@@ -9288,7 +10150,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -9309,7 +10171,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -9323,7 +10185,7 @@ snapshots:
 
   hono@4.11.1: {}
 
-  hono@4.12.14: {}
+  hono@4.12.22: {}
 
   hook-std@3.0.0: {}
 
@@ -9341,9 +10203,7 @@ snapshots:
 
   html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.8.0
-    transitivePeerDependencies:
-      - '@exodus/crypto'
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
 
   http-errors@2.0.1:
     dependencies:
@@ -9355,32 +10215,24 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 2.0.1
       agent-base: 6.0.2
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   human-signals@2.1.0: {}
 
@@ -9392,12 +10244,11 @@ snapshots:
 
   i18next-browser-languagedetector@8.2.0:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
 
   i18next@25.7.4(typescript@5.9.3):
     dependencies:
-      '@babel/runtime': 7.28.4
-    optionalDependencies:
+      '@babel/runtime': 7.29.2
       typescript: 5.9.3
 
   iconv-lite@0.6.3:
@@ -9419,14 +10270,12 @@ snapshots:
     dependencies:
       debug: 4.4.3
       import-meta-resolve: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
 
-  import-in-the-middle@2.0.1:
+  import-in-the-middle@2.0.6:
     dependencies:
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      cjs-module-lexer: 1.4.3
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}
@@ -9441,14 +10290,9 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ini@4.1.1: {}
+  ini@6.0.0: {}
 
   internmap@2.0.3: {}
-
-  into-stream@7.0.0:
-    dependencies:
-      from2: 2.3.0
-      p-is-promise: 3.0.0
 
   io-ts-reporters@2.0.1(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11)):
     dependencies:
@@ -9460,7 +10304,7 @@ snapshots:
     dependencies:
       fp-ts: 2.16.11
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9494,17 +10338,13 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
 
   is-stream@4.0.1: {}
-
-  is-text-path@2.0.0:
-    dependencies:
-      text-extensions: 2.4.0
 
   is-unicode-supported@2.1.0: {}
 
@@ -9514,16 +10354,10 @@ snapshots:
 
   isomorphic-dompurify@2.35.0:
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.4.5
       jsdom: 27.4.0
-    transitivePeerDependencies:
-      - '@exodus/crypto'
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
 
-  issue-parser@7.0.1:
+  issue-parser@7.0.2:
     dependencies:
       lodash.capitalize: 4.2.1
       lodash.escaperegexp: 4.1.2
@@ -9537,78 +10371,71 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.1:
+  jackspeak@4.2.3:
     dependencies:
-      '@isaacs/cliui': 8.0.2
+      '@isaacs/cliui': 9.0.0
 
   java-properties@1.0.2: {}
 
   jiti@2.6.1: {}
 
-  jose@6.2.1: {}
+  jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
   jsdom@27.3.0:
     dependencies:
-      '@acemir/cssom': 0.9.30
-      '@asamuzakjp/dom-selector': 6.7.6
-      cssstyle: 5.3.5
-      data-urls: 6.0.0
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
-      parse5: 8.0.0
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.0
+      tough-cookie: 6.0.1
       w3c-xmlserializer: 5.0.0
-      webidl-conversions: 8.0.0
+      webidl-conversions: 8.0.1
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.21.0
       xml-name-validator: 5.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   jsdom@27.4.0:
     dependencies:
-      '@acemir/cssom': 0.9.30
-      '@asamuzakjp/dom-selector': 6.7.6
-      '@exodus/bytes': 1.8.0
-      cssstyle: 5.3.5
-      data-urls: 6.0.0
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
-      parse5: 8.0.0
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.0
+      tough-cookie: 6.0.1
       w3c-xmlserializer: 5.0.0
-      webidl-conversions: 8.0.0
+      webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.21.0
       xml-name-validator: 5.0.0
-    transitivePeerDependencies:
-      - '@exodus/crypto'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -9620,15 +10447,15 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-with-bigint@3.5.8: {}
+
   json5@2.2.3: {}
 
-  jsonfile@6.2.0:
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsonparse@1.3.1: {}
 
   jsonpointer@5.0.1: {}
 
@@ -9643,7 +10470,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.3
+      semver: 7.8.1
 
   jwa@2.0.1:
     dependencies:
@@ -9658,7 +10485,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  kysely@0.28.11: {}
+  kysely@0.28.17: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -9668,48 +10495,25 @@ snapshots:
 
   libphonenumber-js@1.12.33: {}
 
-  lightningcss-android-arm64@1.30.2:
-    optional: true
+  lightningcss-darwin-arm64@1.30.2: {}
 
-  lightningcss-darwin-arm64@1.30.2:
-    optional: true
+  lightningcss-linux-arm64-gnu@1.30.2: {}
 
-  lightningcss-darwin-x64@1.30.2:
-    optional: true
+  lightningcss-linux-arm64-musl@1.30.2: {}
 
-  lightningcss-freebsd-x64@1.30.2:
-    optional: true
+  lightningcss-linux-x64-gnu@1.30.2: {}
 
-  lightningcss-linux-arm-gnueabihf@1.30.2:
-    optional: true
+  lightningcss-linux-x64-musl@1.30.2: {}
 
-  lightningcss-linux-arm64-gnu@1.30.2:
-    optional: true
+  lightningcss-win32-arm64-msvc@1.30.2: {}
 
-  lightningcss-linux-arm64-musl@1.30.2:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.30.2:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.30.2:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.30.2:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.30.2:
-    optional: true
+  lightningcss-win32-x64-msvc@1.30.2: {}
 
   lightningcss@1.30.2:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.30.2
       lightningcss-darwin-arm64: 1.30.2
-      lightningcss-darwin-x64: 1.30.2
-      lightningcss-freebsd-x64: 1.30.2
-      lightningcss-linux-arm-gnueabihf: 1.30.2
       lightningcss-linux-arm64-gnu: 1.30.2
       lightningcss-linux-arm64-musl: 1.30.2
       lightningcss-linux-x64-gnu: 1.30.2
@@ -9718,6 +10522,10 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.30.2
 
   lines-and-columns@1.2.4: {}
+
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
 
   load-json-file@4.0.0:
     dependencies:
@@ -9737,11 +10545,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  locate-path@7.2.0:
-    dependencies:
-      p-locate: 6.0.0
-
-  lodash-es@4.17.22: {}
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -9765,8 +10569,6 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
-  lodash.kebabcase@4.1.1: {}
-
   lodash.keys@4.2.0: {}
 
   lodash.mapvalues@4.6.0: {}
@@ -9775,27 +10577,21 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash.mergewith@4.6.2: {}
-
   lodash.once@4.1.1: {}
-
-  lodash.snakecase@4.1.1: {}
-
-  lodash.startcase@4.4.0: {}
 
   lodash.uniq@4.5.0: {}
 
   lodash.uniqby@4.7.0: {}
 
-  lodash.upperfirst@4.3.1: {}
-
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   long@5.3.2: {}
 
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.4: {}
+
+  lru-cache@11.5.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9815,15 +10611,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-asynchronous@1.0.1:
+  make-asynchronous@1.1.0:
     dependencies:
       p-event: 6.0.1
       type-fest: 4.41.0
-      web-worker: 1.2.0
+      web-worker: 1.5.0
+
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   marked-terminal@7.3.0(marked@15.0.12):
     dependencies:
-      ansi-escapes: 7.2.0
+      ansi-escapes: 7.3.0
       ansi-regex: 6.2.2
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -9836,19 +10641,17 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
   memfs-or-file-map-to-github-branch@1.3.0:
     dependencies:
       '@octokit/rest': 18.12.0
-    transitivePeerDependencies:
-      - encoding
 
   memory-pager@1.5.0: {}
-
-  meow@12.1.1: {}
 
   meow@13.2.0: {}
 
@@ -9861,7 +10664,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -9883,25 +10686,21 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  minimatch@10.0.3:
+  minimatch@10.2.5:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.6
 
-  minimatch@10.1.1:
+  minimatch@5.1.9:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 2.1.0
 
-  minimatch@5.1.6:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2: {}
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -9916,9 +10715,9 @@ snapshots:
 
   mongodb-uri@0.9.7: {}
 
-  mongodb@7.1.0:
+  mongodb@7.2.0:
     dependencies:
-      '@mongodb-js/saslprep': 1.4.6
+      '@mongodb-js/saslprep': 1.4.11
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
 
@@ -9934,12 +10733,11 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nan@2.23.0:
-    optional: true
+  nan@2.27.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
-  nanostores@1.1.1: {}
+  nanostores@1.3.0: {}
 
   negotiator@1.0.0: {}
 
@@ -9949,7 +10747,7 @@ snapshots:
 
   no-case@4.0.0: {}
 
-  node-addon-api@8.5.0: {}
+  node-addon-api@8.8.0: {}
 
   node-cleanup@2.1.2: {}
 
@@ -9970,23 +10768,22 @@ snapshots:
 
   node-pg-migrate@8.0.4(@types/pg@8.16.0)(pg@8.16.3):
     dependencies:
+      '@types/pg': 8.16.0
       glob: 11.1.0
       pg: 8.16.3
       yargs: 17.7.2
-    optionalDependencies:
-      '@types/pg': 8.16.0
 
-  node-releases@2.0.27: {}
+  node-releases@2.0.46: {}
 
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.3
+      semver: 7.8.1
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
 
-  normalize-url@8.1.0: {}
+  normalize-url@8.1.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -10001,15 +10798,83 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  npm@10.9.4: {}
+  npm@10.9.8:
+    bundledDependencies:
+    - '@isaacs/string-locale-compare'
+    - '@npmcli/arborist'
+    - '@npmcli/config'
+    - '@npmcli/fs'
+    - '@npmcli/map-workspaces'
+    - '@npmcli/package-json'
+    - '@npmcli/promise-spawn'
+    - '@npmcli/redact'
+    - '@npmcli/run-script'
+    - '@sigstore/tuf'
+    - abbrev
+    - archy
+    - cacache
+    - chalk
+    - ci-info
+    - cli-columns
+    - fastest-levenshtein
+    - fs-minipass
+    - glob
+    - graceful-fs
+    - hosted-git-info
+    - ini
+    - init-package-json
+    - is-cidr
+    - json-parse-even-better-errors
+    - libnpmaccess
+    - libnpmdiff
+    - libnpmexec
+    - libnpmfund
+    - libnpmhook
+    - libnpmorg
+    - libnpmpack
+    - libnpmpublish
+    - libnpmsearch
+    - libnpmteam
+    - libnpmversion
+    - make-fetch-happen
+    - minimatch
+    - minipass
+    - minipass-pipeline
+    - ms
+    - node-gyp
+    - nopt
+    - normalize-package-data
+    - npm-audit-report
+    - npm-install-checks
+    - npm-package-arg
+    - npm-pick-manifest
+    - npm-profile
+    - npm-registry-fetch
+    - npm-user-validate
+    - p-map
+    - pacote
+    - parse-conflict-json
+    - proc-log
+    - qrcode-terminal
+    - read
+    - semver
+    - spdx-expression-parse
+    - ssri
+    - supports-color
+    - tar
+    - text-table
+    - tiny-relative-date
+    - treeverse
+    - validate-npm-package-name
+    - which
+    - write-file-atomic
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
+      chokidar: 3.6.0
       commander: 5.1.0
-    optionalDependencies:
-      chokidar: 4.0.3
 
   object-assign@4.1.1: {}
 
@@ -10047,8 +10912,6 @@ snapshots:
     dependencies:
       p-map: 7.0.4
 
-  p-is-promise@3.0.0: {}
-
   p-limit@1.3.0:
     dependencies:
       p-try: 1.0.0
@@ -10061,10 +10924,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@4.0.0:
-    dependencies:
-      yocto-queue: 1.2.1
-
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -10072,10 +10931,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-locate@6.0.0:
-    dependencies:
-      p-limit: 4.0.0
 
   p-map@7.0.4: {}
 
@@ -10103,7 +10958,7 @@ snapshots:
       git-config-path: 1.0.1
       ini: 1.3.8
 
-  parse-github-url@1.0.3: {}
+  parse-github-url@1.0.4: {}
 
   parse-json@4.0.0:
     dependencies:
@@ -10112,14 +10967,14 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
   parse-json@8.3.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
@@ -10139,9 +10994,9 @@ snapshots:
 
   parse5@6.0.1: {}
 
-  parse5@8.0.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 
@@ -10153,8 +11008,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-exists@5.0.0: {}
-
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -10162,12 +11015,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
-  path-scurry@2.0.0:
+  path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.4
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -10175,36 +11028,35 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pg-cloudflare@1.2.7:
-    optional: true
+  pg-cloudflare@1.4.0: {}
 
-  pg-connection-string@2.9.1: {}
+  pg-connection-string@2.13.0: {}
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.10.1(pg@8.16.3):
+  pg-pool@3.14.0(pg@8.16.3):
     dependencies:
       pg: 8.16.3
 
-  pg-protocol@1.10.3: {}
+  pg-protocol@1.14.0: {}
 
   pg-types@2.2.0:
     dependencies:
       pg-int8: 1.0.1
       postgres-array: 2.0.0
-      postgres-bytea: 1.0.0
+      postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
   pg@8.16.3:
     dependencies:
-      pg-connection-string: 2.9.1
-      pg-pool: 3.10.1(pg@8.16.3)
-      pg-protocol: 1.10.3
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.16.3)
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
-      pg-cloudflare: 1.2.7
+      pg-cloudflare: 1.4.0
 
   pgpass@1.0.5:
     dependencies:
@@ -10212,9 +11064,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pify@3.0.0: {}
 
@@ -10230,26 +11082,26 @@ snapshots:
     dependencies:
       get-caller-file: 2.0.5
       pino: 10.1.0
-      pino-std-serializers: 7.0.0
+      pino-std-serializers: 7.1.0
       process-warning: 5.0.0
 
   pino-pretty@13.1.3:
     dependencies:
       colorette: 2.0.20
       dateformat: 4.6.3
-      fast-copy: 4.0.2
+      fast-copy: 4.0.3
       fast-safe-stringify: 2.1.1
       help-me: 5.0.0
       joycon: 3.1.1
       minimist: 1.2.8
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 3.0.0
-      pump: 3.0.3
+      pump: 3.0.4
       secure-json-parse: 4.1.0
-      sonic-boom: 4.2.0
+      sonic-boom: 4.2.1
       strip-json-comments: 5.0.3
 
-  pino-std-serializers@7.0.0: {}
+  pino-std-serializers@7.1.0: {}
 
   pino@10.1.0:
     dependencies:
@@ -10257,12 +11109,12 @@ snapshots:
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.0.0
+      pino-std-serializers: 7.1.0
       process-warning: 5.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.0
+      sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
   pinpoint@1.1.0: {}
@@ -10290,13 +11142,13 @@ snapshots:
 
   postcss@8.5.6:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
-  postgres-bytea@1.0.0: {}
+  postgres-bytea@1.0.1: {}
 
   postgres-date@1.0.7: {}
 
@@ -10339,18 +11191,18 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 25.0.3
       long: 5.3.2
 
@@ -10361,10 +11213,12 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  pump@3.0.3:
+  pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -10374,11 +11228,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -10444,11 +11294,11 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -10468,9 +11318,9 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
-  registry-auth-token@5.1.0:
+  registry-auth-token@5.1.1:
     dependencies:
-      '@pnpm/npm-conf': 2.3.1
+      '@pnpm/npm-conf': 3.0.2
 
   require-directory@2.1.1: {}
 
@@ -10480,8 +11330,6 @@ snapshots:
     dependencies:
       debug: 4.4.3
       module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   resolve-from@4.0.0: {}
 
@@ -10491,34 +11339,20 @@ snapshots:
 
   retry@0.12.0: {}
 
-  robust-predicates@3.0.2: {}
+  robust-predicates@3.0.3: {}
 
-  rollup@4.52.5:
+  rollup@4.60.4:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.52.5
-      '@rollup/rollup-android-arm64': 4.52.5
-      '@rollup/rollup-darwin-arm64': 4.52.5
-      '@rollup/rollup-darwin-x64': 4.52.5
-      '@rollup/rollup-freebsd-arm64': 4.52.5
-      '@rollup/rollup-freebsd-x64': 4.52.5
-      '@rollup/rollup-linux-arm-gnueabihf': 4.52.5
-      '@rollup/rollup-linux-arm-musleabihf': 4.52.5
-      '@rollup/rollup-linux-arm64-gnu': 4.52.5
-      '@rollup/rollup-linux-arm64-musl': 4.52.5
-      '@rollup/rollup-linux-loong64-gnu': 4.52.5
-      '@rollup/rollup-linux-ppc64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-musl': 4.52.5
-      '@rollup/rollup-linux-s390x-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-musl': 4.52.5
-      '@rollup/rollup-openharmony-arm64': 4.52.5
-      '@rollup/rollup-win32-arm64-msvc': 4.52.5
-      '@rollup/rollup-win32-ia32-msvc': 4.52.5
-      '@rollup/rollup-win32-x64-gnu': 4.52.5
-      '@rollup/rollup-win32-x64-msvc': 4.52.5
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
   rou3@0.7.12: {}
@@ -10530,8 +11364,6 @@ snapshots:
       is-promise: 4.0.0
       parseurl: 1.3.3
       path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
 
   rw@1.3.3: {}
 
@@ -10553,15 +11385,15 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
-  semantic-release@24.2.5(typescript@5.9.3):
+  semantic-release@24.2.5:
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.5(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.5)
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 11.0.6(semantic-release@24.2.5(typescript@5.9.3))
-      '@semantic-release/npm': 12.0.2(semantic-release@24.2.5(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@24.2.5(typescript@5.9.3))
+      '@semantic-release/github': 11.0.6(semantic-release@24.2.5)
+      '@semantic-release/npm': 12.0.2(semantic-release@24.2.5)
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@24.2.5)
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@5.9.3)
       debug: 4.4.3
       env-ci: 11.2.0
       execa: 9.6.1
@@ -10572,7 +11404,7 @@ snapshots:
       hook-std: 3.0.0
       hosted-git-info: 8.1.0
       import-from-esm: 2.0.0
-      lodash-es: 4.17.22
+      lodash-es: 4.18.1
       marked: 15.0.12
       marked-terminal: 7.3.0(marked@15.0.12)
       micromatch: 4.0.8
@@ -10580,23 +11412,20 @@ snapshots:
       p-reduce: 3.0.0
       read-package-up: 11.0.0
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.1
       semver-diff: 4.0.0
       signale: 1.4.0
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.1
 
   semver-regex@4.0.5: {}
 
   semver@6.3.1: {}
 
-  semver@7.7.3: {}
+  semver@7.8.1: {}
 
   send@1.2.1:
     dependencies:
@@ -10611,8 +11440,6 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   serve-static@2.2.1:
     dependencies:
@@ -10620,44 +11447,30 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
 
-  set-cookie-parser@2.7.1: {}
+  set-cookie-parser@2.7.2: {}
 
-  set-cookie-parser@3.0.1: {}
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.1
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
       '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
       '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
       '@img/sharp-libvips-linux-x64': 1.2.4
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
       '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
       '@img/sharp-linux-x64': 0.34.5
       '@img/sharp-linuxmusl-arm64': 0.34.5
       '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
@@ -10666,7 +11479,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -10675,14 +11488,14 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
       object-inspect: 1.13.4
 
   side-channel-weakmap@1.0.2:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
@@ -10690,7 +11503,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -10716,7 +11529,7 @@ snapshots:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
 
-  sonic-boom@4.2.0:
+  sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -10739,16 +11552,16 @@ snapshots:
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
 
   spdx-exceptions@2.5.0: {}
 
   spdx-expression-parse@3.0.1:
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
 
-  spdx-license-ids@3.0.22: {}
+  spdx-license-ids@3.0.23: {}
 
   split-ca@1.0.1: {}
 
@@ -10769,7 +11582,7 @@ snapshots:
       bcrypt-pbkdf: 1.0.2
     optionalDependencies:
       cpu-features: 0.0.10
-      nan: 2.23.0
+      nan: 2.27.0
 
   stackback@0.0.2: {}
 
@@ -10782,14 +11595,17 @@ snapshots:
       duplexer2: 0.1.4
       readable-stream: 2.3.8
 
-  streamx@2.23.0:
+  streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
       fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
+      text-decoder: 1.2.7
+
+  string-width-cjs@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string-width@4.2.3:
     dependencies:
@@ -10801,7 +11617,7 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
     dependencies:
@@ -10811,11 +11627,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  strip-ansi-cjs@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.1.2:
+  strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
@@ -10831,32 +11651,30 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  style-mod@4.1.3: {}
+
   super-regex@1.1.0:
     dependencies:
       function-timeout: 1.0.2
-      make-asynchronous: 1.0.1
+      make-asynchronous: 1.1.0
       time-span: 5.1.0
 
-  superagent@10.2.3:
+  superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.4
+      form-data: 4.0.5
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
-    transitivePeerDependencies:
-      - supports-color
+      qs: 6.15.2
 
   supertest@7.1.4:
     dependencies:
       methods: 1.1.2
-      superagent: 10.2.3
-    transitivePeerDependencies:
-      - supports-color
+      superagent: 10.3.0
 
   supports-color@5.5.0:
     dependencies:
@@ -10876,17 +11694,15 @@ snapshots:
       has-flag: 4.0.0
       supports-color: 7.2.0
 
-  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.9.3):
+  svelte-check@4.3.5(svelte@5.46.1)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.46.1
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - picomatch
 
   svelte-easy-crop@5.0.0(svelte@5.46.1):
     dependencies:
@@ -10905,15 +11721,15 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@types/estree': 1.0.8
-      acorn: 8.15.0
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@types/estree': 1.0.9
+      acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.1
+      devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.1
+      esrap: 2.2.9
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
@@ -10923,26 +11739,22 @@ snapshots:
 
   tailwindcss@4.1.18: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
-      pump: 3.0.3
+      pump: 3.0.4
       tar-stream: 2.2.0
 
-  tar-fs@3.1.1:
+  tar-fs@3.1.2:
     dependencies:
-      pump: 3.0.3
-      tar-stream: 3.1.7
+      pump: 3.0.4
+      tar-stream: 3.2.0
     optionalDependencies:
-      bare-fs: 4.5.0
+      bare-fs: 4.7.1
       bare-path: 3.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
 
   tar-stream@2.2.0:
     dependencies:
@@ -10952,18 +11764,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar-stream@3.1.7:
+  tar-stream@3.2.0:
     dependencies:
-      b4a: 1.7.3
+      b4a: 1.8.1
+      bare-fs: 4.7.1
       fast-fifo: 1.3.2
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
+      streamx: 2.25.0
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
 
   temp-dir@3.0.0: {}
 
-  tempy@3.1.0:
+  tempy@3.2.0:
     dependencies:
       is-stream: 3.0.0
       temp-dir: 3.0.0
@@ -10978,28 +11792,19 @@ snapshots:
       async-lock: 1.4.1
       byline: 5.0.0
       debug: 4.4.3
-      docker-compose: 1.3.0
-      dockerode: 4.0.9
-      get-port: 7.1.0
+      docker-compose: 1.4.2
+      dockerode: 4.0.12
+      get-port: 7.2.0
       proper-lockfile: 4.1.2
       properties-reader: 2.3.0
       ssh-remote-port-forward: 1.0.4
-      tar-fs: 3.1.1
+      tar-fs: 3.1.2
       tmp: 0.2.5
-      undici: 7.16.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
+      undici: 7.25.0
 
-  text-decoder@1.2.3:
+  text-decoder@1.2.7:
     dependencies:
-      b4a: 1.7.3
-    transitivePeerDependencies:
-      - react-native-b4a
-
-  text-extensions@2.4.0: {}
+      b4a: 1.8.1
 
   thenify-all@1.6.0:
     dependencies:
@@ -11018,8 +11823,6 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
-  through@2.3.8: {}
-
   time-span@5.1.0:
     dependencies:
       convert-hrtime: 5.0.0
@@ -11033,22 +11836,22 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.2.2: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@3.0.3: {}
+  tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.16: {}
+  tldts-core@7.1.0: {}
 
-  tldts@7.0.16:
+  tldts@7.1.0:
     dependencies:
-      tldts-core: 7.0.16
+      tldts-core: 7.1.0
 
   tmp@0.2.5: {}
 
@@ -11060,9 +11863,9 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tough-cookie@6.0.0:
+  tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.16
+      tldts: 7.1.0
 
   tr46@0.0.3: {}
 
@@ -11081,7 +11884,7 @@ snapshots:
       mongodb-uri: 0.9.7
 
   tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
+    dependencies:
       typescript: 5.9.3
 
   tslib@1.14.1: {}
@@ -11090,8 +11893,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
-      get-tsconfig: 4.13.0
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11107,22 +11910,23 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-is@2.0.1:
+  type-is@2.1.0:
     dependencies:
-      content-type: 1.0.5
+      content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 
   typescript@5.9.3: {}
 
-  uglify-js@3.19.3:
-    optional: true
+  uc.micro@2.1.0: {}
+
+  uglify-js@3.19.3: {}
 
   undici-types@5.26.5: {}
 
   undici-types@7.16.0: {}
 
-  undici@7.16.0: {}
+  undici@7.25.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -11144,14 +11948,14 @@ snapshots:
 
   unplugin@1.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       chokidar: 3.6.0
-      webpack-sources: 3.3.3
+      webpack-sources: 3.5.0
       webpack-virtual-modules: 0.5.0
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -11168,128 +11972,100 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-tsconfig-paths@6.0.3(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-    optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1):
+  vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.52.5
-      tinyglobby: 0.2.15
-    optionalDependencies:
       '@types/node': 25.0.3
-      fsevents: 2.3.3
-      jiti: 2.6.1
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      jiti: 2.7.0
       lightningcss: 1.30.2
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
       tsx: 4.21.0
-      yaml: 2.8.1
-
-  vitefu@1.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)):
+      yaml: 2.9.0
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+      fsevents: 2.3.3
 
-  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1):
+  vitefu@1.1.3(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+
+  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.3.0):
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.0.3
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
       '@vitest/spy': 4.0.16
       '@vitest/utils': 4.0.16
       es-module-lexer: 1.7.0
-      expect-type: 1.2.2
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.0.3
+      expect-type: 1.3.0
       jsdom: 27.3.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
 
-  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(jsdom@27.4.0):
     dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.0.3
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
       '@vitest/spy': 4.0.16
       '@vitest/utils': 4.0.16
       es-module-lexer: 1.7.0
-      expect-type: 1.2.2
+      expect-type: 1.3.0
+      jsdom: 27.4.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.0.3
-      jsdom: 27.4.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
 
-  web-worker@1.2.0: {}
+  web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
 
-  webidl-conversions@8.0.0: {}
+  webidl-conversions@8.0.1: {}
 
-  webpack-sources@3.3.3: {}
+  webpack-sources@3.5.0: {}
 
   webpack-virtual-modules@0.5.0: {}
 
@@ -11299,6 +12075,8 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
+  whatwg-mimetype@5.0.0: {}
+
   whatwg-url@14.2.0:
     dependencies:
       tr46: 5.1.1
@@ -11307,7 +12085,7 @@ snapshots:
   whatwg-url@15.1.0:
     dependencies:
       tr46: 6.0.0
-      webidl-conversions: 8.0.0
+      webidl-conversions: 8.0.1
 
   whatwg-url@5.0.0:
     dependencies:
@@ -11325,6 +12103,12 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi-cjs@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -11335,11 +12119,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
+  ws@8.21.0: {}
 
   xcase@2.0.1: {}
 
@@ -11353,7 +12137,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.1: {}
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 
@@ -11381,8 +12165,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.2.1: {}
-
   yoctocolors@2.1.2: {}
 
   zimmerframe@1.1.4: {}
@@ -11399,4 +12181,4 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
## What

Replaces the plain `<textarea>` for encounter notes with a CodeMirror 6 editor that renders markdown inline, Obsidian-style — typing `## ` makes the line a heading *in place*, while the stored value stays plain markdown. Adds a sanitized read-only viewer for the encounter detail page.

Raw markdown is the source of truth (stored byte-for-byte); rendering is view-only and sanitized. **No DB or backend change** — `encounters.description` is already free-text `TEXT`, and the ArkType validator passes it through untouched.

## Editor engine: vendored, not a dependency

The inline-preview machinery comes from [atomic-editor](https://github.com/kenforthewin/atomic-editor) (MIT). Rather than depend on `@atomic-editor/editor`, the React-free CodeMirror 6 extensions are **vendored** into `apps/frontend/src/lib/editor/inline-preview/` at a pinned commit (`26f75e76`), because the package is pre-1.0, single-maintainer, and declares `react`/`react-dom` as *required* peers (only its React component uses them; the engine does not).

Result: **React is not installed at all** — it cannot end up in the bundle. `VENDORED.md` records the source commit + local modifications for re-syncing; the dir is excluded from Biome to stay verbatim.

## Changes

- `src/lib/editor/inline-preview/` — vendored CM6 engine (+ LICENSE, VENDORED.md, local barrel)
- `MarkdownEditor.svelte` — Svelte 5 wrapper (onMount, `$bindable`, cursor-safe reconcile), themed to design tokens (forest accent, Merriweather body, Yanone headings), forest focus-ring, placeholder + disabled parity
- `MarkdownView.svelte` — `markdown-it` (`html:false`) + existing `isomorphic-dompurify`, link hardening (`target=_blank rel=noopener noreferrer nofollow`)
- Wired into `encounter-form.svelte` (editor) and `encounter-detail.svelte` (viewer — the only display surface)
- Deps via `aube`, exact-pinned; `svelteTesting()` enables Svelte 5 component tests

## Verification

- ✅ 27/27 frontend unit tests (9 new: XSS strip, inert `javascript:` links, link hardening, heading-decoration render, value reconcile)
- ✅ `svelte-check`: 0 errors (new files clean)
- ✅ Biome: clean on authored files
- ✅ Production build succeeds; React absent, CM6 present

## Not covered

- **No Playwright e2e / live browser pass.** The interactive create→save→reload flow is auth-gated and the e2e harness has no authenticated fixture yet. The inline render is covered by a unit asserting the `.cm-atomic-h2` decoration, but a manual pass on the running stack is still wanted.
- Existing plain-text notes starting with `#`/`- `/`> ` will now render as markdown (low blast radius; short free-text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)