### PR TITLE
fix(frontend): Cache-bust home-screen icon URLs so iOS reloads them

### DIFF
--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="%sveltekit.assets%/favicon.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="%sveltekit.assets%/favicon-16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="%sveltekit.assets%/favicon.png?v=2" />
+    <link rel="icon" type="image/png" sizes="16x16" href="%sveltekit.assets%/favicon-16.png?v=2" />
+    <!-- ?v=2 busts iOS/Safari's per-URL home-screen icon cache so the updated icon is re-fetched on re-add -->
+    <link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png?v=2" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
     <meta name="theme-color" content="#2d5016" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/apps/frontend/static/manifest.webmanifest
+++ b/apps/frontend/static/manifest.webmanifest
@@ -10,19 +10,19 @@
   "theme_color": "#2d5016",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "/icon-192.png?v=2",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-512.png",
+      "src": "/icon-512.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-maskable-512.png",
+      "src": "/icon-maskable-512.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
iOS/Safari caches the apple-touch-icon and PWA manifest icons per URL and
freezes the captured home-screen icon, so re-adding the app kept showing
the old cropped icon even after the asset itself was fixed. Append a
version query (?v=2) to the icon references so the updated icons are
fetched fresh on the next re-add.

https://claude.ai/code/session_018eZ6LAXid5tCawPunRVUaQ