### PR TITLE
feat(frontend): Add friend to collective from friend detail page

### DIFF
--- a/apps/frontend/src/lib/components/friends/sections/collectives-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/collectives-section.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { onMount } from 'svelte';
 import BuildingOffice from 'svelte-heros-v2/BuildingOffice.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import { removeMember } from '$lib/api/collectives';
@@ -40,6 +41,16 @@ async function handleRemoveFromCollective(collectiveId: string, membershipId: st
     removingCollectiveId = null;
   }
 }
+
+onMount(() => {
+  function handleAddCollective() {
+    showAddToCollectiveModal = true;
+  }
+  window.addEventListener('shortcut:add-collective', handleAddCollective);
+  return () => {
+    window.removeEventListener('shortcut:add-collective', handleAddCollective);
+  };
+});
 </script>
 
 {#if collectives.length > 0}

--- a/apps/frontend/src/lib/components/friends/subresources/add-detail-dropdown.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/add-detail-dropdown.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Briefcase from 'svelte-heros-v2/Briefcase.svelte';
+import BuildingOffice from 'svelte-heros-v2/BuildingOffice.svelte';
 import Calendar from 'svelte-heros-v2/Calendar.svelte';
 import ChevronDown from 'svelte-heros-v2/ChevronDown.svelte';
 import Envelope from 'svelte-heros-v2/Envelope.svelte';
@@ -21,6 +22,7 @@ export type SubresourceType =
   | 'date'
   | 'social'
   | 'circle'
+  | 'collective'
   | 'professional'
   | 'relationship';
 
@@ -41,6 +43,7 @@ const optionConfig: { type: SubresourceType; labelKey: string; icon: string }[] 
   { type: 'date', labelKey: 'subresources.dropdown.importantDate', icon: 'calendar' },
   { type: 'social', labelKey: 'subresources.dropdown.socialProfile', icon: 'share' },
   { type: 'circle', labelKey: 'subresources.dropdown.circle', icon: 'users' },
+  { type: 'collective', labelKey: 'subresources.dropdown.collective', icon: 'building-office' },
   { type: 'professional', labelKey: 'subresources.dropdown.employment', icon: 'briefcase' },
   { type: 'relationship', labelKey: 'relationshipSection.addRelationship', icon: 'heart' },
 ];
@@ -115,6 +118,8 @@ function handleClickOutside(e: MouseEvent) {
             <Share class="w-4 h-4 text-gray-400" strokeWidth="2" />
           {:else if option.icon === 'users'}
             <Users class="w-4 h-4 text-gray-400" strokeWidth="2" />
+          {:else if option.icon === 'building-office'}
+            <BuildingOffice class="w-4 h-4 text-gray-400" strokeWidth="2" />
           {:else if option.icon === 'briefcase'}
             <Briefcase class="w-4 h-4 text-gray-400" strokeWidth="2" />
           {:else if option.icon === 'heart'}

--- a/apps/frontend/src/lib/components/friends/subresources/mobile-add-detail-modal.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/mobile-add-detail-modal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import Briefcase from 'svelte-heros-v2/Briefcase.svelte';
+import BuildingOffice from 'svelte-heros-v2/BuildingOffice.svelte';
 import Calendar from 'svelte-heros-v2/Calendar.svelte';
 import Envelope from 'svelte-heros-v2/Envelope.svelte';
 import Heart from 'svelte-heros-v2/Heart.svelte';
@@ -34,6 +35,7 @@ const optionConfig: { type: SubresourceType; labelKey: string; icon: string }[] 
   { type: 'date', labelKey: 'subresources.dropdown.importantDate', icon: 'calendar' },
   { type: 'social', labelKey: 'subresources.dropdown.socialProfile', icon: 'share' },
   { type: 'circle', labelKey: 'subresources.dropdown.circle', icon: 'users' },
+  { type: 'collective', labelKey: 'subresources.dropdown.collective', icon: 'building-office' },
   { type: 'professional', labelKey: 'subresources.dropdown.employment', icon: 'briefcase' },
   { type: 'relationship', labelKey: 'relationshipSection.addRelationship', icon: 'heart' },
 ];
@@ -135,6 +137,8 @@ onMount(() => {
               <Share class="w-6 h-6 text-forest" strokeWidth="2" />
             {:else if option.icon === 'users'}
               <Users class="w-6 h-6 text-forest" strokeWidth="2" />
+            {:else if option.icon === 'building-office'}
+              <BuildingOffice class="w-6 h-6 text-forest" strokeWidth="2" />
             {:else if option.icon === 'briefcase'}
               <Briefcase class="w-6 h-6 text-forest" strokeWidth="2" />
             {:else if option.icon === 'heart'}

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -880,6 +880,7 @@
       "socialProfile": "Soziales Profil",
       "relationship": "Beziehung",
       "circle": "Freundekreis",
+      "collective": "Kollektiv",
       "workExperience": "Berufserfahrung",
       "member": "Mitglied"
     },
@@ -1327,6 +1328,7 @@
       "importantDate": "Wichtiger Termin",
       "socialProfile": "Soziales Profil",
       "circle": "Freundeskreis",
+      "collective": "Kollektiv",
       "employment": "Berufserfahrung"
     }
   }

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -880,6 +880,7 @@
       "socialProfile": "Social Profile",
       "relationship": "Relationship",
       "circle": "Circle",
+      "collective": "Collective",
       "workExperience": "Work Experience",
       "member": "Member"
     },
@@ -1327,6 +1328,7 @@
       "importantDate": "Important Date",
       "socialProfile": "Social Profile",
       "circle": "Circle",
+      "collective": "Collective",
       "employment": "Employment"
     }
   }

--- a/apps/frontend/src/lib/shortcuts/config.ts
+++ b/apps/frontend/src/lib/shortcuts/config.ts
@@ -74,6 +74,7 @@ export const FRIEND_DETAIL_ACTIONS: MenuShortcut[] = [
   { key: 's', labelKey: 'shortcuts.add.socialProfile' },
   { key: 'r', labelKey: 'shortcuts.add.relationship' },
   { key: 'c', labelKey: 'shortcuts.add.circle' },
+  { key: 'o', labelKey: 'shortcuts.add.collective' },
   { key: 'w', labelKey: 'shortcuts.add.workExperience' },
 ];
 
@@ -86,6 +87,7 @@ export const FRIEND_DETAIL_EVENTS: Record<string, string> = {
   s: 'shortcut:add-social',
   r: 'shortcut:add-relationship',
   c: 'shortcut:add-circle',
+  o: 'shortcut:add-collective',
   w: 'shortcut:add-professional',
 };
 


### PR DESCRIPTION
## Summary

Friends without any collective membership had no way to be added to a collective from their detail page, since the collectives section is hidden when empty. This exposes the existing `AddToCollectiveModal` through the add-detail menus and a keyboard shortcut.

- Add **Collective** entry to the desktop add dropdown and the mobile add modal
- Add `a` → `o` keyboard shortcut dispatching `shortcut:add-collective` (matches the `o` = collective convention from the nav and create menus)
- Listen for the event in the collectives section, which stays mounted even when the friend has no collectives yet
- New i18n keys in en/de: `shortcuts.add.collective`, `subresources.dropdown.collective`

The modal itself was already wired up and handles collective selection, role choice, relationship preview, and duplicate filtering.

## Test plan

- [ ] Open a friend with no collectives → desktop Add dropdown shows "Collective" → modal opens
- [ ] Mobile FAB → Add detail → "Collective" tile opens modal
- [ ] Press `a` then `o` on friend detail → modal opens
- [ ] Add friend to a collective → section appears with new membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)