### PR TITLE
fix(backend): Read self-profile from DB instead of cached session

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -9,7 +9,7 @@ import { getAuth } from '../lib/auth.js';
 import { authMiddleware, getAuthSession, getAuthUser } from '../middleware/auth.js';
 import { passkeyListRateLimitMiddleware } from '../middleware/rate-limit.js';
 import {
-  getSelfProfileExternalId,
+  getUserSelfProfile,
   getUserWithPreferences,
   updateUserPreferences,
 } from '../models/queries/users.queries.js';
@@ -59,18 +59,14 @@ app.get('/me', authMiddleware, async (c) => {
     throw new UserNotFoundError();
   }
 
-  // Look up the self-profile external_id from the friends table directly,
-  // using the internal self_profile_id from the Better Auth session.
-  // We avoid querying auth.users here because Better Auth user IDs are not
-  // UUIDs and the legacy external_id column is UUID-typed.
-  let selfProfileExternalId: string | null = null;
-  if (session.user.selfProfileId) {
-    const result = await getSelfProfileExternalId.run(
-      { selfProfileId: session.user.selfProfileId },
-      db,
-    );
-    selfProfileExternalId = result[0]?.self_profile_external_id ?? null;
-  }
+  // Look up the self-profile external_id from auth."user" directly instead of
+  // trusting session.user.selfProfileId: the session cookie cache (5 min) holds
+  // a stale null right after onboarding sets the self-profile via SQL, which
+  // trapped users in an onboarding redirect loop until the cache expired.
+  // We still avoid the legacy auth.users table because Better Auth user IDs
+  // are not UUIDs and the legacy external_id column is UUID-typed.
+  const result = await getUserSelfProfile.run({ userExternalId: authUser.betterAuthId }, db);
+  const selfProfileExternalId = result[0]?.self_profile_external_id ?? null;
 
   const response: UserWithPreferencesResponse = {
     user: {


### PR DESCRIPTION
## Summary
- `GET /api/auth/me` derived `hasCompletedOnboarding` from `session.user.selfProfileId`, which the Better Auth cookie cache holds for 5 minutes
- Onboarding sets the self-profile via direct SQL, so the cached `null` trapped fresh users in an onboarding redirect loop until the cache expired; retrying the onboarding form then 400s with "Self-profile already exists"
- Fix: look up `auth."user".self_profile_id` directly via the existing `getUserSelfProfile` query (single indexed query)

## Test plan
- [x] Reproduced the trap with a fresh registration before the fix
- [x] After the fix: fresh user completes onboarding and immediately navigates freely (no redirect loop)
- [x] Backend `tsc --noEmit` clean, full test suite green via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)