### PR TITLE
feat(frontend): Teach keyboard shortcuts via hints on mouse actions

### DIFF
--- a/apps/frontend/src/lib/components/collectives/collective-detail.svelte
+++ b/apps/frontend/src/lib/components/collectives/collective-detail.svelte
@@ -502,6 +502,8 @@ onMount(() => {
         type="button"
         onclick={() => onEdit?.()}
         class="px-4 py-2 bg-forest text-white rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+        data-shortcut="e"
+        data-shortcut-label="shortcuts.help.editCollective"
       >
         {$i18n.t('common.edit')}
       </button>
@@ -542,6 +544,8 @@ onMount(() => {
             onclick={() => openEditModal('phone')}
             class="text-sm font-body font-semibold text-white/90 hover:text-white
                    flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+            data-shortcut="a p"
+            data-shortcut-label="shortcuts.add.phone"
           >
             <Plus class="w-4 h-4" strokeWidth="2" />
             {$i18n.t('friendDetail.actions.addPhone')}
@@ -573,6 +577,8 @@ onMount(() => {
             onclick={() => openEditModal('email')}
             class="text-sm font-body font-semibold text-white/90 hover:text-white
                    flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+            data-shortcut="a e"
+            data-shortcut-label="shortcuts.add.email"
           >
             <Plus class="w-4 h-4" strokeWidth="2" />
             {$i18n.t('friendDetail.actions.addEmail')}
@@ -604,6 +610,8 @@ onMount(() => {
             onclick={() => openEditModal('address')}
             class="text-sm font-body font-semibold text-white/90 hover:text-white
                    flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+            data-shortcut="a a"
+            data-shortcut-label="shortcuts.add.address"
           >
             <Plus class="w-4 h-4" strokeWidth="2" />
             {$i18n.t('friendDetail.actions.addAddress')}
@@ -635,6 +643,8 @@ onMount(() => {
             onclick={() => openEditModal('url')}
             class="text-sm font-body font-semibold text-white/90 hover:text-white
                    flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+            data-shortcut="a u"
+            data-shortcut-label="shortcuts.add.url"
           >
             <Plus class="w-4 h-4" strokeWidth="2" />
             {$i18n.t('friendDetail.actions.addUrl')}
@@ -667,6 +677,8 @@ onMount(() => {
           onclick={() => openEditModal('circle')}
           class="text-sm font-body font-semibold text-white/90 hover:text-white
                  flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+          data-shortcut="a c"
+          data-shortcut-label="shortcuts.add.circle"
         >
           <Plus class="w-4 h-4" strokeWidth="2" />
           {$i18n.t('friendDetail.actions.addCircle')}
@@ -697,6 +709,8 @@ onMount(() => {
         onclick={() => { showAddMember = true; isModalOpen.set(true); }}
         class="text-sm font-body font-semibold text-white/90 hover:text-white
                flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+        data-shortcut="a m"
+        data-shortcut-label="shortcuts.add.member"
       >
         <Plus class="w-4 h-4" strokeWidth="2" />
         {$i18n.t('collectives.addMember.button')}

--- a/apps/frontend/src/lib/components/collectives/collective-grid.svelte
+++ b/apps/frontend/src/lib/components/collectives/collective-grid.svelte
@@ -8,7 +8,11 @@ import Home from 'svelte-heros-v2/Home.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { goto } from '$app/navigation';
 import { createI18n } from '$lib/i18n/index.js';
-import { isOpenCollectiveModeActive, openCollectiveModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenCollectiveModeActive,
+  openCollectiveModePrefix,
+} from '$lib/stores/ui';
 import { collectiveTypeI18nKey } from '$lib/utils/collective-types';
 import type { CollectiveListItem } from '$shared';
 import FriendAvatar from '../friends/friend-avatar.svelte';
@@ -148,6 +152,8 @@ function formatDate(dateString: string | undefined): string {
           tabindex="0"
           role="link"
           aria-label="View {item.name}"
+          data-shortcut="o {getKeyboardHint(index)}"
+          data-shortcut-label="shortcuts.panels.openCollective"
         >
           <!-- Name -->
           <td class="py-2 px-3 relative">
@@ -213,6 +219,8 @@ function formatDate(dateString: string | undefined): string {
       class="flex items-start gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:border-forest hover:shadow-sm transition-all relative"
       class:opacity-60={item.deletedAt}
       data-sveltekit-preload-data="tap"
+      data-shortcut="o {getKeyboardHint(index)}"
+      data-shortcut-label="shortcuts.panels.openCollective"
     >
       <KeyboardHintBadge {index} isActive={$isOpenCollectiveModeActive} prefix={$openCollectiveModePrefix} variant="card" />
 

--- a/apps/frontend/src/lib/components/collectives/member-list.svelte
+++ b/apps/frontend/src/lib/components/collectives/member-list.svelte
@@ -4,7 +4,7 @@ import NoSymbol from 'svelte-heros-v2/NoSymbol.svelte';
 import Tag from 'svelte-heros-v2/Tag.svelte';
 import Trash from 'svelte-heros-v2/Trash.svelte';
 import { createI18n } from '$lib/i18n/index.js';
-import { isOpenMemberModeActive, openMemberModePrefix } from '$lib/stores/ui';
+import { getKeyboardHint, isOpenMemberModeActive, openMemberModePrefix } from '$lib/stores/ui';
 import type { CollectiveMember } from '$shared';
 import FriendAvatar from '../friends/friend-avatar.svelte';
 import KeyboardHintBadge from '../keyboard-hint-badge.svelte';
@@ -59,7 +59,12 @@ function formatDate(dateStr: string | null): string {
         {#each activeMembers as member, index (member.id)}
           <div class="flex items-center justify-between gap-4 bg-white border border-gray-200 rounded-lg p-3 hover:border-gray-300 transition-colors relative">
             <KeyboardHintBadge {index} isActive={$isOpenMemberModeActive} prefix={$openMemberModePrefix} variant="card" />
-            <a href="/friends/{member.contact.id}" class="flex items-center gap-3 flex-1 min-w-0">
+            <a
+              href="/friends/{member.contact.id}"
+              class="flex items-center gap-3 flex-1 min-w-0"
+              data-shortcut="o {getKeyboardHint(index)}"
+              data-shortcut-label="shortcuts.panels.openMember"
+            >
               <FriendAvatar
                 displayName={member.contact.displayName}
                 photoUrl={member.contact.photoUrl}

--- a/apps/frontend/src/lib/components/encounters/encounter-card.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-card.svelte
@@ -66,6 +66,8 @@ function formatDate(dateStr: string): string {
 <a
   {href}
   class="block bg-white border border-gray-200 rounded-lg p-4 hover:border-forest hover:shadow-sm transition-all relative"
+  data-shortcut={keyHint ? `o ${keyHint}` : undefined}
+  data-shortcut-label={keyHint ? 'shortcuts.panels.openEncounter' : undefined}
 >
   {#if showHint && keyHint}
     <div class="absolute -left-1 -top-1 min-w-6 h-6 px-1 bg-forest text-white rounded-full flex items-center justify-center text-xs font-mono font-bold shadow-md z-10">

--- a/apps/frontend/src/lib/components/encounters/encounter-detail.svelte
+++ b/apps/frontend/src/lib/components/encounters/encounter-detail.svelte
@@ -8,6 +8,7 @@ import MarkdownView from '$lib/editor/markdown-view.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { encounters } from '$lib/stores/encounters';
 import {
+  getKeyboardHint,
   isOpenEncounterFriendModeActive,
   openEncounterFriendModePrefix,
   visibleEncounterFriendIds,
@@ -102,6 +103,8 @@ async function handleDelete() {
         type="button"
         onclick={() => onEdit?.()}
         class="px-4 py-2 bg-forest text-white rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+        data-shortcut="e"
+        data-shortcut-label="shortcuts.help.editEncounter"
       >
         {$i18n.t('common.edit')}
       </button>
@@ -129,6 +132,8 @@ async function handleDelete() {
           <a
             href="/friends/{friend.id}"
             class="inline-flex items-center gap-2 bg-white border border-gray-200 px-3 py-2 rounded-lg hover:border-forest transition-colors"
+            data-shortcut="o {getKeyboardHint(index)}"
+            data-shortcut-label="shortcuts.panels.openFriend"
           >
             <FriendAvatar
               displayName={friend.displayName}

--- a/apps/frontend/src/lib/components/friends/friend-detail.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-detail.svelte
@@ -234,6 +234,8 @@ onMount(() => {
       <a
         href="/friends/{friend.id}/edit"
         class="px-4 py-2 bg-forest text-white rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+        data-shortcut="e"
+        data-shortcut-label="shortcuts.help.editFriend"
       >
         {$i18n.t('common.edit')}
       </a>

--- a/apps/frontend/src/lib/components/friends/friend-grid.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-grid.svelte
@@ -6,7 +6,7 @@ import ChevronUp from 'svelte-heros-v2/ChevronUp.svelte';
 import Star from 'svelte-heros-v2/Star.svelte';
 import { goto } from '$app/navigation';
 import { createI18n } from '$lib/i18n/index.js';
-import { isOpenModeActive, openModePrefix } from '$lib/stores/ui';
+import { getKeyboardHint, isOpenModeActive, openModePrefix } from '$lib/stores/ui';
 import {
   type BirthdayFormat,
   COLUMN_DEFINITIONS,
@@ -246,6 +246,8 @@ function getMatchSourceBadge(
           tabindex="0"
           role="link"
           aria-label="View {item.displayName}"
+          data-shortcut="o {getKeyboardHint(index)}"
+          data-shortcut-label="shortcuts.panels.openFriend"
         >
           {#each columns as columnId}
             <td
@@ -336,6 +338,8 @@ function getMatchSourceBadge(
       href={getFriendDetailUrl(item.id)}
       class="flex items-start gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:border-forest hover:shadow-sm transition-all relative"
       data-sveltekit-preload-data="tap"
+      data-shortcut="o {getKeyboardHint(index)}"
+      data-shortcut-label="shortcuts.panels.openFriend"
     >
       <KeyboardHintBadge {index} isActive={$isOpenModeActive} prefix={$openModePrefix} variant="card" />
 

--- a/apps/frontend/src/lib/components/friends/friend-list.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-list.svelte
@@ -547,6 +547,8 @@ function openFirstResult() {
             class="p-1.5 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             title={$i18n.t('aria.previousPage')}
             aria-label={$i18n.t('aria.previousPage')}
+            data-shortcut="<"
+            data-shortcut-label="shortcuts.help.previousPage"
           >
             <ChevronLeft class="w-4 h-4 text-gray-600" strokeWidth="2" />
           </button>
@@ -559,6 +561,8 @@ function openFirstResult() {
             class="p-1.5 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             title={$i18n.t('aria.nextPage')}
             aria-label={$i18n.t('aria.nextPage')}
+            data-shortcut=">"
+            data-shortcut-label="shortcuts.help.nextPage"
           >
             <ChevronRight class="w-4 h-4 text-gray-600" strokeWidth="2" />
           </button>

--- a/apps/frontend/src/lib/components/friends/relationships-section.svelte
+++ b/apps/frontend/src/lib/components/friends/relationships-section.svelte
@@ -6,7 +6,11 @@ import Users from 'svelte-heros-v2/Users.svelte';
 import XMark from 'svelte-heros-v2/XMark.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
-import { isOpenFriendLinkModeActive, openFriendLinkModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenFriendLinkModeActive,
+  openFriendLinkModePrefix,
+} from '$lib/stores/ui';
 import type { Relationship, RelationshipCategory, RelationshipTypeId } from '$shared';
 import KeyboardHintBadge from '../keyboard-hint-badge.svelte';
 import FriendAvatar from './friend-avatar.svelte';
@@ -233,6 +237,12 @@ onMount(() => {
                     <a
                       href="/friends/{relationship.relatedFriendId}"
                       class="font-body text-sm font-medium text-gray-900 hover:text-forest transition-colors truncate"
+                      data-shortcut={relationshipBadgeIndex.has(relationship.id)
+                        ? `o ${getKeyboardHint(relationshipBadgeIndex.get(relationship.id) ?? 0)}`
+                        : undefined}
+                      data-shortcut-label={relationshipBadgeIndex.has(relationship.id)
+                        ? 'shortcuts.panels.openLink'
+                        : undefined}
                     >
                       {relationship.relatedFriendDisplayName}
                     </a>

--- a/apps/frontend/src/lib/components/friends/sections/collectives-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/collectives-section.svelte
@@ -4,7 +4,11 @@ import BuildingOffice from 'svelte-heros-v2/BuildingOffice.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import { removeMember } from '$lib/api/collectives';
 import { createI18n } from '$lib/i18n/index.js';
-import { isOpenFriendLinkModeActive, openFriendLinkModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenFriendLinkModeActive,
+  openFriendLinkModePrefix,
+} from '$lib/stores/ui';
 import type { ContactCollectiveSummary } from '$shared';
 import KeyboardHintBadge from '../../keyboard-hint-badge.svelte';
 import { AddToCollectiveModal, CollectiveRow } from '../subresources';
@@ -80,6 +84,9 @@ onMount(() => {
             {collective}
             onRemove={handleRemoveFromCollective}
             isRemoving={removingCollectiveId === collective.id}
+            shortcutHint={linkStartIndex !== undefined
+              ? `o ${getKeyboardHint(linkStartIndex + i)}`
+              : undefined}
           />
         </div>
       {/each}

--- a/apps/frontend/src/lib/components/friends/sections/email-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/email-section.svelte
@@ -4,7 +4,11 @@ import Envelope from 'svelte-heros-v2/Envelope.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
-import { isOpenFriendLinkModeActive, openFriendLinkModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenFriendLinkModeActive,
+  openFriendLinkModePrefix,
+} from '$lib/stores/ui';
 import type { Email, EmailInput } from '$shared';
 import KeyboardHintBadge from '../../keyboard-hint-badge.svelte';
 import { DeleteConfirmModal, DetailEditModal, EmailEditForm, EmailRow } from '../subresources';
@@ -137,6 +141,9 @@ onMount(() => {
             onEdit={() => openEdit(email)}
             onDelete={() => openDeleteConfirm(email.id, email.emailAddress)}
             isDeleting={deletingId === email.id}
+            shortcutHint={linkStartIndex !== undefined
+              ? `o ${getKeyboardHint(linkStartIndex + i)}`
+              : undefined}
           />
         </div>
       {/each}

--- a/apps/frontend/src/lib/components/friends/sections/phone-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/phone-section.svelte
@@ -4,7 +4,11 @@ import PhoneIcon from 'svelte-heros-v2/Phone.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
-import { isOpenFriendLinkModeActive, openFriendLinkModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenFriendLinkModeActive,
+  openFriendLinkModePrefix,
+} from '$lib/stores/ui';
 import type { Phone, PhoneInput } from '$shared';
 import KeyboardHintBadge from '../../keyboard-hint-badge.svelte';
 import { DeleteConfirmModal, DetailEditModal, PhoneEditForm, PhoneRow } from '../subresources';
@@ -139,6 +143,9 @@ onMount(() => {
             onEdit={() => openEdit(phone)}
             onDelete={() => openDeleteConfirm(phone.id, phone.phoneNumber)}
             isDeleting={deletingId === phone.id}
+            shortcutHint={linkStartIndex !== undefined
+              ? `o ${getKeyboardHint(linkStartIndex + i)}`
+              : undefined}
           />
         </div>
       {/each}

--- a/apps/frontend/src/lib/components/friends/sections/social-profile-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/social-profile-section.svelte
@@ -4,7 +4,11 @@ import GlobeAlt from 'svelte-heros-v2/GlobeAlt.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
-import { isOpenFriendLinkModeActive, openFriendLinkModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenFriendLinkModeActive,
+  openFriendLinkModePrefix,
+} from '$lib/stores/ui';
 import type { SocialProfile, SocialProfileInput } from '$shared';
 import KeyboardHintBadge from '../../keyboard-hint-badge.svelte';
 import {
@@ -156,6 +160,9 @@ onMount(() => {
             onEdit={() => openEdit(profile)}
             onDelete={() => openDeleteConfirm(profile.id, profile.username || profile.profileUrl || profile.platform)}
             isDeleting={deletingId === profile.id}
+            shortcutHint={socialProfileBadgeIndex.has(profile.id)
+              ? `o ${getKeyboardHint(socialProfileBadgeIndex.get(profile.id) ?? 0)}`
+              : undefined}
           />
         </div>
       {/each}

--- a/apps/frontend/src/lib/components/friends/sections/url-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/url-section.svelte
@@ -4,7 +4,11 @@ import Link from 'svelte-heros-v2/Link.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
-import { isOpenFriendLinkModeActive, openFriendLinkModePrefix } from '$lib/stores/ui';
+import {
+  getKeyboardHint,
+  isOpenFriendLinkModeActive,
+  openFriendLinkModePrefix,
+} from '$lib/stores/ui';
 import type { Url, UrlInput } from '$shared';
 import KeyboardHintBadge from '../../keyboard-hint-badge.svelte';
 import { DeleteConfirmModal, DetailEditModal, UrlEditForm, UrlRow } from '../subresources';
@@ -137,6 +141,9 @@ onMount(() => {
             onEdit={() => openEdit(url)}
             onDelete={() => openDeleteConfirm(url.id, url.url)}
             isDeleting={deletingId === url.id}
+            shortcutHint={linkStartIndex !== undefined
+              ? `o ${getKeyboardHint(linkStartIndex + i)}`
+              : undefined}
           />
         </div>
       {/each}

--- a/apps/frontend/src/lib/components/friends/subresources/add-detail-dropdown.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/add-detail-dropdown.svelte
@@ -35,17 +35,48 @@ let isOpen = $state(false);
 let buttonRef = $state<HTMLButtonElement | null>(null);
 let menuRef = $state<HTMLDivElement | null>(null);
 
-const optionConfig: { type: SubresourceType; labelKey: string; icon: string }[] = [
-  { type: 'phone', labelKey: 'subresources.dropdown.phoneNumber', icon: 'phone' },
-  { type: 'email', labelKey: 'subresources.dropdown.emailAddress', icon: 'mail' },
-  { type: 'address', labelKey: 'subresources.dropdown.address', icon: 'map-pin' },
-  { type: 'url', labelKey: 'subresources.dropdown.websiteUrl', icon: 'link' },
-  { type: 'date', labelKey: 'subresources.dropdown.importantDate', icon: 'calendar' },
-  { type: 'social', labelKey: 'subresources.dropdown.socialProfile', icon: 'share' },
-  { type: 'circle', labelKey: 'subresources.dropdown.circle', icon: 'users' },
-  { type: 'collective', labelKey: 'subresources.dropdown.collective', icon: 'building-office' },
-  { type: 'professional', labelKey: 'subresources.dropdown.employment', icon: 'briefcase' },
-  { type: 'relationship', labelKey: 'relationshipSection.addRelationship', icon: 'heart' },
+// Shortcut keys mirror FRIEND_DETAIL_ACTIONS in $lib/shortcuts/config.ts ("a" + key)
+const optionConfig: {
+  type: SubresourceType;
+  labelKey: string;
+  icon: string;
+  shortcutKey: string;
+}[] = [
+  { type: 'phone', labelKey: 'subresources.dropdown.phoneNumber', icon: 'phone', shortcutKey: 'p' },
+  { type: 'email', labelKey: 'subresources.dropdown.emailAddress', icon: 'mail', shortcutKey: 'e' },
+  { type: 'address', labelKey: 'subresources.dropdown.address', icon: 'map-pin', shortcutKey: 'a' },
+  { type: 'url', labelKey: 'subresources.dropdown.websiteUrl', icon: 'link', shortcutKey: 'u' },
+  {
+    type: 'date',
+    labelKey: 'subresources.dropdown.importantDate',
+    icon: 'calendar',
+    shortcutKey: 'd',
+  },
+  {
+    type: 'social',
+    labelKey: 'subresources.dropdown.socialProfile',
+    icon: 'share',
+    shortcutKey: 's',
+  },
+  { type: 'circle', labelKey: 'subresources.dropdown.circle', icon: 'users', shortcutKey: 'c' },
+  {
+    type: 'collective',
+    labelKey: 'subresources.dropdown.collective',
+    icon: 'building-office',
+    shortcutKey: 'o',
+  },
+  {
+    type: 'professional',
+    labelKey: 'subresources.dropdown.employment',
+    icon: 'briefcase',
+    shortcutKey: 'w',
+  },
+  {
+    type: 'relationship',
+    labelKey: 'relationshipSection.addRelationship',
+    icon: 'heart',
+    shortcutKey: 'r',
+  },
 ];
 
 function handleSelect(type: SubresourceType) {
@@ -103,6 +134,8 @@ function handleClickOutside(e: MouseEvent) {
           class="w-full px-4 py-2 text-left text-sm font-body text-gray-700
                  hover:bg-gray-50 flex items-center gap-3 transition-colors"
           role="menuitem"
+          data-shortcut="a {option.shortcutKey}"
+          data-shortcut-label={option.labelKey}
         >
           {#if option.icon === 'phone'}
             <Phone class="w-4 h-4 text-gray-400" strokeWidth="2" />

--- a/apps/frontend/src/lib/components/friends/subresources/collective-row.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/collective-row.svelte
@@ -10,9 +10,11 @@ interface Props {
   collective: ContactCollectiveSummary;
   onRemove: (collectiveId: string, membershipId: string) => void;
   isRemoving?: boolean;
+  /** Keyboard chord that opens this link (e.g. "o 3"), shown as a hint on click */
+  shortcutHint?: string;
 }
 
-let { collective, onRemove, isRemoving = false }: Props = $props();
+let { collective, onRemove, isRemoving = false, shortcutHint }: Props = $props();
 </script>
 
 <!-- Mobile: Swipeable row (only swipe left for remove, no edit) -->
@@ -56,6 +58,8 @@ let { collective, onRemove, isRemoving = false }: Props = $props();
         <a
           href="/collectives/{collective.id}"
           class="font-body font-semibold text-forest hover:underline"
+          data-shortcut={shortcutHint}
+          data-shortcut-label={shortcutHint ? 'shortcuts.panels.openLink' : undefined}
         >
           {collective.name}
         </a>

--- a/apps/frontend/src/lib/components/friends/subresources/detail-actions.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/detail-actions.svelte
@@ -8,6 +8,10 @@ interface Props {
   isDeleting?: boolean;
   editLabel?: string;
   deleteLabel?: string;
+  /** Keyboard chord for the edit action (e.g. "e 2"), shown as a hint on click */
+  editShortcutHint?: string;
+  /** Keyboard chord for the delete action (e.g. "d 2"), shown as a hint on click */
+  deleteShortcutHint?: string;
 }
 
 let {
@@ -16,6 +20,8 @@ let {
   isDeleting = false,
   editLabel = 'Edit',
   deleteLabel = 'Delete',
+  editShortcutHint,
+  deleteShortcutHint,
 }: Props = $props();
 </script>
 
@@ -40,6 +46,8 @@ let {
              transition-colors min-w-[28px] min-h-[28px] flex items-center justify-center
              sm:min-w-[44px] sm:min-h-[44px]"
       aria-label={editLabel}
+      data-shortcut={editShortcutHint}
+      data-shortcut-label={editShortcutHint ? 'shortcuts.panels.editCircle' : undefined}
     >
       <PencilSquare class="w-4 h-4" strokeWidth="2" />
     </button>
@@ -56,6 +64,8 @@ let {
            sm:min-w-[44px] sm:min-h-[44px]
            disabled:opacity-50 disabled:cursor-not-allowed"
     aria-label={deleteLabel}
+    data-shortcut={deleteShortcutHint}
+    data-shortcut-label={deleteShortcutHint ? 'shortcuts.panels.deleteCircle' : undefined}
   >
     {#if isDeleting}
       <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">

--- a/apps/frontend/src/lib/components/friends/subresources/email-row.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/email-row.svelte
@@ -7,9 +7,11 @@ interface Props {
   onEdit: () => void;
   onDelete: () => void;
   isDeleting?: boolean;
+  /** Keyboard chord that opens this link (e.g. "o 3"), shown as a hint on click */
+  shortcutHint?: string;
 }
 
-let { email, onEdit, onDelete, isDeleting = false }: Props = $props();
+let { email, onEdit, onDelete, isDeleting = false, shortcutHint }: Props = $props();
 
 function formatEmailType(type: EmailType): string {
   const typeLabels: Record<EmailType, string> = {
@@ -26,6 +28,8 @@ function formatEmailType(type: EmailType): string {
     <a
       href="mailto:{email.emailAddress}"
       class="text-forest font-body font-semibold hover:text-forest-light truncate block"
+      data-shortcut={shortcutHint}
+      data-shortcut-label={shortcutHint ? 'shortcuts.panels.openLink' : undefined}
     >
       {email.emailAddress}
     </a>

--- a/apps/frontend/src/lib/components/friends/subresources/phone-row.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/phone-row.svelte
@@ -7,9 +7,11 @@ interface Props {
   onEdit: () => void;
   onDelete: () => void;
   isDeleting?: boolean;
+  /** Keyboard chord that opens this link (e.g. "o 3"), shown as a hint on click */
+  shortcutHint?: string;
 }
 
-let { phone, onEdit, onDelete, isDeleting = false }: Props = $props();
+let { phone, onEdit, onDelete, isDeleting = false, shortcutHint }: Props = $props();
 
 function formatPhoneType(type: PhoneType): string {
   const typeLabels: Record<PhoneType, string> = {
@@ -28,6 +30,8 @@ function formatPhoneType(type: PhoneType): string {
     <a
       href="tel:{phone.phoneNumber}"
       class="text-forest font-body font-semibold hover:text-forest-light"
+      data-shortcut={shortcutHint}
+      data-shortcut-label={shortcutHint ? 'shortcuts.panels.openLink' : undefined}
     >
       {phone.phoneNumber}
     </a>

--- a/apps/frontend/src/lib/components/friends/subresources/social-profile-row.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/social-profile-row.svelte
@@ -7,9 +7,11 @@ interface Props {
   onEdit: () => void;
   onDelete: () => void;
   isDeleting?: boolean;
+  /** Keyboard chord that opens this link (e.g. "o 3"), shown as a hint on click */
+  shortcutHint?: string;
 }
 
-let { profile, onEdit, onDelete, isDeleting = false }: Props = $props();
+let { profile, onEdit, onDelete, isDeleting = false, shortcutHint }: Props = $props();
 
 const platformLabels: Record<SocialPlatform, string> = {
   linkedin: 'LinkedIn',
@@ -52,6 +54,8 @@ function getLink(): string | null {
         target="_blank"
         rel="noopener noreferrer"
         class="text-forest font-body font-semibold hover:text-forest-light truncate block"
+        data-shortcut={shortcutHint}
+        data-shortcut-label={shortcutHint ? 'shortcuts.panels.openLink' : undefined}
       >
         {getDisplayText()}
       </a>

--- a/apps/frontend/src/lib/components/friends/subresources/url-row.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/url-row.svelte
@@ -7,9 +7,11 @@ interface Props {
   onEdit: () => void;
   onDelete: () => void;
   isDeleting?: boolean;
+  /** Keyboard chord that opens this link (e.g. "o 3"), shown as a hint on click */
+  shortcutHint?: string;
 }
 
-let { url, onEdit, onDelete, isDeleting = false }: Props = $props();
+let { url, onEdit, onDelete, isDeleting = false, shortcutHint }: Props = $props();
 
 function formatUrlType(type: UrlType): string {
   const typeLabels: Record<UrlType, string> = {
@@ -38,6 +40,8 @@ function formatUrl(rawUrl: string): string {
       target="_blank"
       rel="noopener noreferrer"
       class="text-forest font-body font-semibold hover:text-forest-light truncate block"
+      data-shortcut={shortcutHint}
+      data-shortcut-label={shortcutHint ? 'shortcuts.panels.openLink' : undefined}
     >
       {formatUrl(url.url)}
     </a>

--- a/apps/frontend/src/lib/components/nav-bar.svelte
+++ b/apps/frontend/src/lib/components/nav-bar.svelte
@@ -153,6 +153,8 @@ $effect(() => {
         <a
           href="/friends/new"
           data-sveltekit-preload-data="tap"
+          data-shortcut="n f"
+          data-shortcut-label="shortcuts.newFriend"
           onclick={closeMobileMenu}
           class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 hover:text-forest font-body font-medium transition-colors duration-200"
         >
@@ -162,6 +164,8 @@ $effect(() => {
         <a
           href="/friends"
           data-sveltekit-preload-data="tap"
+          data-shortcut="g f"
+          data-shortcut-label="shortcuts.goFriends"
           onclick={closeMobileMenu}
           class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 hover:text-forest font-body font-medium transition-colors duration-200"
         >
@@ -171,6 +175,8 @@ $effect(() => {
         <a
           href="/circles"
           data-sveltekit-preload-data="tap"
+          data-shortcut="g c"
+          data-shortcut-label="shortcuts.goCircles"
           onclick={closeMobileMenu}
           class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 hover:text-forest font-body font-medium transition-colors duration-200"
         >
@@ -180,6 +186,8 @@ $effect(() => {
         <a
           href="/encounters"
           data-sveltekit-preload-data="tap"
+          data-shortcut="g e"
+          data-shortcut-label="shortcuts.goEncounters"
           onclick={closeMobileMenu}
           class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 hover:text-forest font-body font-medium transition-colors duration-200"
         >
@@ -189,6 +197,8 @@ $effect(() => {
         <a
           href="/collectives"
           data-sveltekit-preload-data="tap"
+          data-shortcut="g o"
+          data-shortcut-label="shortcuts.goCollectives"
           onclick={closeMobileMenu}
           class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 hover:text-forest font-body font-medium transition-colors duration-200"
         >
@@ -198,6 +208,8 @@ $effect(() => {
         <a
           href="/profile"
           data-sveltekit-preload-data="tap"
+          data-shortcut="g p"
+          data-shortcut-label="shortcuts.goProfile"
           onclick={closeMobileMenu}
           class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 hover:text-forest font-body font-medium transition-colors duration-200"
         >
@@ -295,6 +307,8 @@ $effect(() => {
           class="sm:hidden p-2 rounded-md text-gray-700 hover:bg-gray-100 transition-colors duration-200"
           onclick={() => search.open()}
           aria-label="Search"
+          data-shortcut="/"
+          data-shortcut-label="shortcuts.help.focusSearch"
         >
           <MagnifyingGlass class="w-6 h-6" strokeWidth="2" />
         </button>
@@ -309,6 +323,8 @@ $effect(() => {
             onclick={() => search.open()}
             class="w-full max-w-md flex items-center gap-3 px-4 py-2 text-gray-400 bg-gray-50 hover:bg-gray-100 border border-gray-200 rounded-lg transition-colors duration-200 cursor-text"
             title="{$i18n.t('common.search')} ({isMac ? 'Cmd' : 'Ctrl'}+K)"
+            data-shortcut="/"
+            data-shortcut-label="shortcuts.help.focusSearch"
           >
             <MagnifyingGlass class="w-5 h-5 shrink-0" strokeWidth="2" />
             <span class="flex-1 text-left font-body text-sm">{$i18n.t('friends.search')}</span>
@@ -325,6 +341,8 @@ $effect(() => {
           <a
             href="/friends/new"
             data-sveltekit-preload-data="tap"
+            data-shortcut="n f"
+            data-shortcut-label="shortcuts.newFriend"
             class="inline-flex items-center gap-1.5 bg-forest text-white px-3 py-1.5 rounded-md font-body font-medium hover:bg-forest-light transition-colors duration-200 text-sm"
             title="{$i18n.t('friends.addNew')} (n)"
           >

--- a/apps/frontend/src/lib/components/search/facet-dropdown.svelte
+++ b/apps/frontend/src/lib/components/search/facet-dropdown.svelte
@@ -3,6 +3,7 @@ import { tick } from 'svelte';
 import Funnel from 'svelte-heros-v2/Funnel.svelte';
 import XMark from 'svelte-heros-v2/XMark.svelte';
 import {
+  FILTER_CATEGORY_LABELS,
   filterModeCategory,
   filterModePrefix,
   getKeyboardHint,
@@ -459,9 +460,10 @@ $effect(() => {
             <div class="mb-2">
               <span class="text-xs text-gray-400">{group.label}</span>
               <div class="mt-1 space-y-1 max-h-24 overflow-y-auto">
-                {#each group.values.slice(0, 8) as facet}
+                {#each group.values.slice(0, 8) as facet, i}
                   <label
                     class="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded text-sm"
+                    data-shortcut="f {FILTER_CATEGORY_LABELS[group.field]?.key} {getKeyboardHint(i)}"
                   >
                     <input
                       type="checkbox"
@@ -489,9 +491,10 @@ $effect(() => {
             <div class="mb-2">
               <span class="text-xs text-gray-400">{group.label}</span>
               <div class="mt-1 space-y-1 max-h-24 overflow-y-auto">
-                {#each group.values.slice(0, 8) as facet}
+                {#each group.values.slice(0, 8) as facet, i}
                   <label
                     class="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded text-sm"
+                    data-shortcut="f {FILTER_CATEGORY_LABELS[group.field]?.key} {getKeyboardHint(i)}"
                   >
                     <input
                       type="checkbox"
@@ -517,9 +520,10 @@ $effect(() => {
           </h4>
           {#each facets.relationship as group}
             <div class="space-y-1">
-              {#each group.values as facet}
+              {#each group.values as facet, i}
                 <label
                   class="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded text-sm"
+                  data-shortcut="f {FILTER_CATEGORY_LABELS[group.field]?.key} {getKeyboardHint(i)}"
                 >
                   <input
                     type="checkbox"
@@ -546,6 +550,7 @@ $effect(() => {
             <!-- No Circle option -->
             <label
               class="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded text-sm"
+              data-shortcut="f l 1"
             >
               <input
                 type="checkbox"
@@ -555,9 +560,10 @@ $effect(() => {
               />
               <span class="flex-1 italic text-gray-500">No Circle</span>
             </label>
-            {#each circlesWithMembers.slice(0, 8) as circle}
+            {#each circlesWithMembers.slice(0, 8) as circle, i}
               <label
                 class="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded text-sm"
+                data-shortcut="f l {getKeyboardHint(i + 1)}"
               >
                 <input
                   type="checkbox"

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -581,7 +581,9 @@
         "us": "US (05/15)",
         "eu": "EU (15.05.)",
         "long": "Lang (15. Mai)"
-      }
+      },
+      "shortcutHints": "Tastenkürzel-Hinweise",
+      "shortcutHintsHelp": "Zeigt einen Tipp, wenn eine angeklickte Aktion auch ein Tastenkürzel hat"
     },
     "appPasswords": {
       "title": "App-Passwörter",
@@ -908,6 +910,10 @@
       "pressKeyShown": "Die angezeigte Taste auf {{item}} drücken",
       "pressKeyShownFilter": "Taste neben dem Filterwert drücken (1-9 oder a1, b2, ...)",
       "clearAllFilters": "Alle Filter löschen"
+    },
+    "hintToast": {
+      "tip": "Tipp:",
+      "then": "dann"
     },
     "help": {
       "globalSearch": "Globale Suche",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -581,7 +581,9 @@
         "us": "US (05/15)",
         "eu": "EU (15.05.)",
         "long": "Long (May 15)"
-      }
+      },
+      "shortcutHints": "Keyboard shortcut hints",
+      "shortcutHintsHelp": "Show a tip when a clicked action also has a keyboard shortcut"
     },
     "appPasswords": {
       "title": "App Passwords",
@@ -908,6 +910,10 @@
       "pressKeyShown": "Press the key shown on {{item}}",
       "pressKeyShownFilter": "Press key shown next to filter value (1-9 or a1, b2, ...)",
       "clearAllFilters": "Clear all filters"
+    },
+    "hintToast": {
+      "tip": "Tip:",
+      "then": "then"
     },
     "help": {
       "globalSearch": "Global Search",

--- a/apps/frontend/src/lib/shortcuts/components/index.ts
+++ b/apps/frontend/src/lib/shortcuts/components/index.ts
@@ -2,3 +2,4 @@ export { default as FilterPanel } from './filter-panel.svelte';
 export { default as HelpDialog } from './help-dialog.svelte';
 export { default as HintModePanel } from './hint-mode-panel.svelte';
 export { default as MenuPanel } from './menu-panel.svelte';
+export { default as ShortcutHintToast } from './shortcut-hint-toast.svelte';

--- a/apps/frontend/src/lib/shortcuts/components/shortcut-hint-toast.svelte
+++ b/apps/frontend/src/lib/shortcuts/components/shortcut-hint-toast.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { fly } from 'svelte/transition';
+import { createI18n } from '$lib/i18n/index.js';
+import { activeHint, dismissHint } from '../hint-store.js';
+
+const i18n = createI18n();
+const DISMISS_MS = 4500;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+// Re-arm the auto-dismiss timer whenever a new hint appears
+$effect(() => {
+  const hint = $activeHint;
+  if (timer) clearTimeout(timer);
+  timer = hint ? setTimeout(dismissHint, DISMISS_MS) : null;
+  return () => {
+    if (timer) clearTimeout(timer);
+  };
+});
+
+let keyParts = $derived($activeHint ? $activeHint.keys.split(' ') : []);
+</script>
+
+{#if $activeHint}
+  <div
+    role="status"
+    aria-live="polite"
+    transition:fly={{ y: 16, duration: 200 }}
+    class="fixed bottom-6 left-6 bg-white rounded-lg shadow-lg z-50 border border-gray-200 overflow-hidden max-w-xs"
+  >
+    <div class="px-4 py-3 font-body text-sm text-gray-700">
+      <div class="flex items-center gap-1.5 flex-wrap">
+        <span class="font-medium">{$i18n.t('shortcuts.hintToast.tip')}</span>
+        {#each keyParts as part, i (i)}
+          {#if i > 0}
+            <span class="text-gray-400 text-xs">{$i18n.t('shortcuts.hintToast.then')}</span>
+          {/if}
+          <kbd class="px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs font-mono">{part}</kbd>
+        {/each}
+      </div>
+      {#if $activeHint.labelKey}
+        <div class="mt-1 text-xs text-gray-500">{$i18n.t($activeHint.labelKey)}</div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/apps/frontend/src/lib/shortcuts/hint-store.test.ts
+++ b/apps/frontend/src/lib/shortcuts/hint-store.test.ts
@@ -1,0 +1,134 @@
+import { get, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the auth store so the preference can be toggled per test
+const mockShowShortcutHints = writable(true);
+vi.mock('$lib/stores/auth', () => ({
+  showShortcutHints: mockShowShortcutHints,
+}));
+
+const { activeHint, dismissHint, handleShortcutHintClick, resetShownHints, showShortcutHint } =
+  await import('./hint-store.js');
+
+describe('showShortcutHint', () => {
+  beforeEach(() => {
+    mockShowShortcutHints.set(true);
+    resetShownHints();
+    dismissHint();
+  });
+
+  it('sets the active hint with keys and label', () => {
+    showShortcutHint('g f', 'shortcuts.goFriends');
+
+    const hint = get(activeHint);
+    expect(hint).not.toBeNull();
+    expect(hint?.keys).toBe('g f');
+    expect(hint?.labelKey).toBe('shortcuts.goFriends');
+  });
+
+  it('shows each chord only once per session', () => {
+    showShortcutHint('g f');
+    dismissHint();
+    showShortcutHint('g f');
+
+    expect(get(activeHint)).toBeNull();
+  });
+
+  it('dedupes chords independently', () => {
+    showShortcutHint('g f');
+    dismissHint();
+    showShortcutHint('o 3');
+
+    expect(get(activeHint)?.keys).toBe('o 3');
+  });
+
+  it('does nothing when the preference is disabled', () => {
+    mockShowShortcutHints.set(false);
+    showShortcutHint('g f');
+
+    expect(get(activeHint)).toBeNull();
+  });
+
+  it('persists shown chords to sessionStorage', () => {
+    showShortcutHint('g f');
+
+    const raw = sessionStorage.getItem('freundebuch-shortcut-hints-shown');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toContain('g f');
+  });
+
+  it('ignores empty keys', () => {
+    showShortcutHint('');
+
+    expect(get(activeHint)).toBeNull();
+  });
+});
+
+describe('handleShortcutHintClick', () => {
+  beforeEach(() => {
+    mockShowShortcutHints.set(true);
+    resetShownHints();
+    dismissHint();
+    document.body.innerHTML = '';
+  });
+
+  function clickEvent(target: Element, detail = 1): MouseEvent {
+    const event = new MouseEvent('click', { bubbles: true, detail });
+    Object.defineProperty(event, 'target', { value: target });
+    return event;
+  }
+
+  it('shows a hint when clicking an element with data-shortcut', () => {
+    const button = document.createElement('button');
+    button.dataset.shortcut = 'n f';
+    button.dataset.shortcutLabel = 'shortcuts.newFriend';
+    document.body.appendChild(button);
+
+    handleShortcutHintClick(clickEvent(button));
+
+    const hint = get(activeHint);
+    expect(hint?.keys).toBe('n f');
+    expect(hint?.labelKey).toBe('shortcuts.newFriend');
+  });
+
+  it('resolves data-shortcut from an ancestor of the clicked element', () => {
+    const row = document.createElement('tr');
+    row.dataset.shortcut = 'o 3';
+    const cell = document.createElement('td');
+    row.appendChild(cell);
+    document.body.appendChild(row);
+
+    handleShortcutHintClick(clickEvent(cell));
+
+    expect(get(activeHint)?.keys).toBe('o 3');
+  });
+
+  it('skips keyboard-activated synthetic clicks (detail === 0)', () => {
+    const button = document.createElement('button');
+    button.dataset.shortcut = 'g f';
+    document.body.appendChild(button);
+
+    handleShortcutHintClick(clickEvent(button, 0));
+
+    expect(get(activeHint)).toBeNull();
+  });
+
+  it('skips elements with an empty data-shortcut attribute', () => {
+    const button = document.createElement('button');
+    button.dataset.shortcut = '';
+    document.body.appendChild(button);
+
+    handleShortcutHintClick(clickEvent(button));
+
+    expect(get(activeHint)).toBeNull();
+  });
+
+  it('ignores clicks outside any data-shortcut element', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    handleShortcutHintClick(clickEvent(div));
+
+    expect(get(activeHint)).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/shortcuts/hint-store.ts
+++ b/apps/frontend/src/lib/shortcuts/hint-store.ts
@@ -1,0 +1,80 @@
+import { get, writable } from 'svelte/store';
+import { showShortcutHints } from '$lib/stores/auth';
+
+/** A shortcut hint toast triggered by a mouse-driven action */
+export interface ActiveHint {
+  /** Space-separated key chord, e.g. "g f", "o 3", "a p" */
+  keys: string;
+  /** Optional i18n key describing the action, e.g. "shortcuts.goFriends" */
+  labelKey?: string;
+  /** Monotonic id so re-showing retriggers the dismiss timer */
+  id: number;
+}
+
+const SESSION_KEY = 'freundebuch-shortcut-hints-shown';
+
+function loadShown(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    // sessionStorage unavailable (SSR, private mode) — in-memory Set still dedupes
+    return new Set();
+  }
+}
+
+const shown = loadShown();
+let counter = 0;
+
+export const activeHint = writable<ActiveHint | null>(null);
+
+function persistShown(): void {
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify([...shown]));
+  } catch {
+    // Ignore — dedupe falls back to the in-memory Set
+  }
+}
+
+/**
+ * Show a hint toast for a shortcut, once per session per chord.
+ * No-op when the user disabled shortcut hints in their preferences.
+ */
+export function showShortcutHint(keys: string, labelKey?: string): void {
+  if (!keys) return;
+  if (!get(showShortcutHints)) return;
+  if (shown.has(keys)) return;
+  shown.add(keys);
+  persistShown();
+  activeHint.set({ keys, labelKey, id: ++counter });
+}
+
+export function dismissHint(): void {
+  activeHint.set(null);
+}
+
+/** Test-only: reset the once-per-session dedupe state */
+export function resetShownHints(): void {
+  shown.clear();
+  persistShown();
+}
+
+/**
+ * Global click handler: when a mouse click lands on (or inside) an element
+ * with a data-shortcut attribute, show the hint toast for that shortcut.
+ * Registered in the capture phase so it fires even when inner handlers
+ * call stopPropagation().
+ */
+export function handleShortcutHintClick(event: MouseEvent): void {
+  // Keyboard-activated buttons (Enter/Space) fire synthetic clicks with
+  // detail === 0 — the user already knows the keyboard, skip the hint.
+  if (event.detail === 0) return;
+
+  const target = event.target instanceof Element ? event.target : null;
+  const el = target?.closest<HTMLElement>('[data-shortcut]');
+  const keys = el?.dataset.shortcut?.trim();
+  // Empty data-shortcut means "no valid shortcut in this context"
+  if (!el || !keys) return;
+
+  showShortcutHint(keys, el.dataset.shortcutLabel || undefined);
+}

--- a/apps/frontend/src/lib/shortcuts/keyboard-shortcuts.svelte
+++ b/apps/frontend/src/lib/shortcuts/keyboard-shortcuts.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { onMount } from 'svelte';
 import { page } from '$app/stores';
 import { createI18n } from '$lib/i18n/index.js';
 import {
@@ -22,7 +23,13 @@ import {
   openMemberModePrefix,
   openModePrefix,
 } from '$lib/stores/ui';
-import { FilterPanel, HelpDialog, HintModePanel, MenuPanel } from './components/index.js';
+import {
+  FilterPanel,
+  HelpDialog,
+  HintModePanel,
+  MenuPanel,
+  ShortcutHintToast,
+} from './components/index.js';
 import {
   COLLECTIVE_DETAIL_ACTIONS,
   CREATION_SHORTCUTS,
@@ -30,6 +37,7 @@ import {
   NAVIGATION_SHORTCUTS,
 } from './config.js';
 import { createKeydownHandler } from './handlers/index.js';
+import { handleShortcutHintClick } from './hint-store.js';
 
 const i18n = createI18n();
 
@@ -72,6 +80,12 @@ function clearPending() {
   isOpenEncounterFriendModeActive.set(false);
   openEncounterFriendModePrefix.set(null);
 }
+
+// Capture phase so the hint fires even when inner handlers stopPropagation()
+onMount(() => {
+  document.addEventListener('click', handleShortcutHintClick, true);
+  return () => document.removeEventListener('click', handleShortcutHintClick, true);
+});
 
 // The handler is recreated when showHelp changes so guards get fresh state
 const handleKeydown = $derived(
@@ -132,4 +146,6 @@ const handleKeydown = $derived(
   <HintModePanel title={$i18n.t('shortcuts.panels.editCircle')} prefix={$editCircleModePrefix} itemDescription={$i18n.t('shortcuts.items.circleEdit')} />
 {:else if pendingKey === 'd' && isOnCirclesPage}
   <HintModePanel title={$i18n.t('shortcuts.panels.deleteCircle')} prefix={$deleteCircleModePrefix} variant="danger" itemDescription={$i18n.t('shortcuts.items.circleDelete')} />
+{:else}
+  <ShortcutHintToast />
 {/if}

--- a/apps/frontend/src/lib/stores/auth.ts
+++ b/apps/frontend/src/lib/stores/auth.ts
@@ -343,6 +343,14 @@ export const friendsTableColumns = derived(
 export const birthdayFormat = derived(auth, ($auth) => $auth.preferences.birthdayFormat ?? 'iso');
 
 /**
+ * Derived store for shortcut hint toasts (default: enabled)
+ */
+export const showShortcutHints = derived(
+  auth,
+  ($auth) => $auth.preferences.showShortcutHints ?? true,
+);
+
+/**
  * Helper to wait for auth initialization
  * Returns a promise that resolves when auth is initialized
  */

--- a/apps/frontend/src/routes/circles/+page.svelte
+++ b/apps/frontend/src/routes/circles/+page.svelte
@@ -184,6 +184,8 @@ function getActualDepth(circle: Circle): number {
         <button
           onclick={openCreateModal}
           class="inline-flex items-center gap-2 bg-forest text-white px-4 py-2 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+          data-shortcut="n c"
+          data-shortcut-label="shortcuts.newCircle"
         >
           <Plus class="w-5 h-5" strokeWidth="2" />
           {$i18n.t('circles.newCircle')}
@@ -314,6 +316,8 @@ function getActualDepth(circle: Circle): number {
                     {isDeleting}
                     editLabel={$i18n.t('common.edit') + ' ' + circle.name}
                     deleteLabel={$i18n.t('common.delete') + ' ' + circle.name}
+                    editShortcutHint="e {keyHint}"
+                    deleteShortcutHint="d {keyHint}"
                   />
                 </div>
               </SwipeableRow>
@@ -367,6 +371,8 @@ function getActualDepth(circle: Circle): number {
                   {isDeleting}
                   editLabel={$i18n.t('common.edit') + ' ' + circle.name}
                   deleteLabel={$i18n.t('common.delete') + ' ' + circle.name}
+                  editShortcutHint="e {keyHint}"
+                  deleteShortcutHint="d {keyHint}"
                 />
               </div>
             </div>

--- a/apps/frontend/src/routes/collectives/+page.svelte
+++ b/apps/frontend/src/routes/collectives/+page.svelte
@@ -21,6 +21,8 @@ const i18n = createI18n();
         <a
           href="/collectives/new"
           class="inline-flex items-center gap-2 bg-forest text-white px-4 py-2 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+          data-shortcut="n o"
+          data-shortcut-label="shortcuts.newCollective"
         >
           <Plus class="w-5 h-5" strokeWidth="2" />
           {$i18n.t('collectives.createNew')}

--- a/apps/frontend/src/routes/encounters/+page.svelte
+++ b/apps/frontend/src/routes/encounters/+page.svelte
@@ -21,6 +21,8 @@ const i18n = createI18n();
         <a
           href="/encounters/new"
           class="inline-flex items-center gap-2 bg-forest text-white px-4 py-2 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+          data-shortcut="n e"
+          data-shortcut-label="shortcuts.newEncounter"
         >
           <Plus class="w-5 h-5" strokeWidth="2" />
           {$i18n.t('encounters.logNew')}

--- a/apps/frontend/src/routes/profile/display/+page.svelte
+++ b/apps/frontend/src/routes/profile/display/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import ChevronLeft from 'svelte-heros-v2/ChevronLeft.svelte';
 import { createI18n, languageNames } from '$lib/i18n/index.js';
-import { auth, birthdayFormat } from '$lib/stores/auth';
+import { auth, birthdayFormat, showShortcutHints } from '$lib/stores/auth';
 import {
   currentLanguage,
   locale,
@@ -18,6 +18,10 @@ function handleBirthdayFormatChange(format: BirthdayFormat) {
 
 function handleLanguageChange(lang: SupportedLanguage) {
   locale.setLanguage(lang);
+}
+
+function handleShortcutHintsChange(enabled: boolean) {
+  auth.updatePreferences({ showShortcutHints: enabled });
 }
 </script>
 
@@ -72,6 +76,23 @@ function handleLanguageChange(lang: SupportedLanguage) {
       </select>
       <p class="mt-1 text-xs font-body text-gray-500">
         {$i18n.t('profile.preferences.birthdayFormatHelp')}
+      </p>
+    </div>
+
+    <div>
+      <label class="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={$showShortcutHints}
+          onchange={(e) => handleShortcutHintsChange(e.currentTarget.checked)}
+          class="rounded border-gray-300 text-forest focus:ring-forest"
+        />
+        <span class="text-sm font-body font-semibold text-gray-700">
+          {$i18n.t('profile.preferences.shortcutHints')}
+        </span>
+      </label>
+      <p class="mt-1 text-xs font-body text-gray-500 ml-7">
+        {$i18n.t('profile.preferences.shortcutHintsHelp')}
       </p>
     </div>
   </div>

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -45,6 +45,7 @@ export const UserPreferencesSchema = type({
   'friendsTableColumns?': 'string[]',
   'birthdayFormat?': BirthdayFormatSchema,
   'language?': LanguageSchema,
+  'showShortcutHints?': 'boolean',
 });
 export type UserPreferences = typeof UserPreferencesSchema.infer;
 
@@ -53,6 +54,7 @@ export const UpdatePreferencesRequestSchema = type({
   'friendsTableColumns?': 'string[]',
   'birthdayFormat?': BirthdayFormatSchema,
   'language?': LanguageSchema,
+  'showShortcutHints?': 'boolean',
 });
 export type UpdatePreferencesRequest = typeof UpdatePreferencesRequestSchema.infer;
 


### PR DESCRIPTION
## Summary

When a mouse click performs an action that also has a keyboard shortcut, a small toast in the bottom-left corner now tells the user the equivalent chord — e.g. opening the friend list via the menu shows **Tip: `g` then `f`**. This makes the extensive chord system (`g`/`n`/`a`/`o`/`f`/`e`/`d` modes, `<`/`>`, `/`, `e`) discoverable for mouse-first users.

## How it works

- **Declarative detection**: clickable elements carry a `data-shortcut` attribute (static like `g f`, or computed per item like `o 3` / `o b2` via `getKeyboardHint`). One global capture-phase click listener resolves the attribute with `closest()`, so it survives `stopPropagation()` in row action buttons.
- **No false hints from keyboard use**: synthetic clicks from Enter/Space have `event.detail === 0` and are skipped.
- **Once per session**: each chord is shown at most once, tracked in sessionStorage.
- **Opt-out**: new server-side `showShortcutHints` preference (default on) with a toggle on the display settings page. Added to both arktype schemas so the PATCH round-trip persists it; no backend code or migration needed (JSONB column).
- **Design**: toast matches the existing chord panels (fixed bottom-left, kbd badges, `aria-live=polite`, auto-dismiss after 4.5 s) and only renders when no chord panel is open.

## Coverage

Nav links, new-item buttons, friend/collective/encounter list rows and cards, friend-detail link rows and the Add dropdown (`a p` …), collective-detail add buttons (`a m` …), edit buttons (`e`), circle edit/delete (`e 2` / `d 2`), pagination (`<` / `>`), search triggers (`/`), and filter values (`f c 1` …). The mobile add-detail modal is intentionally untagged (touch context).

## Testing

- 11 new vitest cases for the hint store (dedupe, preference gate, sessionStorage) and the click handler (`detail === 0` guard, ancestor resolution, empty-attribute skip) — 40/40 pass
- `svelte-check`: 0 errors; backend `tsc`: clean; biome: clean
- Verified live in the running app: row click records `o 1`, toast renders fixed bottom-left with kbd badges and label, dedupe holds across repeat clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)