### PR TITLE
Hide FAB on all entity creation routes, not just friends

### DIFF
--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -76,10 +76,12 @@ $effect(() => {
   }
 });
 
-// Hide FAB on new friend page and friend detail pages (which have their own FAB)
+// Hide the FAB while the user is creating a new entity (any /new route, e.g.
+// /friends/new, /encounters/new, /collectives/new) so an accidental tap can't
+// interrupt them, and on friend detail pages (which have their own FAB).
 const showFab = $derived(
   $isAuthenticated &&
-    !$page.url.pathname.includes('/friends/new') &&
+    !$page.url.pathname.endsWith('/new') &&
     !$page.url.pathname.match(/^\/friends\/[^/]+$/),
 );
 


### PR DESCRIPTION
## Summary
Updated the FAB (Floating Action Button) visibility logic to hide it on all entity creation routes (any `/new` route) rather than only on the `/friends/new` route. This prevents accidental taps from interrupting users while they're creating new entities.

## Changes
- Modified the FAB visibility condition from checking specifically for `/friends/new` to using a more generic pattern that matches any route ending with `/new`
- Updated the comment to clarify the intent: preventing accidental FAB taps during entity creation across all entity types (friends, encounters, collectives, etc.)
- Changed from `includes('/friends/new')` to `endsWith('/new')` for a more precise and maintainable check

## Implementation Details
The change makes the FAB hiding logic more scalable and future-proof. As new entity creation routes are added to the application (like `/encounters/new` or `/collectives/new`), they will automatically benefit from this FAB-hiding behavior without requiring additional code changes.

https://claude.ai/code/session_017t3dWmVQYaXZpGfgrRum9j