### PR TITLE
Add age/year count to notification messages

### DIFF
--- a/apps/backend/src/utils/notification-messages.test.ts
+++ b/apps/backend/src/utils/notification-messages.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IGetUpcomingDatesResult } from '../models/queries/friend-dates.queries.js';
+import { formatNotificationMessage } from './notification-messages.js';
+
+function makeDate(overrides: Partial<IGetUpcomingDatesResult>): IGetUpcomingDatesResult {
+  return {
+    date_external_id: 'date-1',
+    date_type: 'birthday',
+    date_value: new Date(1990, 5, 20), // 1990-06-20
+    days_until: 7,
+    friend_display_name: 'Anna Bauer',
+    friend_external_id: 'friend-1',
+    friend_photo_thumbnail_url: null,
+    label: null,
+    year_known: true,
+    ...overrides,
+  };
+}
+
+describe('formatNotificationMessage age handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Fixed "today" so age math is deterministic
+    vi.setSystemTime(new Date(2026, 5, 13)); // 2026-06-13
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('includes the age the friend turns for a known-year birthday (en)', () => {
+    const { plain, html } = formatNotificationMessage(
+      [makeDate({ date_value: new Date(1990, 5, 20), days_until: 7 })],
+      'en',
+    );
+    // 2026 occurrence - 1990 birth year = 36
+    expect(plain).toContain("Anna Bauer's birthday (June 20, turns 36)");
+    expect(html).toContain('turns 36');
+  });
+
+  it('includes the age for a known-year birthday (de)', () => {
+    const { plain } = formatNotificationMessage(
+      [makeDate({ date_value: new Date(1990, 5, 20), days_until: 7 })],
+      'de',
+    );
+    expect(plain).toContain('Geburtstag (20. Juni, wird 36)');
+  });
+
+  it('uses the upcoming-occurrence year across a year boundary', () => {
+    vi.setSystemTime(new Date(2026, 11, 28)); // 2026-12-28
+    const { plain } = formatNotificationMessage(
+      [
+        makeDate({
+          date_value: new Date(1990, 0, 2), // Jan 2 1990
+          days_until: 5, // -> 2027-01-02
+        }),
+      ],
+      'en',
+    );
+    // 2027 occurrence - 1990 = 37
+    expect(plain).toContain('turns 37');
+  });
+
+  it('omits the age when the year is not known', () => {
+    const { plain } = formatNotificationMessage([makeDate({ year_known: false })], 'en');
+    expect(plain).toContain("Anna Bauer's birthday (June 20)");
+    expect(plain).not.toContain('turns');
+  });
+
+  it('shows a year count for known-year anniversaries instead of "turns"', () => {
+    const { plain } = formatNotificationMessage(
+      [
+        makeDate({
+          date_type: 'anniversary',
+          date_value: new Date(2016, 5, 20),
+          days_until: 7,
+        }),
+      ],
+      'en',
+    );
+    // 2026 - 2016 = 10
+    expect(plain).toContain('wedding anniversary (June 20, 10 years)');
+    expect(plain).not.toContain('turns');
+  });
+
+  it('shows a year count for known-year anniversaries (de)', () => {
+    const { plain } = formatNotificationMessage(
+      [
+        makeDate({
+          date_type: 'anniversary',
+          date_value: new Date(2016, 5, 20),
+          days_until: 7,
+        }),
+      ],
+      'de',
+    );
+    expect(plain).toContain('Hochzeitstag (20. Juni, 10 Jahre)');
+  });
+
+  it('uses the year count for known-year "other" dates with a label', () => {
+    const { plain } = formatNotificationMessage(
+      [
+        makeDate({
+          date_type: 'other',
+          label: 'Gotcha day',
+          date_value: new Date(2020, 5, 20),
+          days_until: 7,
+        }),
+      ],
+      'en',
+    );
+    expect(plain).toContain('Gotcha day (June 20, 6 years)');
+  });
+});

--- a/apps/backend/src/utils/notification-messages.test.ts
+++ b/apps/backend/src/utils/notification-messages.test.ts
@@ -123,6 +123,29 @@ describe('formatNotificationMessage age handling', () => {
     expect(formatNotificationMessage([date], 'de').plain).toContain('20. Juni, 1 Jahr)');
   });
 
+  it('escapes user-controlled values in the HTML body to prevent injection', () => {
+    const { plain, html } = formatNotificationMessage(
+      [
+        makeDate({
+          date_type: 'other',
+          friend_display_name: '<b>Mallory</b> & "friends"',
+          label: '<img src=x onerror=alert(1)>',
+          year_known: false,
+        }),
+      ],
+      'en',
+      'https://example.com/?a=1&b=2',
+    );
+    // HTML body must not contain the raw injected markup
+    expect(html).not.toContain('<img src=x');
+    expect(html).not.toContain('<b>Mallory</b> &');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(html).toContain('&lt;b&gt;Mallory&lt;/b&gt; &amp; &quot;friends&quot;');
+    expect(html).toContain('https://example.com/?a=1&amp;b=2');
+    // Plain text stays unescaped
+    expect(plain).toContain('<b>Mallory</b> & "friends"');
+  });
+
   it('displays the normalized occurrence date for Feb 29 in a non-leap year', () => {
     vi.setSystemTime(new Date(2026, 1, 20)); // 2026-02-20, non-leap year
     const { plain } = formatNotificationMessage(

--- a/apps/backend/src/utils/notification-messages.test.ts
+++ b/apps/backend/src/utils/notification-messages.test.ts
@@ -111,4 +111,31 @@ describe('formatNotificationMessage age handling', () => {
     );
     expect(plain).toContain('Gotcha day (June 20, 6 years)');
   });
+
+  it('uses singular year wording for a one-year count (en/de)', () => {
+    const date = makeDate({
+      date_type: 'anniversary',
+      date_value: new Date(2025, 5, 20),
+      days_until: 7,
+    });
+    // 2026 - 2025 = 1
+    expect(formatNotificationMessage([date], 'en').plain).toContain('June 20, 1 year)');
+    expect(formatNotificationMessage([date], 'de').plain).toContain('20. Juni, 1 Jahr)');
+  });
+
+  it('displays the normalized occurrence date for Feb 29 in a non-leap year', () => {
+    vi.setSystemTime(new Date(2026, 1, 20)); // 2026-02-20, non-leap year
+    const { plain } = formatNotificationMessage(
+      [
+        makeDate({
+          date_value: new Date(2000, 1, 29), // Feb 29 2000
+          days_until: 8, // -> 2026-02-28 (SQL normalizes Feb 29 to Feb 28)
+        }),
+      ],
+      'en',
+    );
+    // Shows the actual upcoming occurrence (Feb 28), not the stored Feb 29
+    expect(plain).toContain("Anna Bauer's birthday (February 28, turns 26)");
+    expect(plain).not.toContain('February 29');
+  });
 });

--- a/apps/backend/src/utils/notification-messages.ts
+++ b/apps/backend/src/utils/notification-messages.ts
@@ -7,6 +7,10 @@ interface LocaleStrings {
   inDays: (n: number) => string;
   birthday: string;
   anniversary: string;
+  /** Age phrasing for a birthday, e.g. "turns 30" */
+  birthdayAge: (n: number) => string;
+  /** Year count for non-birthday dates, e.g. "30 years" */
+  yearsCount: (n: number) => string;
   footer: (url: string) => string;
   months: string[];
   formatDate: (month: number, day: number) => string;
@@ -20,6 +24,8 @@ const locales: Record<string, LocaleStrings> = {
     inDays: (n) => `In ${n} days`,
     birthday: 'birthday',
     anniversary: 'wedding anniversary',
+    birthdayAge: (n) => `turns ${n}`,
+    yearsCount: (n) => `${n} years`,
     footer: (url) => `View your Freundebuch: ${url}`,
     months: [
       'January',
@@ -46,6 +52,8 @@ const locales: Record<string, LocaleStrings> = {
     inDays: (n) => `In ${n} Tagen`,
     birthday: 'Geburtstag',
     anniversary: 'Hochzeitstag',
+    birthdayAge: (n) => `wird ${n}`,
+    yearsCount: (n) => `${n} Jahre`,
     footer: (url) => `Dein Freundebuch öffnen: ${url}`,
     months: [
       'Januar',
@@ -91,6 +99,31 @@ function extractMonthDay(dateValue: Date): { month: number; day: number } {
 }
 
 /**
+ * Compute the age (or number of years) the date marks on its upcoming occurrence.
+ *
+ * The occurrence year is derived from `daysUntil` (added to today) so it stays
+ * consistent with the value the SQL query produced, correctly handling dates
+ * that roll over into next year. Returns null when the birth year is unknown or
+ * the resulting age is not a positive number.
+ */
+function computeAge(dateValue: Date, yearKnown: boolean, daysUntil: number): number | null {
+  if (!yearKnown) return null;
+
+  const now = new Date();
+  // Use all-local date arithmetic to stay consistent with extractMonthDay.
+  const occurrence = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntil);
+  const age = occurrence.getFullYear() - dateValue.getFullYear();
+
+  return age > 0 ? age : null;
+}
+
+function getAgePhrase(l: LocaleStrings, dateType: string, age: number | null): string | null {
+  if (age === null) return null;
+  if (dateType === 'birthday') return l.birthdayAge(age);
+  return l.yearsCount(age);
+}
+
+/**
  * Format upcoming dates into a notification message
  * Returns both plain text and HTML versions
  */
@@ -111,8 +144,12 @@ export function formatNotificationMessage(
     const { month, day } = extractMonthDay(date.date_value);
     const formattedDate = l.formatDate(month, day);
 
-    const plainLine = `${dayPhrase}: ${date.friend_display_name}'s ${eventLabel} (${formattedDate})`;
-    const htmlLine = `${dayPhrase}: <b>${date.friend_display_name}</b>'s ${eventLabel} (${formattedDate})`;
+    const age = computeAge(date.date_value, date.year_known, daysUntil);
+    const agePhrase = getAgePhrase(l, date.date_type, age);
+    const datePart = agePhrase ? `${formattedDate}, ${agePhrase}` : formattedDate;
+
+    const plainLine = `${dayPhrase}: ${date.friend_display_name}'s ${eventLabel} (${datePart})`;
+    const htmlLine = `${dayPhrase}: <b>${date.friend_display_name}</b>'s ${eventLabel} (${datePart})`;
 
     plainLines.push(plainLine);
     htmlLines.push(htmlLine);

--- a/apps/backend/src/utils/notification-messages.ts
+++ b/apps/backend/src/utils/notification-messages.ts
@@ -25,7 +25,7 @@ const locales: Record<string, LocaleStrings> = {
     birthday: 'birthday',
     anniversary: 'wedding anniversary',
     birthdayAge: (n) => `turns ${n}`,
-    yearsCount: (n) => `${n} years`,
+    yearsCount: (n) => `${n} year${n === 1 ? '' : 's'}`,
     footer: (url) => `View your Freundebuch: ${url}`,
     months: [
       'January',
@@ -53,7 +53,7 @@ const locales: Record<string, LocaleStrings> = {
     birthday: 'Geburtstag',
     anniversary: 'Hochzeitstag',
     birthdayAge: (n) => `wird ${n}`,
-    yearsCount: (n) => `${n} Jahre`,
+    yearsCount: (n) => `${n} Jahr${n === 1 ? '' : 'e'}`,
     footer: (url) => `Dein Freundebuch öffnen: ${url}`,
     months: [
       'Januar',
@@ -91,27 +91,32 @@ function getEventLabel(l: LocaleStrings, dateType: string, label: string | null)
   return label ?? dateType;
 }
 
-function extractMonthDay(dateValue: Date): { month: number; day: number } {
-  // date_value is a DATE type, extract month and day
-  const month = dateValue.getMonth() + 1;
-  const day = dateValue.getDate();
+function extractMonthDay(date: Date): { month: number; day: number } {
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
   return { month, day };
 }
 
 /**
- * Compute the age (or number of years) the date marks on its upcoming occurrence.
- *
- * The occurrence year is derived from `daysUntil` (added to today) so it stays
- * consistent with the value the SQL query produced, correctly handling dates
- * that roll over into next year. Returns null when the birth year is unknown or
- * the resulting age is not a positive number.
+ * Resolve the actual upcoming occurrence date by adding `daysUntil` (the value
+ * the SQL query computed) to today. Using this for both the displayed date and
+ * the age keeps the notification consistent with the query logic, including its
+ * leap-year handling (e.g. a Feb 29 date is shown as Feb 28 in non-leap years).
  */
-function computeAge(dateValue: Date, yearKnown: boolean, daysUntil: number): number | null {
+function getUpcomingOccurrence(daysUntil: number): Date {
+  const now = new Date();
+  // All-local date arithmetic, matching how date_value is read.
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntil);
+}
+
+/**
+ * Compute the age (or number of years) the date marks on its upcoming
+ * occurrence. Returns null when the birth year is unknown or the resulting age
+ * is not a positive number.
+ */
+function computeAge(dateValue: Date, yearKnown: boolean, occurrence: Date): number | null {
   if (!yearKnown) return null;
 
-  const now = new Date();
-  // Use all-local date arithmetic to stay consistent with extractMonthDay.
-  const occurrence = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntil);
   const age = occurrence.getFullYear() - dateValue.getFullYear();
 
   return age > 0 ? age : null;
@@ -141,10 +146,11 @@ export function formatNotificationMessage(
     const daysUntil = date.days_until ?? 0;
     const dayPhrase = getDayPhrase(l, daysUntil);
     const eventLabel = getEventLabel(l, date.date_type, date.label);
-    const { month, day } = extractMonthDay(date.date_value);
+    const occurrence = getUpcomingOccurrence(daysUntil);
+    const { month, day } = extractMonthDay(occurrence);
     const formattedDate = l.formatDate(month, day);
 
-    const age = computeAge(date.date_value, date.year_known, daysUntil);
+    const age = computeAge(date.date_value, date.year_known, occurrence);
     const agePhrase = getAgePhrase(l, date.date_type, age);
     const datePart = agePhrase ? `${formattedDate}, ${agePhrase}` : formattedDate;
 

--- a/apps/backend/src/utils/notification-messages.ts
+++ b/apps/backend/src/utils/notification-messages.ts
@@ -129,6 +129,21 @@ function getAgePhrase(l: LocaleStrings, dateType: string, age: number | null): s
 }
 
 /**
+ * Escape values that are interpolated into the HTML notification body. The HTML
+ * is delivered as a Matrix `formatted_body`, so user-controlled values such as
+ * the friend's display name and custom date labels must be escaped to prevent
+ * HTML injection.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
  * Format upcoming dates into a notification message
  * Returns both plain text and HTML versions
  */
@@ -155,7 +170,7 @@ export function formatNotificationMessage(
     const datePart = agePhrase ? `${formattedDate}, ${agePhrase}` : formattedDate;
 
     const plainLine = `${dayPhrase}: ${date.friend_display_name}'s ${eventLabel} (${datePart})`;
-    const htmlLine = `${dayPhrase}: <b>${date.friend_display_name}</b>'s ${eventLabel} (${datePart})`;
+    const htmlLine = `${dayPhrase}: <b>${escapeHtml(date.friend_display_name)}</b>'s ${escapeHtml(eventLabel)} (${escapeHtml(datePart)})`;
 
     plainLines.push(plainLine);
     htmlLines.push(htmlLine);
@@ -163,7 +178,10 @@ export function formatNotificationMessage(
 
   if (instanceUrl) {
     plainLines.push('', l.footer(instanceUrl));
-    htmlLines.push('', `<a href="${instanceUrl}">${l.footer(instanceUrl)}</a>`);
+    htmlLines.push(
+      '',
+      `<a href="${escapeHtml(instanceUrl)}">${escapeHtml(l.footer(instanceUrl))}</a>`,
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary
Enhanced notification messages to include age information for birthdays and year counts for anniversaries and other dated events. This provides more context in the notification text without requiring users to open the app.

## Key Changes
- Added `birthdayAge` and `yearsCount` locale string functions to support age/year phrasing in English and German
- Implemented `computeAge()` function to calculate the age or year count for an upcoming date occurrence, accounting for year boundaries and unknown birth years
- Implemented `getAgePhrase()` function to format the age appropriately based on date type (birthdays use "turns X", other dates use "X years")
- Updated notification message formatting to include age/year information in parentheses after the date
- Added comprehensive test suite covering:
  - Age calculation for known-year birthdays
  - Bilingual support (English and German)
  - Year boundary handling (dates rolling into next year)
  - Omission of age when year is unknown
  - Year counts for anniversaries and other labeled dates

## Implementation Details
- Age calculation uses `daysUntil` from the query result to determine the occurrence year, ensuring consistency with server-side logic and proper handling of dates crossing year boundaries
- Age is only included when `year_known` is true and the calculated age is positive
- Different phrasing for birthdays ("turns 36") vs. other dates ("10 years") to match natural language conventions

https://claude.ai/code/session_01KkkiHL1UtjNW9jroY26HAn