### PR TITLE
Consolidate dashboard data fetching into single request

### DIFF
--- a/apps/backend/src/models/queries/users.queries.ts
+++ b/apps/backend/src/models/queries/users.queries.ts
@@ -195,6 +195,7 @@ export interface IUpdateUserReturningWithSelfProfileResult {
   email: string;
   /** Public UUID for API exposure (always use this in APIs) */
   external_id: string;
+  self_profile_display_name: string | null;
   self_profile_external_id: string | null;
   updated_at: Date;
 }
@@ -205,7 +206,7 @@ export interface IUpdateUserReturningWithSelfProfileQuery {
   result: IUpdateUserReturningWithSelfProfileResult;
 }
 
-const updateUserReturningWithSelfProfileIR: any = {"usedParamSet":{"email":true,"externalId":true},"params":[{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":32,"b":37}]},{"name":"externalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":93,"b":103}]}],"statement":"UPDATE auth.users u\nSET email = :email, updated_at = CURRENT_TIMESTAMP\nWHERE u.external_id = :externalId\nRETURNING\n    u.external_id,\n    u.email,\n    u.created_at,\n    u.updated_at,\n    (SELECT c.external_id FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_external_id"};
+const updateUserReturningWithSelfProfileIR: any = {"usedParamSet":{"email":true,"externalId":true},"params":[{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":32,"b":37}]},{"name":"externalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":93,"b":103}]}],"statement":"UPDATE auth.users u\nSET email = :email, updated_at = CURRENT_TIMESTAMP\nWHERE u.external_id = :externalId\nRETURNING\n    u.external_id,\n    u.email,\n    u.created_at,\n    u.updated_at,\n    (SELECT c.external_id FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_external_id,\n    (SELECT c.display_name FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_display_name"};
 
 /**
  * Query generated from SQL:
@@ -218,7 +219,8 @@ const updateUserReturningWithSelfProfileIR: any = {"usedParamSet":{"email":true,
  *     u.email,
  *     u.created_at,
  *     u.updated_at,
- *     (SELECT c.external_id FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_external_id
+ *     (SELECT c.external_id FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_external_id,
+ *     (SELECT c.display_name FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_display_name
  * ```
  */
 export const updateUserReturningWithSelfProfile = new PreparedQuery<IUpdateUserReturningWithSelfProfileParams,IUpdateUserReturningWithSelfProfileResult>(updateUserReturningWithSelfProfileIR);

--- a/apps/backend/src/models/queries/users.queries.ts
+++ b/apps/backend/src/models/queries/users.queries.ts
@@ -81,6 +81,8 @@ export interface IGetUserByEmailWithSelfProfileResult {
   email: string;
   /** UUID primary key (mapped from legacy external_id) */
   external_id: string;
+  /** Display name of the self-profile friend */
+  self_profile_display_name: string | null;
   /** Public UUID for API exposure (always use this in APIs) */
   self_profile_external_id: string;
   updated_at: Date;
@@ -92,7 +94,7 @@ export interface IGetUserByEmailWithSelfProfileQuery {
   result: IGetUserByEmailWithSelfProfileResult;
 }
 
-const getUserByEmailWithSelfProfileIR: any = {"usedParamSet":{"email":true},"params":[{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":243,"b":248}]}],"statement":"SELECT\n    u.id as external_id,\n    u.email,\n    u.created_at,\n    u.updated_at,\n    c.external_id as self_profile_external_id\nFROM auth.\"user\" u\nLEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL\nWHERE u.email = :email"};
+const getUserByEmailWithSelfProfileIR: any = {"usedParamSet":{"email":true},"params":[{"name":"email","required":false,"transform":{"type":"scalar"},"locs":[{"a":292,"b":297}]}],"statement":"SELECT\n    u.id as external_id,\n    u.email,\n    u.created_at,\n    u.updated_at,\n    c.external_id as self_profile_external_id,\n    c.display_name as self_profile_display_name\nFROM auth.\"user\" u\nLEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL\nWHERE u.email = :email"};
 
 /**
  * Query generated from SQL:
@@ -102,7 +104,8 @@ const getUserByEmailWithSelfProfileIR: any = {"usedParamSet":{"email":true},"par
  *     u.email,
  *     u.created_at,
  *     u.updated_at,
- *     c.external_id as self_profile_external_id
+ *     c.external_id as self_profile_external_id,
+ *     c.display_name as self_profile_display_name
  * FROM auth."user" u
  * LEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL
  * WHERE u.email = :email
@@ -363,6 +366,8 @@ export interface IGetUserSelfProfileParams {
 
 /** 'GetUserSelfProfile' return type */
 export interface IGetUserSelfProfileResult {
+  /** Display name of the self-profile friend */
+  self_profile_display_name: string | null;
   /** Public UUID for API exposure (always use this in APIs) */
   self_profile_external_id: string;
   /** FK to friends.friends - set during onboarding */
@@ -375,14 +380,15 @@ export interface IGetUserSelfProfileQuery {
   result: IGetUserSelfProfileResult;
 }
 
-const getUserSelfProfileIR: any = {"usedParamSet":{"userExternalId":true},"params":[{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":189,"b":203}]}],"statement":"SELECT\n    u.self_profile_id,\n    c.external_id as self_profile_external_id\nFROM auth.\"user\" u\nLEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL\nWHERE u.id = :userExternalId"};
+const getUserSelfProfileIR: any = {"usedParamSet":{"userExternalId":true},"params":[{"name":"userExternalId","required":false,"transform":{"type":"scalar"},"locs":[{"a":238,"b":252}]}],"statement":"SELECT\n    u.self_profile_id,\n    c.external_id as self_profile_external_id,\n    c.display_name as self_profile_display_name\nFROM auth.\"user\" u\nLEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL\nWHERE u.id = :userExternalId"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT
  *     u.self_profile_id,
- *     c.external_id as self_profile_external_id
+ *     c.external_id as self_profile_external_id,
+ *     c.display_name as self_profile_display_name
  * FROM auth."user" u
  * LEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL
  * WHERE u.id = :userExternalId

--- a/apps/backend/src/models/queries/users.queries.ts
+++ b/apps/backend/src/models/queries/users.queries.ts
@@ -82,7 +82,7 @@ export interface IGetUserByEmailWithSelfProfileResult {
   /** UUID primary key (mapped from legacy external_id) */
   external_id: string;
   /** Display name of the self-profile friend */
-  self_profile_display_name: string | null;
+  self_profile_display_name: string;
   /** Public UUID for API exposure (always use this in APIs) */
   self_profile_external_id: string;
   updated_at: Date;
@@ -369,7 +369,7 @@ export interface IGetUserSelfProfileParams {
 /** 'GetUserSelfProfile' return type */
 export interface IGetUserSelfProfileResult {
   /** Display name of the self-profile friend */
-  self_profile_display_name: string | null;
+  self_profile_display_name: string;
   /** Public UUID for API exposure (always use this in APIs) */
   self_profile_external_id: string;
   /** FK to friends.friends - set during onboarding */

--- a/apps/backend/src/models/queries/users.sql
+++ b/apps/backend/src/models/queries/users.sql
@@ -40,7 +40,8 @@ RETURNING
     u.email,
     u.created_at,
     u.updated_at,
-    (SELECT c.external_id FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_external_id;
+    (SELECT c.external_id FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_external_id,
+    (SELECT c.display_name FROM friends.friends c WHERE c.id = u.self_profile_id AND c.deleted_at IS NULL) as self_profile_display_name;
 
 /* @name DeleteUser */
 DELETE FROM auth.users

--- a/apps/backend/src/models/queries/users.sql
+++ b/apps/backend/src/models/queries/users.sql
@@ -14,7 +14,8 @@ SELECT
     u.email,
     u.created_at,
     u.updated_at,
-    c.external_id as self_profile_external_id
+    c.external_id as self_profile_external_id,
+    c.display_name as self_profile_display_name
 FROM auth."user" u
 LEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL
 WHERE u.email = :email;
@@ -67,7 +68,8 @@ RETURNING id as external_id, email, preferences, created_at, updated_at;
 /* @name GetUserSelfProfile */
 SELECT
     u.self_profile_id,
-    c.external_id as self_profile_external_id
+    c.external_id as self_profile_external_id,
+    c.display_name as self_profile_display_name
 FROM auth."user" u
 LEFT JOIN friends.friends c ON u.self_profile_id = c.id AND c.deleted_at IS NULL
 WHERE u.id = :userExternalId;

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -67,12 +67,14 @@ app.get('/me', authMiddleware, async (c) => {
   // are not UUIDs and the legacy external_id column is UUID-typed.
   const result = await getUserSelfProfile.run({ userExternalId: authUser.betterAuthId }, db);
   const selfProfileExternalId = result[0]?.self_profile_external_id ?? null;
+  const selfProfileDisplayName = result[0]?.self_profile_display_name ?? null;
 
   const response: UserWithPreferencesResponse = {
     user: {
       externalId: authUser.betterAuthId,
       email: authUser.email,
       selfProfileId: selfProfileExternalId ?? undefined,
+      displayName: selfProfileDisplayName ?? undefined,
       hasCompletedOnboarding: selfProfileExternalId !== null,
     },
     preferences: parseUserPreferences(session.user.preferences ?? {}),

--- a/apps/backend/src/routes/circles.ts
+++ b/apps/backend/src/routes/circles.ts
@@ -1,6 +1,7 @@
 import { CircleInputSchema } from '@freundebuch/shared/index.js';
 import { type } from 'arktype';
 import { Hono } from 'hono';
+import { etag } from 'hono/etag';
 import { authMiddleware, getAuthUser } from '../middleware/auth.js';
 import { onboardingMiddleware } from '../middleware/onboarding.js';
 import { circlesRateLimitMiddleware } from '../middleware/rate-limit.js';
@@ -24,9 +25,11 @@ app.use('*', onboardingMiddleware);
 
 /**
  * GET /api/circles
- * List all circles for the authenticated user
+ * List all circles for the authenticated user.
+ * Emits an ETag so warm reloads can revalidate cheaply (304) without
+ * serving stale data.
  */
-app.get('/', async (c) => {
+app.get('/', etag(), async (c) => {
   const db = c.get('db');
   const user = getAuthUser(c);
 

--- a/apps/backend/src/routes/friends/dashboard.routes.ts
+++ b/apps/backend/src/routes/friends/dashboard.routes.ts
@@ -1,9 +1,27 @@
 import { Hono } from 'hono';
+import { etag } from 'hono/etag';
 import { getAuthUser } from '../../middleware/auth.js';
 import { FriendsService } from '../../services/friends/index.js';
 import type { AppContext } from '../../types/context.js';
 
 const app = new Hono<AppContext>();
+
+// Emit ETags so browsers can revalidate dashboard/graph responses cheaply
+// (304 Not Modified) on warm navigations and back/forward, without ever
+// serving stale data — these payloads change whenever friends or
+// relationships do.
+app.use('/dashboard', etag());
+app.use('/network-graph', etag());
+
+/** Clamp the `days` query param to a sane range (default 30). */
+function parseDays(value: string | undefined): number {
+  return value ? Math.min(365, Math.max(1, Number.parseInt(value, 10) || 30)) : 30;
+}
+
+/** Clamp the `limit` query param to a sane range (default 10). */
+function parseLimit(value: string | undefined): number {
+  return value ? Math.min(50, Math.max(1, Number.parseInt(value, 10) || 10)) : 10;
+}
 
 /**
  * GET /api/friends/dates/upcoming
@@ -15,16 +33,35 @@ app.get('/dates/upcoming', async (c) => {
   const db = c.get('db');
   const user = getAuthUser(c);
 
-  const daysParam = c.req.query('days');
-  const limitParam = c.req.query('limit');
-
-  const days = daysParam ? Math.min(365, Math.max(1, Number.parseInt(daysParam, 10) || 30)) : 30;
-  const limit = limitParam ? Math.min(50, Math.max(1, Number.parseInt(limitParam, 10) || 10)) : 10;
+  const days = parseDays(c.req.query('days'));
+  const limit = parseLimit(c.req.query('limit'));
 
   const friendsService = new FriendsService(db, logger);
   const upcomingDates = await friendsService.getUpcomingDates(user.userId, { days, limit });
 
   return c.json(upcomingDates);
+});
+
+/**
+ * GET /api/friends/dashboard
+ * Consolidated dashboard payload: upcoming dates + network graph in one request.
+ * Query params: days (default 30), limit (default 10) — applied to upcoming dates.
+ */
+app.get('/dashboard', async (c) => {
+  const logger = c.get('logger');
+  const db = c.get('db');
+  const user = getAuthUser(c);
+
+  const days = parseDays(c.req.query('days'));
+  const limit = parseLimit(c.req.query('limit'));
+
+  const friendsService = new FriendsService(db, logger);
+  const [upcomingDates, networkGraph] = await Promise.all([
+    friendsService.getUpcomingDates(user.userId, { days, limit }),
+    friendsService.getNetworkGraphData(user.userId),
+  ]);
+
+  return c.json({ upcomingDates, networkGraph });
 });
 
 /**

--- a/apps/backend/src/routes/friends/dashboard.routes.ts
+++ b/apps/backend/src/routes/friends/dashboard.routes.ts
@@ -15,12 +15,16 @@ app.use('/network-graph', etag());
 
 /** Clamp the `days` query param to a sane range (default 30). */
 function parseDays(value: string | undefined): number {
-  return value ? Math.min(365, Math.max(1, Number.parseInt(value, 10) || 30)) : 30;
+  if (value === undefined) return 30;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? 30 : Math.min(365, Math.max(1, parsed));
 }
 
 /** Clamp the `limit` query param to a sane range (default 10). */
 function parseLimit(value: string | undefined): number {
-  return value ? Math.min(50, Math.max(1, Number.parseInt(value, 10) || 10)) : 10;
+  if (value === undefined) return 10;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? 10 : Math.min(50, Math.max(1, parsed));
 }
 
 /**

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -81,6 +81,7 @@ app.put('/me', async (c) => {
       createdAt: user.created_at.toISOString(),
       updatedAt: user.updated_at.toISOString(),
       selfProfileId: selfProfileExternalId ?? undefined,
+      displayName: user.self_profile_display_name ?? undefined,
       hasCompletedOnboarding: selfProfileExternalId !== null,
     });
   }
@@ -108,6 +109,7 @@ app.put('/me', async (c) => {
     createdAt: updatedUser.created_at.toISOString(),
     updatedAt: updatedUser.updated_at.toISOString(),
     selfProfileId: selfProfileExternalId ?? undefined,
+    displayName: updatedUser.self_profile_display_name ?? undefined,
     hasCompletedOnboarding: selfProfileExternalId !== null,
   });
 });

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -44,6 +44,7 @@ app.get('/me', async (c) => {
     createdAt: user.created_at.toISOString(),
     updatedAt: user.updated_at.toISOString(),
     selfProfileId: selfProfileExternalId ?? undefined,
+    displayName: user.self_profile_display_name ?? undefined,
     hasCompletedOnboarding: selfProfileExternalId !== null,
   });
 });

--- a/apps/frontend/src/lib/api/friends.ts
+++ b/apps/frontend/src/lib/api/friends.ts
@@ -2,6 +2,7 @@ import type {
   Address,
   AddressInput,
   ContactCollectiveSummary,
+  DashboardData,
   DateInput,
   Email,
   EmailInput,
@@ -674,6 +675,19 @@ export async function clearRecentSearches(): Promise<void> {
  */
 export async function getNetworkGraphData(): Promise<NetworkGraphData> {
   return apiRequest<NetworkGraphData>('/api/friends/network-graph');
+}
+
+/**
+ * Get the consolidated dashboard payload (upcoming dates + network graph)
+ * in a single request. Used by the home page to avoid multiple round-trips.
+ */
+export async function getDashboardData(options?: UpcomingDatesOptions): Promise<DashboardData> {
+  const searchParams = new URLSearchParams();
+  if (options?.days) searchParams.set('days', options.days.toString());
+  if (options?.limit) searchParams.set('limit', options.limit.toString());
+  const queryString = searchParams.toString();
+  const endpoint = `/api/friends/dashboard${queryString ? `?${queryString}` : ''}`;
+  return apiRequest<DashboardData>(endpoint);
 }
 
 // ============================================================================

--- a/apps/frontend/src/lib/components/dashboard/network-graph.svelte
+++ b/apps/frontend/src/lib/components/dashboard/network-graph.svelte
@@ -16,9 +16,11 @@ interface Props {
   graphData?: NetworkGraphData | null;
   isLoading?: boolean;
   error?: string | null;
+  /** Called when the user retries after an error. */
+  onRetry?: () => void;
 }
 
-let { graphData = null, isLoading = false, error = null }: Props = $props();
+let { graphData = null, isLoading = false, error = null, onRetry }: Props = $props();
 
 let container = $state<HTMLDivElement | null>(null);
 let svg: d3.Selection<SVGSVGElement, unknown, null, undefined>;
@@ -270,7 +272,18 @@ onDestroy(() => {
     </div>
   {:else if error}
     <div class="h-[400px] flex items-center justify-center">
-      <div class="text-red-600 text-sm">{error}</div>
+      <div class="text-center">
+        <div class="text-red-600 text-sm">{error}</div>
+        {#if onRetry}
+          <button
+            type="button"
+            onclick={onRetry}
+            class="mt-3 text-sm font-body text-forest hover:text-forest-light"
+          >
+            {$i18n.t('common.retry')}
+          </button>
+        {/if}
+      </div>
     </div>
   {:else if !graphData || graphData.nodes.length === 0}
     <div class="h-[400px] flex items-center justify-center">

--- a/apps/frontend/src/lib/components/dashboard/network-graph.svelte
+++ b/apps/frontend/src/lib/components/dashboard/network-graph.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import * as d3 from 'd3';
-import { onDestroy, onMount } from 'svelte';
-import { getNetworkGraphData } from '$lib/api/friends.js';
+import { onDestroy } from 'svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import type {
   NetworkGraphData,
@@ -12,13 +11,18 @@ import type {
 
 const i18n = createI18n();
 
+interface Props {
+  /** Network graph data to render (fetched by the parent dashboard). */
+  graphData?: NetworkGraphData | null;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+let { graphData = null, isLoading = false, error = null }: Props = $props();
+
 let container = $state<HTMLDivElement | null>(null);
 let svg: d3.Selection<SVGSVGElement, unknown, null, undefined>;
 let simulation: d3.Simulation<SimulationNode, SimulationLink>;
-
-let graphData = $state<NetworkGraphData | null>(null);
-let isLoading = $state(true);
-let error = $state<string | null>(null);
 
 // Extended node type for D3 simulation (D3 adds x, y, fx, fy properties)
 type SimulationNode = NetworkGraphNode & d3.SimulationNodeDatum;
@@ -35,18 +39,6 @@ const categoryColors: Record<RelationshipCategory, string> = {
   professional: '#D4A574', // Warm amber
   social: '#8B9D83', // Sage green
 };
-
-async function loadGraphData() {
-  isLoading = true;
-  error = null;
-  try {
-    graphData = await getNetworkGraphData();
-  } catch (err) {
-    error = err instanceof Error ? err.message : 'Failed to load network graph';
-  } finally {
-    isLoading = false;
-  }
-}
 
 function initializeGraph() {
   if (!container || !graphData || graphData.nodes.length === 0) return;
@@ -245,10 +237,6 @@ function initializeGraph() {
     d.fy = null;
   }
 }
-
-onMount(() => {
-  loadGraphData();
-});
 
 // Watch for graphData changes to initialize the graph
 $effect(() => {

--- a/apps/frontend/src/lib/components/dashboard/upcoming-dates.svelte
+++ b/apps/frontend/src/lib/components/dashboard/upcoming-dates.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-import { onMount } from 'svelte';
-import { getUpcomingDates } from '$lib/api/friends.js';
 import FriendAvatar from '$lib/components/friends/friend-avatar.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import type { DateType, UpcomingDate } from '$shared';
@@ -8,32 +6,21 @@ import type { DateType, UpcomingDate } from '$shared';
 const i18n = createI18n();
 
 interface Props {
+  /** Upcoming dates to display (fetched by the parent dashboard). */
+  upcomingDates?: UpcomingDate[];
+  isLoading?: boolean;
+  error?: string | null;
   days?: number;
   limit?: number;
 }
 
-let { days = 30, limit = 10 }: Props = $props();
-
-let upcomingDates = $state<UpcomingDate[]>([]);
-let isLoading = $state(true);
-let error = $state<string | null>(null);
-
-async function loadUpcomingDates() {
-  isLoading = true;
-  error = null;
-  try {
-    upcomingDates = await getUpcomingDates({ days, limit });
-  } catch (err) {
-    error = err instanceof Error ? err.message : 'Failed to load upcoming dates';
-  } finally {
-    isLoading = false;
-  }
-}
-
-// Load once on mount - props are static for dashboard usage
-onMount(() => {
-  loadUpcomingDates();
-});
+let {
+  upcomingDates = [],
+  isLoading = false,
+  error = null,
+  days = 30,
+  limit = 10,
+}: Props = $props();
 
 function formatDateType(type: DateType): string {
   const typeKeys: Record<DateType, string> = {

--- a/apps/frontend/src/lib/components/dashboard/upcoming-dates.svelte
+++ b/apps/frontend/src/lib/components/dashboard/upcoming-dates.svelte
@@ -10,6 +10,8 @@ interface Props {
   upcomingDates?: UpcomingDate[];
   isLoading?: boolean;
   error?: string | null;
+  /** Called when the user retries after an error. */
+  onRetry?: () => void;
   days?: number;
   limit?: number;
 }
@@ -18,6 +20,7 @@ let {
   upcomingDates = [],
   isLoading = false,
   error = null,
+  onRetry,
   days = 30,
   limit = 10,
 }: Props = $props();
@@ -85,6 +88,15 @@ function getDaysUntilClass(daysUntil: number): string {
     </div>
   {:else if error}
     <div class="text-red-600 text-sm">{error}</div>
+    {#if onRetry}
+      <button
+        type="button"
+        onclick={onRetry}
+        class="mt-3 text-sm font-body text-forest hover:text-forest-light"
+      >
+        {$i18n.t('common.retry')}
+      </button>
+    {/if}
   {:else if upcomingDates.length === 0}
     <div class="text-center py-6">
       <div class="text-gray-400 text-4xl mb-2">&#128197;</div>

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "loading": "Laden...",
+    "retry": "Erneut versuchen",
     "save": "Speichern",
     "cancel": "Abbrechen",
     "delete": "Löschen",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "loading": "Loading...",
+    "retry": "Try again",
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",

--- a/apps/frontend/src/lib/stores/auth.ts
+++ b/apps/frontend/src/lib/stores/auth.ts
@@ -48,6 +48,7 @@ function createAuthStore() {
         externalId: result.user.externalId,
         email: result.user.email,
         selfProfileId: result.user.selfProfileId,
+        displayName: result.user.displayName,
         hasCompletedOnboarding: result.user.hasCompletedOnboarding,
         preferences: result.preferences,
       };
@@ -179,47 +180,35 @@ function createAuthStore() {
     initialize: async () => {
       update((state) => ({ ...state, isLoading: true }));
 
-      try {
-        const session = await authClient.getSession();
+      // Fetch the user directly from /api/auth/me. The endpoint already
+      // validates the session via auth middleware, so a separate
+      // authClient.getSession() round-trip would only add a redundant request
+      // to the critical path. fetchUserData() returns null on any failure
+      // (including a 401 when there's no valid session).
+      const userData = await fetchUserData();
 
-        if (session.data) {
-          // We have a valid session, fetch full user data
-          const userData = await fetchUserData();
-
-          if (userData) {
-            update((state) => ({
-              ...state,
-              user: userData,
-              preferences: { ...DEFAULT_PREFERENCES, ...userData.preferences },
-              isLoading: false,
-              isInitialized: true,
-              error: null,
-            }));
-
-            return { user: userData };
-          }
-        }
-
-        // No valid session
+      if (userData) {
         update((state) => ({
           ...state,
+          user: userData,
+          preferences: { ...DEFAULT_PREFERENCES, ...userData.preferences },
           isLoading: false,
           isInitialized: true,
           error: null,
         }));
 
-        return null;
-      } catch {
-        // Not an error if there's no valid session
-        update((state) => ({
-          ...state,
-          isLoading: false,
-          isInitialized: true,
-          error: null,
-        }));
-
-        return null;
+        return { user: userData };
       }
+
+      // No valid session
+      update((state) => ({
+        ...state,
+        isLoading: false,
+        isInitialized: true,
+        error: null,
+      }));
+
+      return null;
     },
 
     /**

--- a/apps/frontend/src/lib/stores/circles.ts
+++ b/apps/frontend/src/lib/stores/circles.ts
@@ -1,4 +1,4 @@
-import { derived, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 import type { Circle, CircleInput, CircleSummary, CircleWithHierarchy } from '$shared';
 import { buildCircleHierarchy } from '$shared';
 import * as circlesApi from '../api/circles.js';
@@ -8,12 +8,15 @@ interface CirclesState {
   circles: Circle[];
   isLoading: boolean;
   error: string | null;
+  /** Whether circles have been successfully loaded at least once. */
+  hasLoaded: boolean;
 }
 
 const initialState: CirclesState = {
   circles: [],
   isLoading: false,
   error: null,
+  hasLoaded: false,
 };
 
 function createCirclesStore() {
@@ -22,13 +25,24 @@ function createCirclesStore() {
   return {
     subscribe,
 
-    loadCircles: () =>
-      storeAction(
+    /**
+     * Load circles, caching the result. Subsequent calls are a no-op while a
+     * load is in flight or after a successful load, so the many call sites
+     * (layout, circles page, circle picker) share a single request. Pass
+     * `force` to bypass the cache and refetch.
+     */
+    loadCircles: (force = false) => {
+      const state = get({ subscribe });
+      if (!force && (state.hasLoaded || state.isLoading)) {
+        return Promise.resolve(state.circles);
+      }
+      return storeAction(
         update,
         () => circlesApi.listCircles(),
-        (_state, circles) => ({ circles }),
+        (_state, circles) => ({ circles, hasLoaded: true }),
         'Failed to load circles',
-      ),
+      );
+    },
 
     createCircle: (input: CircleInput) =>
       storeAction(

--- a/apps/frontend/src/lib/stores/circles.ts
+++ b/apps/frontend/src/lib/stores/circles.ts
@@ -22,26 +22,35 @@ const initialState: CirclesState = {
 function createCirclesStore() {
   const { subscribe, set, update } = writable<CirclesState>(initialState);
 
+  // Tracks an in-flight load so concurrent callers share one request and all
+  // await the same result rather than receiving stale/empty data.
+  let inFlight: Promise<Circle[]> | null = null;
+
   return {
     subscribe,
 
     /**
-     * Load circles, caching the result. Subsequent calls are a no-op while a
-     * load is in flight or after a successful load, so the many call sites
-     * (layout, circles page, circle picker) share a single request. Pass
-     * `force` to bypass the cache and refetch.
+     * Load circles, caching the result. After a successful load this is a
+     * no-op; while a load is in flight, concurrent callers reuse the same
+     * promise. This lets the many call sites (layout, circles page, circle
+     * picker) share a single request. Pass `force` to bypass the cache and
+     * refetch.
      */
-    loadCircles: (force = false) => {
+    loadCircles: (force = false): Promise<Circle[]> => {
       const state = get({ subscribe });
-      if (!force && (state.hasLoaded || state.isLoading)) {
-        return Promise.resolve(state.circles);
+      if (!force) {
+        if (state.hasLoaded) return Promise.resolve(state.circles);
+        if (inFlight) return inFlight;
       }
-      return storeAction(
+      inFlight = storeAction(
         update,
         () => circlesApi.listCircles(),
         (_state, circles) => ({ circles, hasLoaded: true }),
         'Failed to load circles',
-      );
+      ).finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
     },
 
     createCircle: (input: CircleInput) =>
@@ -103,6 +112,7 @@ function createCirclesStore() {
       ),
 
     clear: () => {
+      inFlight = null;
       set(initialState);
     },
   };

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@ import Plus from 'svelte-heros-v2/Plus.svelte';
 import '../app.css';
 import type { Snippet } from 'svelte';
 import { onMount } from 'svelte';
+import { get } from 'svelte/store';
 import { goto } from '$app/navigation';
 import { page } from '$app/stores';
 import { longPress } from '$lib/actions/long-press';
@@ -52,14 +53,27 @@ onMount(async () => {
 // (e.g. the dashboard's consolidated request).
 let circlesPreloaded = false;
 $effect(() => {
-  if ($isAuthInitialized && $isAuthenticated && !circlesPreloaded) {
+  if (!$isAuthInitialized) return;
+
+  if ($isAuthenticated) {
+    if (circlesPreloaded) return;
     circlesPreloaded = true;
-    const preload = () => circles.loadCircles();
+    const preload = () => {
+      // Re-check auth: the user may have logged out (or the session may have
+      // expired) between scheduling and this callback firing, in which case we
+      // must not issue an unauthenticated request.
+      if (get(isAuthenticated)) circles.loadCircles();
+    };
     if (typeof requestIdleCallback === 'function') {
       requestIdleCallback(preload);
     } else {
       setTimeout(preload, 0);
     }
+  } else {
+    // On logout/session loss, drop the previous user's cached circles and
+    // re-arm the preload so a subsequent login fetches a fresh set.
+    circlesPreloaded = false;
+    circles.clear();
   }
 });
 

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -45,12 +45,21 @@ onMount(async () => {
   await locale.initialize(userLanguage);
 });
 
-// Load circles when user is authenticated
-let circlesLoaded = false;
+// Preload circles when the user is authenticated. The circles store caches
+// the result, so this only fetches once and is shared by every consumer
+// (circles page, circle picker, etc.). We defer the preload off the critical
+// path so it doesn't compete with the current page's initial data requests
+// (e.g. the dashboard's consolidated request).
+let circlesPreloaded = false;
 $effect(() => {
-  if ($isAuthInitialized && $isAuthenticated && !circlesLoaded) {
-    circlesLoaded = true;
-    circles.loadCircles();
+  if ($isAuthInitialized && $isAuthenticated && !circlesPreloaded) {
+    circlesPreloaded = true;
+    const preload = () => circles.loadCircles();
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(preload);
+    } else {
+      setTimeout(preload, 0);
+    }
   }
 });
 

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -1,33 +1,46 @@
 <script lang="ts">
-import { getFriend } from '$lib/api/friends';
+import { getDashboardData } from '$lib/api/friends';
 import NetworkGraph from '$lib/components/dashboard/network-graph.svelte';
 import UpcomingDates from '$lib/components/dashboard/upcoming-dates.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { currentUser, isAuthenticated, isAuthInitialized } from '$lib/stores/auth';
+import type { NetworkGraphData, UpcomingDate } from '$shared';
 
 const i18n = createI18n();
 
-let displayName = $state<string | null>(null);
-let lastFetchedId = $state<string | null>(null);
-let userDisplayName = $derived(displayName || $currentUser?.email || '');
+// The self-profile display name is provided by /api/auth/me (via the auth
+// store), so no extra request is needed to greet the user by name.
+let userDisplayName = $derived($currentUser?.displayName || $currentUser?.email || '');
+
+// Dashboard widgets share a single request via /api/friends/dashboard rather
+// than each fetching independently.
+const UPCOMING_DAYS = 30;
+const UPCOMING_LIMIT = 10;
+
+let upcomingDates = $state<UpcomingDate[]>([]);
+let networkGraph = $state<NetworkGraphData | null>(null);
+let isDashboardLoading = $state(true);
+let dashboardError = $state<string | null>(null);
+let dashboardLoaded = false;
 
 $effect(() => {
-  const selfProfileId = $currentUser?.selfProfileId;
-  // Only fetch when selfProfileId changes to a new value
-  // This prevents duplicate fetches and handles user switching properly
-  if (selfProfileId && selfProfileId !== lastFetchedId) {
-    lastFetchedId = selfProfileId;
-    fetchDisplayName(selfProfileId);
+  if ($isAuthInitialized && $isAuthenticated && !dashboardLoaded) {
+    dashboardLoaded = true;
+    loadDashboard();
   }
 });
 
-async function fetchDisplayName(selfProfileId: string) {
+async function loadDashboard() {
+  isDashboardLoading = true;
+  dashboardError = null;
   try {
-    const friend = await getFriend(selfProfileId);
-    displayName = friend.displayName;
-  } catch (error) {
-    console.warn('Failed to fetch self-profile for display name:', error);
-    displayName = null;
+    const data = await getDashboardData({ days: UPCOMING_DAYS, limit: UPCOMING_LIMIT });
+    upcomingDates = data.upcomingDates;
+    networkGraph = data.networkGraph;
+  } catch (err) {
+    dashboardError = err instanceof Error ? err.message : 'Failed to load dashboard';
+  } finally {
+    isDashboardLoading = false;
   }
 }
 </script>
@@ -54,7 +67,13 @@ async function fetchDisplayName(selfProfileId: string) {
 				{$i18n.t('home.welcomeBack', { name: userDisplayName })}
 			</p>
 			<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 text-left max-w-6xl mx-auto">
-				<UpcomingDates days={30} limit={10} />
+				<UpcomingDates
+					{upcomingDates}
+					isLoading={isDashboardLoading}
+					error={dashboardError}
+					days={UPCOMING_DAYS}
+					limit={UPCOMING_LIMIT}
+				/>
 				<div class="bg-white rounded-xl shadow-lg p-6">
 					<h3 class="text-xl font-heading text-gray-800 mb-4">{$i18n.t('home.quickActions')}</h3>
 					<div class="space-y-3">
@@ -75,7 +94,7 @@ async function fetchDisplayName(selfProfileId: string) {
 					</div>
 				</div>
 				<div class="lg:col-span-2">
-					<NetworkGraph />
+					<NetworkGraph graphData={networkGraph} isLoading={isDashboardLoading} error={dashboardError} />
 				</div>
 			</div>
 		{:else}

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -24,9 +24,16 @@ let dashboardError = $state<string | null>(null);
 let dashboardLoaded = false;
 
 $effect(() => {
-  if ($isAuthInitialized && $isAuthenticated && !dashboardLoaded) {
+  if (!$isAuthInitialized) return;
+
+  if ($isAuthenticated) {
+    if (dashboardLoaded) return;
     dashboardLoaded = true;
     loadDashboard();
+  } else {
+    // Reset so re-authentication in the same SPA session reloads the dashboard
+    // instead of showing the previous (or empty) state.
+    dashboardLoaded = false;
   }
 });
 
@@ -39,6 +46,9 @@ async function loadDashboard() {
     networkGraph = data.networkGraph;
   } catch (err) {
     dashboardError = err instanceof Error ? err.message : 'Failed to load dashboard';
+    // Allow a retry: a transient failure shouldn't latch the dashboard into a
+    // permanent error state for the lifetime of this component instance.
+    dashboardLoaded = false;
   } finally {
     isDashboardLoading = false;
   }

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -46,9 +46,6 @@ async function loadDashboard() {
     networkGraph = data.networkGraph;
   } catch (err) {
     dashboardError = err instanceof Error ? err.message : 'Failed to load dashboard';
-    // Allow a retry: a transient failure shouldn't latch the dashboard into a
-    // permanent error state for the lifetime of this component instance.
-    dashboardLoaded = false;
   } finally {
     isDashboardLoading = false;
   }
@@ -81,6 +78,7 @@ async function loadDashboard() {
 					{upcomingDates}
 					isLoading={isDashboardLoading}
 					error={dashboardError}
+					onRetry={loadDashboard}
 					days={UPCOMING_DAYS}
 					limit={UPCOMING_LIMIT}
 				/>
@@ -104,7 +102,7 @@ async function loadDashboard() {
 					</div>
 				</div>
 				<div class="lg:col-span-2">
-					<NetworkGraph graphData={networkGraph} isLoading={isDashboardLoading} error={dashboardError} />
+					<NetworkGraph graphData={networkGraph} isLoading={isDashboardLoading} error={dashboardError} onRetry={loadDashboard} />
 				</div>
 			</div>
 		{:else}

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -67,6 +67,8 @@ export interface User {
   updatedAt?: string;
   /** External ID of the user's self-profile (if set) */
   selfProfileId?: string;
+  /** Display name of the user's self-profile (if set) */
+  displayName?: string;
   /** Whether the user has completed onboarding (has a self-profile) */
   hasCompletedOnboarding: boolean;
 }

--- a/packages/shared/src/friends.ts
+++ b/packages/shared/src/friends.ts
@@ -846,6 +846,16 @@ export interface NetworkGraphData {
   links: NetworkGraphLink[];
 }
 
+/**
+ * Consolidated dashboard payload.
+ * Bundles the home page widgets into a single response so the dashboard
+ * can load with one request instead of several.
+ */
+export interface DashboardData {
+  upcomingDates: UpcomingDate[];
+  networkGraph: NetworkGraphData;
+}
+
 export function parseFacetedSearchQuery(query: FacetedSearchQuery): FacetedSearchOptions {
   const sortBy = query.sortBy || (query.q ? 'relevance' : 'display_name');
 


### PR DESCRIPTION
## Summary
Refactored the home page dashboard to fetch upcoming dates and network graph data in a single consolidated request instead of multiple independent requests. This reduces network round-trips and improves page load performance while simplifying data flow management.

## Key Changes

**Backend**
- Added new `/api/friends/dashboard` endpoint that returns both upcoming dates and network graph data in one response
- Added ETag support to dashboard and network-graph endpoints for efficient cache revalidation
- Extracted query parameter parsing (`parseDays`, `parseLimit`) into reusable functions
- Updated user queries to include `display_name` from the self-profile friend record

**Frontend - Home Page**
- Replaced individual component-level data fetching with parent-level consolidated fetch via `getDashboardData()`
- Removed `getFriend()` call for display name; now uses `displayName` from auth store (populated by `/api/auth/me`)
- Pass fetched data and loading/error states as props to `UpcomingDates` and `NetworkGraph` components
- Simplified state management with single `isDashboardLoading` and `dashboardError` for both widgets

**Frontend - Components**
- `UpcomingDates`: Converted from self-fetching to prop-driven; accepts `upcomingDates`, `isLoading`, and `error` as inputs
- `NetworkGraph`: Converted from self-fetching to prop-driven; accepts `graphData`, `isLoading`, and `error` as inputs

**Frontend - Auth & Stores**
- Added `displayName` field to `User` type and auth store initialization
- Simplified auth store initialization by removing redundant `getSession()` call; relies on `/api/auth/me` validation
- Enhanced `circles` store with caching logic: `loadCircles()` now deduplicates requests and caches results
- Updated layout to preload circles off the critical path using `requestIdleCallback` to avoid competing with initial page requests

**Shared Types**
- Added `DashboardData` interface to bundle `upcomingDates` and `networkGraph` in a single response

## Implementation Details
- The dashboard now loads with a single request to `/api/friends/dashboard?days=30&limit=10`, eliminating the previous three separate requests (upcoming dates, network graph, and self-profile display name)
- User display name is now sourced from the auth store (populated during login) rather than requiring an extra API call
- ETag middleware enables browsers to revalidate dashboard responses cheaply (304 Not Modified) on warm navigations without serving stale data
- Circles preloading is deferred to `requestIdleCallback` to keep the critical rendering path clear for the current page's data needs

https://claude.ai/code/session_0182dg3nkDm95rwXXch3HLRf