### PR TITLE
fix(backend): Clarify phone rejection when a number's country can't be inferred

### DIFF
--- a/apps/backend/src/routes/collectives/sub-resources/phones.routes.ts
+++ b/apps/backend/src/routes/collectives/sub-resources/phones.routes.ts
@@ -10,6 +10,7 @@ import type { AppContext } from '../../../types/context.js';
 import { countryNameToCode, localeToCountry } from '../../../utils/country.js';
 import {
   CollectiveNotFoundError,
+  PhoneCountryUnknownError,
   ResourceNotFoundError,
   ValidationError,
 } from '../../../utils/errors.js';
@@ -68,7 +69,13 @@ app.post('/', async (c) => {
     const countryCode =
       (primaryAddress?.country && countryNameToCode(primaryAddress.country)) ??
       localeToCountry(c.req.header('Accept-Language'));
-    rawBody.phone_number = normalizePhoneNumber(rawBody.phone_number, countryCode);
+    const normalized = normalizePhoneNumber(rawBody.phone_number, countryCode);
+    // If it still isn't in E.164 form, we couldn't pin down a country (no usable
+    // address, ambiguous locale, or the number is invalid for the guessed one).
+    if (!normalized.startsWith('+')) {
+      throw new PhoneCountryUnknownError();
+    }
+    rawBody.phone_number = normalized;
   }
 
   const validated = PhoneInputSchema(rawBody);
@@ -119,7 +126,13 @@ app.put('/:phoneId', async (c) => {
     const countryCode =
       (primaryAddress?.country && countryNameToCode(primaryAddress.country)) ??
       localeToCountry(c.req.header('Accept-Language'));
-    rawBody.phone_number = normalizePhoneNumber(rawBody.phone_number, countryCode);
+    const normalized = normalizePhoneNumber(rawBody.phone_number, countryCode);
+    // If it still isn't in E.164 form, we couldn't pin down a country (no usable
+    // address, ambiguous locale, or the number is invalid for the guessed one).
+    if (!normalized.startsWith('+')) {
+      throw new PhoneCountryUnknownError();
+    }
+    rawBody.phone_number = normalized;
   }
 
   const validated = PhoneInputSchema(rawBody);

--- a/apps/backend/src/routes/friends/sub-resources/phones.routes.ts
+++ b/apps/backend/src/routes/friends/sub-resources/phones.routes.ts
@@ -7,6 +7,7 @@ import type { AppContext } from '../../../types/context.js';
 import { countryNameToCode, localeToCountry } from '../../../utils/country.js';
 import {
   FriendNotFoundError,
+  PhoneCountryUnknownError,
   ResourceNotFoundError,
   ValidationError,
 } from '../../../utils/errors.js';
@@ -47,7 +48,13 @@ app.post('/', async (c) => {
     const countryCode =
       (primaryAddress?.country && countryNameToCode(primaryAddress.country)) ??
       localeToCountry(c.req.header('Accept-Language'));
-    body.phone_number = normalizePhoneNumber(body.phone_number, countryCode);
+    const normalized = normalizePhoneNumber(body.phone_number, countryCode);
+    // If it still isn't in E.164 form, we couldn't pin down a country (no usable
+    // address, ambiguous locale, or the number is invalid for the guessed one).
+    if (!normalized.startsWith('+')) {
+      throw new PhoneCountryUnknownError();
+    }
+    body.phone_number = normalized;
   }
 
   const validated = PhoneInputSchema(body);
@@ -99,7 +106,13 @@ app.put('/:phoneId', async (c) => {
     const countryCode =
       (primaryAddress?.country && countryNameToCode(primaryAddress.country)) ??
       localeToCountry(c.req.header('Accept-Language'));
-    body.phone_number = normalizePhoneNumber(body.phone_number, countryCode);
+    const normalized = normalizePhoneNumber(body.phone_number, countryCode);
+    // If it still isn't in E.164 form, we couldn't pin down a country (no usable
+    // address, ambiguous locale, or the number is invalid for the guessed one).
+    if (!normalized.startsWith('+')) {
+      throw new PhoneCountryUnknownError();
+    }
+    body.phone_number = normalized;
   }
 
   const validated = PhoneInputSchema(body);

--- a/apps/backend/src/utils/country.test.ts
+++ b/apps/backend/src/utils/country.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { countryNameToCode, localeToCountry } from './country.js';
+
+describe('countryNameToCode', () => {
+  it('maps English country names to codes', () => {
+    expect(countryNameToCode('Germany')).toBe('DE');
+    expect(countryNameToCode('United States')).toBe('US');
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(countryNameToCode('  germany ')).toBe('DE');
+    expect(countryNameToCode('GERMANY')).toBe('DE');
+  });
+
+  it('maps localized (German) country names to codes', () => {
+    expect(countryNameToCode('Deutschland')).toBe('DE');
+    expect(countryNameToCode('Österreich')).toBe('AT');
+    expect(countryNameToCode('Schweiz')).toBe('CH');
+    expect(countryNameToCode('Großbritannien')).toBe('GB');
+  });
+
+  it('accepts a value that is already an ISO alpha-2 code', () => {
+    expect(countryNameToCode('DE')).toBe('DE');
+    expect(countryNameToCode('ch')).toBe('CH');
+  });
+
+  it('returns undefined for empty or unknown names', () => {
+    expect(countryNameToCode('')).toBeUndefined();
+    expect(countryNameToCode('   ')).toBeUndefined();
+    expect(countryNameToCode('Atlantis')).toBeUndefined();
+  });
+});
+
+describe('localeToCountry', () => {
+  it('returns undefined when the header is missing or empty', () => {
+    expect(localeToCountry(undefined)).toBeUndefined();
+    expect(localeToCountry('')).toBeUndefined();
+  });
+
+  it('extracts the region subtag from the most-preferred locale', () => {
+    expect(localeToCountry('de-DE,de;q=0.9,en;q=0.8')).toBe('DE');
+    expect(localeToCountry('en-US')).toBe('US');
+  });
+
+  it('honours q-weights rather than list order', () => {
+    expect(localeToCountry('en;q=0.5,de-DE;q=0.9')).toBe('DE');
+  });
+
+  it('skips script subtags to find the region', () => {
+    expect(localeToCountry('zh-Hant-TW')).toBe('TW');
+  });
+
+  it('does not turn a language-only tag into a bogus country code', () => {
+    // The old bug returned "EN" here.
+    expect(localeToCountry('en')).toBeUndefined();
+  });
+
+  it('maps unambiguous language-only tags to their primary country', () => {
+    expect(localeToCountry('de')).toBe('DE');
+    expect(localeToCountry('fr')).toBe('FR');
+  });
+
+  it('falls back to a language guess when no entry has a region', () => {
+    expect(localeToCountry('en,de;q=0.9')).toBe('DE');
+  });
+});

--- a/apps/backend/src/utils/country.ts
+++ b/apps/backend/src/utils/country.ts
@@ -1,23 +1,106 @@
 import { SUPPORTED_COUNTRIES } from '../services/external/zipcodebase.client.js';
 
+const SUPPORTED_CODES = new Set(SUPPORTED_COUNTRIES.map((c) => c.code));
+
 /**
- * Map a country name (e.g. "Germany") to its ISO 3166-1 alpha-2 code (e.g. "DE").
+ * Country names stored in the user's own language (e.g. from CardDAV imports or
+ * legacy data) don't match the English {@link SUPPORTED_COUNTRIES} names. Map
+ * the common non-English spellings — German first, since that's our primary
+ * market — to ISO 3166-1 alpha-2 codes.
+ */
+const LOCALIZED_COUNTRY_NAMES: Record<string, string> = {
+  deutschland: 'DE',
+  österreich: 'AT',
+  oesterreich: 'AT',
+  schweiz: 'CH',
+  frankreich: 'FR',
+  italien: 'IT',
+  spanien: 'ES',
+  niederlande: 'NL',
+  belgien: 'BE',
+  luxemburg: 'LU',
+  polen: 'PL',
+  tschechien: 'CZ',
+  dänemark: 'DK',
+  daenemark: 'DK',
+  'vereinigtes königreich': 'GB',
+  großbritannien: 'GB',
+  grossbritannien: 'GB',
+  'vereinigte staaten': 'US',
+  usa: 'US',
+};
+
+/**
+ * Languages that map cleanly to a single primary country, used as a fallback
+ * when an Accept-Language entry carries no region subtag (e.g. "de" → "DE").
+ * Languages spoken across many countries (en, es, pt, ar, …) are intentionally
+ * omitted — guessing one would be wrong as often as right.
+ */
+const LANGUAGE_TO_COUNTRY: Record<string, string> = {
+  de: 'DE',
+  fr: 'FR',
+  it: 'IT',
+  nl: 'NL',
+  pl: 'PL',
+  cs: 'CZ',
+  da: 'DK',
+};
+
+/**
+ * Map a country name (e.g. "Germany" or "Deutschland") to its ISO 3166-1
+ * alpha-2 code (e.g. "DE"). Also accepts a code that's already in alpha-2 form.
  */
 export function countryNameToCode(name: string): string | undefined {
-  return SUPPORTED_COUNTRIES.find((c) => c.name.toLowerCase() === name.toLowerCase())?.code;
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  // Already an ISO alpha-2 code we recognize.
+  const asCode = normalized.toUpperCase();
+  if (SUPPORTED_CODES.has(asCode)) return asCode;
+
+  return (
+    SUPPORTED_COUNTRIES.find((c) => c.name.toLowerCase() === normalized)?.code ??
+    LOCALIZED_COUNTRY_NAMES[normalized]
+  );
 }
 
 /**
  * Extract a country code from the Accept-Language header.
- * E.g. "de-DE,de;q=0.9,en;q=0.8" → "DE"
+ * E.g. "de-DE,de;q=0.9,en;q=0.8" → "DE", "en" → undefined (not "EN").
  */
 export function localeToCountry(acceptLanguage: string | undefined): string | undefined {
   if (!acceptLanguage) return undefined;
-  const primary = acceptLanguage.split(',')[0]?.trim();
-  if (!primary) return undefined;
-  // Extract region subtag: "de-DE" → "DE"
-  const parts = primary.split('-');
-  if (parts.length >= 2) return parts[1].toUpperCase();
-  // No region subtag: "de" → "DE" (language code as rough country guess)
-  return parts[0].toUpperCase();
+
+  // Accept-Language is a comma-separated, q-weighted list. Parse it and sort by
+  // preference so we honour the user's most-wanted locale first.
+  const tags = acceptLanguage
+    .split(',')
+    .map((part) => {
+      const [tag, ...params] = part.trim().split(';');
+      const q = params.map((p) => p.trim()).find((p) => p.startsWith('q='));
+      const weight = q ? Number.parseFloat(q.slice(2)) : 1;
+      return { tag: tag.trim(), weight: Number.isNaN(weight) ? 0 : weight };
+    })
+    .filter((entry) => entry.tag.length > 0)
+    .sort((a, b) => b.weight - a.weight)
+    .map((entry) => entry.tag);
+
+  // First choice: an explicit region subtag, e.g. "de-DE" → "DE" or
+  // "zh-Hant-TW" → "TW". A region subtag is two letters (alpha-2).
+  for (const tag of tags) {
+    const region = tag
+      .split('-')
+      .slice(1)
+      .find((subtag) => /^[A-Za-z]{2}$/.test(subtag));
+    if (region) return region.toUpperCase();
+  }
+
+  // Fallback: a language-only tag mapped to its primary country. Never return
+  // the language code itself ("en" is not the country "EN").
+  for (const tag of tags) {
+    const country = LANGUAGE_TO_COUNTRY[tag.split('-')[0].toLowerCase()];
+    if (country) return country;
+  }
+
+  return undefined;
 }

--- a/apps/backend/src/utils/errors.ts
+++ b/apps/backend/src/utils/errors.ts
@@ -213,6 +213,23 @@ export class ValidationError extends AppError {
 }
 
 /**
+ * Thrown when a phone number is entered in national format (no leading "+")
+ * but we can't determine which country it belongs to — so it can't be
+ * normalized to E.164 and validated. The dedicated code lets the frontend show
+ * actionable guidance (use international format, or add an address).
+ */
+export class PhoneCountryUnknownError extends AppError {
+  readonly statusCode = 400;
+
+  constructor() {
+    super(
+      'Could not determine the country for this phone number. Enter it in international format (e.g. +49 6709 426) or add an address to detect the country.',
+      { code: 'PHONE_COUNTRY_UNKNOWN' },
+    );
+  }
+}
+
+/**
  * Thrown when search parameters are invalid or missing required fields.
  */
 export class InvalidSearchParametersError extends AppError {

--- a/apps/frontend/src/lib/components/collectives/collective-detail.svelte
+++ b/apps/frontend/src/lib/components/collectives/collective-detail.svelte
@@ -12,6 +12,7 @@ import Plus from 'svelte-heros-v2/Plus.svelte';
 import UserPlus from 'svelte-heros-v2/UserPlus.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { goto } from '$app/navigation';
+import { ApiError } from '$lib/api/client';
 import {
   type AvailableCircleInfo,
   addAddress,
@@ -375,7 +376,11 @@ async function handleSave() {
     }
     closeEditModal();
   } catch (err) {
-    editError = (err as Error).message || 'Failed to save';
+    if (err instanceof ApiError && err.code === 'PHONE_COUNTRY_UNKNOWN') {
+      editError = $i18n.t('subresources.phone.unknownCountry');
+    } else {
+      editError = (err as Error).message || $i18n.t('subresources.common.failedToSave');
+    }
   } finally {
     isEditLoading = false;
   }

--- a/apps/frontend/src/lib/components/friends/sections/phone-section.svelte
+++ b/apps/frontend/src/lib/components/friends/sections/phone-section.svelte
@@ -80,7 +80,11 @@ async function handleSave() {
     }
     closeModal();
   } catch (err) {
-    if (err instanceof ApiError && err.statusCode === 400) {
+    if (err instanceof ApiError && err.code === 'PHONE_COUNTRY_UNKNOWN') {
+      // National-format number we couldn't pin to a country — point the user at
+      // international format or adding an address.
+      editError = $i18n.t('subresources.phone.unknownCountry');
+    } else if (err instanceof ApiError && err.statusCode === 400) {
       // A 400 from this form means the entered phone number failed validation.
       // Show a clear, actionable hint instead of the backend's terse "Invalid request".
       editError = $i18n.t('subresources.phone.invalidNumber');

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -1264,6 +1264,7 @@
       "phoneNumber": "Telefonnummer",
       "primaryPhone": "Primäre Telefonnummer",
       "invalidNumber": "Bitte gib eine gültige Telefonnummer ein, z. B. +49 176 12345678 oder mit führender 0 für eine lokale Nummer.",
+      "unknownCountry": "Wir konnten das Land dieser Nummer nicht erkennen. Gib sie im internationalen Format ein (z. B. +49 6709 426) oder hinterlege eine Adresse mit Land, damit wir es automatisch erkennen können.",
       "types": {
         "mobile": "Mobil",
         "home": "Privat",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -1264,6 +1264,7 @@
       "phoneNumber": "Phone Number",
       "primaryPhone": "Primary phone number",
       "invalidNumber": "Please enter a valid phone number, e.g. +49 176 12345678 or with a leading 0 for a local number.",
+      "unknownCountry": "We couldn't tell which country this number belongs to. Enter it in international format (e.g. +49 6709 426), or add an address with a country so we can detect it automatically.",
       "types": {
         "mobile": "Mobile",
         "home": "Home",


### PR DESCRIPTION
## Problem

A valid German landline like `06709 426` was rejected at the phone form with a generic "invalid number" message.

National-format numbers are validated by first normalizing to E.164 using a country **guessed** from the friend's primary address or the `Accept-Language` header. When that guess is missing or wrong (e.g. English browser locale + no address on the friend), the number stays in national format and fails `isValidPhoneNumber` — even though it's a perfectly valid number. Verified with libphonenumber: `isValidPhoneNumber('06709426')` → `false`, but `isValidPhoneNumber('06709426', 'DE')` → `true` (`+496709426`).

## Changes

**Clearer error instead of silent generic rejection**
- New `PhoneCountryUnknownError` (400, code `PHONE_COUNTRY_UNKNOWN`). When a national-format number can't be normalized, the routes throw this instead of falling through to the terse validation error.
- Frontend (`phone-section.svelte`, `collective-detail.svelte`) maps the code to a dedicated, actionable message: enter international format (e.g. `+49 6709 426`) **or** add an address so we can detect the country.
- New i18n key `subresources.phone.unknownCountry` (en + de).

**Hardened country inference** (`utils/country.ts`) — fixes two latent bugs surfaced while diagnosing:
- `localeToCountry` no longer emits bogus codes like `"EN"` for language-only tags. It now parses `q`-weights, prefers real region subtags (skipping script subtags, e.g. `zh-Hant-TW` → `TW`), and only falls back to a curated language→country map.
- `countryNameToCode` now matches localized (German) country names (`Deutschland` → `DE`) and accepts values already in ISO alpha-2 form — case/whitespace-insensitive. Mainly helps CardDAV/CalDAV imports and legacy data, where the country can arrive non-English.

Applied to both friends and collectives phone routes (POST + PUT).

## Tests

- New `apps/backend/src/utils/country.test.ts` (12 cases) covering both functions: English/localized/code/empty names, region extraction, q-weights, script subtags, the no-bogus-`EN` regression, and language fallback. All pass.
- Backend + frontend type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)