### PR TITLE
feat(frontend): re-login in place when a session expires

### DIFF
--- a/apps/frontend/src/lib/api/client.test.ts
+++ b/apps/frontend/src/lib/api/client.test.ts
@@ -3,15 +3,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('$shared', () => ({}));
 
-import { sessionExpired, setHasSession } from '../stores/session.js';
+import {
+  abandonSessionExpired,
+  resolveSessionExpired,
+  sessionExpired,
+  setHasSession,
+} from '../stores/session.js';
 import { ApiError, apiRequest } from './client.js';
 
-function mock401() {
-  vi.mocked(fetch).mockResolvedValue({
+function response401() {
+  return {
     ok: false,
     status: 401,
     json: () => Promise.resolve({ error: 'Unauthorized' }),
-  } as unknown as Response);
+  } as unknown as Response;
 }
 
 describe('ApiError', () => {
@@ -130,23 +135,49 @@ describe('apiRequest', () => {
 
   describe('401 session expiry', () => {
     afterEach(() => {
+      // Release any request still parked on the prompt, then reset state.
+      abandonSessionExpired();
       setHasSession(false);
-      sessionExpired.set(false);
     });
 
-    it('flags the session as expired on 401 when a session was active', async () => {
+    it('prompts re-login and rejects when the user logs out', async () => {
       setHasSession(true);
       sessionExpired.set(false);
-      mock401();
+      vi.mocked(fetch).mockResolvedValue(response401());
 
-      await expect(apiRequest('/api/test')).rejects.toMatchObject({ statusCode: 401 });
-      expect(get(sessionExpired)).toBe(true);
+      const pending = apiRequest('/api/test');
+      // The prompt is shown while the request is parked awaiting re-auth.
+      await vi.waitFor(() => expect(get(sessionExpired)).toBe(true));
+
+      // User logs out -> the parked request rejects with the original 401.
+      abandonSessionExpired();
+      await expect(pending).rejects.toMatchObject({ statusCode: 401 });
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    it('does not flag session expiry on 401 when unauthenticated', async () => {
+    it('replays the original request after the user re-authenticates', async () => {
+      setHasSession(true);
+      sessionExpired.set(false);
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(response401())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ replayed: true }),
+        } as unknown as Response);
+
+      const pending = apiRequest('/api/test');
+      await vi.waitFor(() => expect(get(sessionExpired)).toBe(true));
+
+      // Re-auth succeeds -> the request is replayed and resolves normally.
+      resolveSessionExpired();
+      await expect(pending).resolves.toEqual({ replayed: true });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not prompt on 401 when unauthenticated', async () => {
       setHasSession(false);
       sessionExpired.set(false);
-      mock401();
+      vi.mocked(fetch).mockResolvedValue(response401());
 
       await expect(apiRequest('/api/test')).rejects.toMatchObject({ statusCode: 401 });
       expect(get(sessionExpired)).toBe(false);

--- a/apps/frontend/src/lib/api/client.test.ts
+++ b/apps/frontend/src/lib/api/client.test.ts
@@ -1,8 +1,18 @@
+import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('$shared', () => ({}));
 
+import { sessionExpired, setHasSession } from '../stores/session.js';
 import { ApiError, apiRequest } from './client.js';
+
+function mock401() {
+  vi.mocked(fetch).mockResolvedValue({
+    ok: false,
+    status: 401,
+    json: () => Promise.resolve({ error: 'Unauthorized' }),
+  } as unknown as Response);
+}
 
 describe('ApiError', () => {
   it('has correct properties', () => {
@@ -115,6 +125,31 @@ describe('apiRequest', () => {
     await expect(apiRequest('/api/test')).rejects.toMatchObject({
       statusCode: 500,
       message: 'An unknown error occurred',
+    });
+  });
+
+  describe('401 session expiry', () => {
+    afterEach(() => {
+      setHasSession(false);
+      sessionExpired.set(false);
+    });
+
+    it('flags the session as expired on 401 when a session was active', async () => {
+      setHasSession(true);
+      sessionExpired.set(false);
+      mock401();
+
+      await expect(apiRequest('/api/test')).rejects.toMatchObject({ statusCode: 401 });
+      expect(get(sessionExpired)).toBe(true);
+    });
+
+    it('does not flag session expiry on 401 when unauthenticated', async () => {
+      setHasSession(false);
+      sessionExpired.set(false);
+      mock401();
+
+      await expect(apiRequest('/api/test')).rejects.toMatchObject({ statusCode: 401 });
+      expect(get(sessionExpired)).toBe(false);
     });
   });
 });

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -1,4 +1,5 @@
 import type { ErrorResponse } from '$shared';
+import { notifyUnauthorized } from '../stores/session.js';
 
 // In production with single-domain deployment, use empty string for same-origin requests.
 // In development, VITE_API_URL can point to the backend server if needed.
@@ -38,6 +39,12 @@ export async function apiRequest<T>(endpoint: string, options: RequestInit = {})
   });
 
   if (!response.ok) {
+    // A 401 mid-session means the session expired. Surface a re-login prompt so
+    // the user can re-authenticate without losing their current page state.
+    if (response.status === 401) {
+      notifyUnauthorized();
+    }
+
     const errorData: ErrorResponse = await response.json().catch(() => ({
       error: 'An unknown error occurred',
     }));

--- a/apps/frontend/src/lib/api/client.ts
+++ b/apps/frontend/src/lib/api/client.ts
@@ -24,7 +24,13 @@ export class ApiError extends Error {
  * Helper function to make API requests with proper error handling.
  * Authentication is handled via Better Auth session cookies (credentials: 'include').
  */
-export async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+export async function apiRequest<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  // Internal: whether a 401 should pause for re-login and replay the request.
+  // Disabled on the replay itself so a still-failing request can't loop.
+  retryOnUnauthorized = true,
+): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
 
   const headers: Record<string, string> = {
@@ -39,10 +45,15 @@ export async function apiRequest<T>(endpoint: string, options: RequestInit = {})
   });
 
   if (!response.ok) {
-    // A 401 mid-session means the session expired. Surface a re-login prompt so
-    // the user can re-authenticate without losing their current page state.
-    if (response.status === 401) {
-      notifyUnauthorized();
+    // A 401 mid-session means the session expired. Surface a re-login prompt and
+    // wait for the outcome: if the user re-authenticates, replay the original
+    // request transparently so they don't lose the action; otherwise fall
+    // through and reject as usual.
+    if (response.status === 401 && retryOnUnauthorized) {
+      const reAuthenticated = await notifyUnauthorized();
+      if (reAuthenticated) {
+        return apiRequest<T>(endpoint, options, false);
+      }
     }
 
     const errorData: ErrorResponse = await response.json().catch(() => ({

--- a/apps/frontend/src/lib/components/login-form.svelte
+++ b/apps/frontend/src/lib/components/login-form.svelte
@@ -7,13 +7,35 @@ import AlertBanner from '$lib/components/alert-banner.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { auth } from '$lib/stores/auth';
 
+interface Props {
+  /**
+   * Called after a successful sign-in. Defaults to navigating to the home page.
+   * The re-login modal overrides this to dismiss the prompt and keep the user
+   * on their current page instead.
+   */
+  onSuccess?: () => void;
+  /** Pre-fill the email field (e.g. the expired session's user). */
+  initialEmail?: string;
+}
+
+let { onSuccess, initialEmail = '' }: Props = $props();
+
 const i18n = createI18n();
 
-let email = $state('');
+let email = $state(initialEmail);
 let password = $state('');
 let isLoading = $state(false);
 let isPasskeyLoading = $state(false);
 let error = $state('');
+
+function handleSuccess() {
+  if (onSuccess) {
+    onSuccess();
+  } else {
+    // Redirect to home page after successful login
+    goto('/');
+  }
+}
 
 async function handleSubmit(e) {
   e.preventDefault();
@@ -22,8 +44,7 @@ async function handleSubmit(e) {
 
   try {
     await auth.login(email, password);
-    // Redirect to home page after successful login
-    goto('/');
+    handleSuccess();
   } catch (err) {
     error = (err as Error)?.message || $i18n.t('auth.login.error.generic');
     isLoading = false;
@@ -42,7 +63,7 @@ async function handlePasskeySignIn() {
     } else {
       // Refresh the auth store so the app has the user data
       await auth.initialize();
-      goto('/');
+      handleSuccess();
     }
   } catch (err) {
     error = (err as Error)?.message || $i18n.t('profile.passkeys.signInFailed');

--- a/apps/frontend/src/lib/components/session-expired-modal.svelte
+++ b/apps/frontend/src/lib/components/session-expired-modal.svelte
@@ -31,9 +31,11 @@ function handleKeydown(e: KeyboardEvent) {
 }
 
 // Re-login succeeded: the auth store already dismissed the prompt and released
-// any parked requests, so there's nothing left to do here (just don't navigate
-// away — keep the user on their current page).
-function handleReauthenticated() {}
+// any parked requests, so there's nothing left to do here.
+function handleReauthenticated() {
+  // Intentionally a no-op: unlike the standalone login page, we must NOT
+  // navigate away — the point is to keep the user on their current page.
+}
 
 async function handleLogout() {
   isLoggingOut = true;

--- a/apps/frontend/src/lib/components/session-expired-modal.svelte
+++ b/apps/frontend/src/lib/components/session-expired-modal.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+import LockClosed from 'svelte-heros-v2/LockClosed.svelte';
+import LoginForm from '$lib/components/login-form.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+import { currentUser } from '$lib/stores/auth';
+import { clearSessionExpired } from '$lib/stores/session';
+import { isModalOpen } from '$lib/stores/ui';
+
+const i18n = createI18n();
+
+// Pre-fill the email of the user whose session expired so re-login is one tap
+// (password / passkey) away.
+const email = $derived($currentUser?.email ?? '');
+
+// Suppress global keyboard shortcuts while the prompt is open.
+$effect(() => {
+  isModalOpen.set(true);
+  return () => isModalOpen.set(false);
+});
+
+// Trap Escape so the user can't dismiss an expired session into a broken state;
+// the only way forward is to re-authenticate.
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- Modal backdrop. Intentionally not dismissible by backdrop click: the
+     session is gone, so re-authentication is the only path forward. -->
+<div
+  class="fixed inset-0 bg-gray-900/50 z-[60] flex items-center justify-center p-4"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="session-expired-title"
+  tabindex="-1"
+>
+  <div class="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto p-8">
+    <!-- Explanatory banner -->
+    <div class="flex items-start gap-3 mb-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
+      <LockClosed class="w-6 h-6 text-amber-500 flex-shrink-0" strokeWidth="2" />
+      <div>
+        <h2 id="session-expired-title" class="font-heading text-forest mb-1">
+          {$i18n.t('auth.sessionExpired.title')}
+        </h2>
+        <p class="text-sm font-body text-gray-600">
+          {$i18n.t('auth.sessionExpired.message')}
+        </p>
+      </div>
+    </div>
+
+    <LoginForm initialEmail={email} onSuccess={clearSessionExpired} />
+  </div>
+</div>

--- a/apps/frontend/src/lib/components/session-expired-modal.svelte
+++ b/apps/frontend/src/lib/components/session-expired-modal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import LockClosed from 'svelte-heros-v2/LockClosed.svelte';
+import { goto } from '$app/navigation';
 import LoginForm from '$lib/components/login-form.svelte';
 import { createI18n } from '$lib/i18n/index.js';
-import { currentUser } from '$lib/stores/auth';
-import { clearSessionExpired } from '$lib/stores/session';
+import { auth, currentUser } from '$lib/stores/auth';
+import { abandonSessionExpired } from '$lib/stores/session';
 import { isModalOpen } from '$lib/stores/ui';
 
 const i18n = createI18n();
@@ -12,6 +13,8 @@ const i18n = createI18n();
 // (password / passkey) away.
 const email = $derived($currentUser?.email ?? '');
 
+let isLoggingOut = $state(false);
+
 // Suppress global keyboard shortcuts while the prompt is open.
 $effect(() => {
   isModalOpen.set(true);
@@ -19,11 +22,31 @@ $effect(() => {
 });
 
 // Trap Escape so the user can't dismiss an expired session into a broken state;
-// the only way forward is to re-authenticate.
+// the only ways forward are to re-authenticate or explicitly log out.
 function handleKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
     e.preventDefault();
     e.stopPropagation();
+  }
+}
+
+// Re-login succeeded: the auth store already dismissed the prompt and released
+// any parked requests, so there's nothing left to do here (just don't navigate
+// away — keep the user on their current page).
+function handleReauthenticated() {}
+
+async function handleLogout() {
+  isLoggingOut = true;
+  try {
+    await auth.logout();
+  } catch {
+    // Best effort: even if the sign-out request fails, the session is already
+    // gone client-side, so drop the prompt and head to a clean login page.
+  } finally {
+    // Ensure the prompt is dismissed and parked requests reject regardless of
+    // how the sign-out request resolved.
+    abandonSessionExpired();
+    await goto('/auth/login');
   }
 }
 </script>
@@ -31,7 +54,7 @@ function handleKeydown(e: KeyboardEvent) {
 <svelte:window onkeydown={handleKeydown} />
 
 <!-- Modal backdrop. Intentionally not dismissible by backdrop click: the
-     session is gone, so re-authentication is the only path forward. -->
+     session is gone, so re-authentication (or logout) is the only path forward. -->
 <div
   class="fixed inset-0 bg-gray-900/50 z-[60] flex items-center justify-center p-4"
   role="dialog"
@@ -53,6 +76,17 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
     </div>
 
-    <LoginForm initialEmail={email} onSuccess={clearSessionExpired} />
+    <LoginForm initialEmail={email} onSuccess={handleReauthenticated} />
+
+    <div class="mt-6 pt-6 border-t border-gray-200 text-center">
+      <button
+        type="button"
+        onclick={handleLogout}
+        disabled={isLoggingOut}
+        class="text-sm font-body font-semibold text-gray-500 hover:text-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isLoggingOut ? $i18n.t('common.loading') : $i18n.t('auth.sessionExpired.logout')}
+      </button>
+    </div>
   </div>
 </div>

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -290,7 +290,8 @@
   "auth": {
     "sessionExpired": {
       "title": "Deine Sitzung ist abgelaufen",
-      "message": "Du wurdest abgemeldet. Melde dich erneut an, um genau dort weiterzumachen, wo du aufgehört hast."
+      "message": "Du wurdest abgemeldet. Melde dich erneut an, um genau dort weiterzumachen, wo du aufgehört hast.",
+      "logout": "Stattdessen abmelden"
     },
     "login": {
       "title": "Anmelden",

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -288,6 +288,10 @@
     }
   },
   "auth": {
+    "sessionExpired": {
+      "title": "Deine Sitzung ist abgelaufen",
+      "message": "Du wurdest abgemeldet. Melde dich erneut an, um genau dort weiterzumachen, wo du aufgehört hast."
+    },
     "login": {
       "title": "Anmelden",
       "subtitle": "Willkommen zurück! Bitte melde dich an.",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -290,7 +290,8 @@
   "auth": {
     "sessionExpired": {
       "title": "Your session expired",
-      "message": "You've been signed out. Sign back in to pick up right where you left off."
+      "message": "You've been signed out. Sign back in to pick up right where you left off.",
+      "logout": "Log out instead"
     },
     "login": {
       "title": "Sign In",

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -288,6 +288,10 @@
     }
   },
   "auth": {
+    "sessionExpired": {
+      "title": "Your session expired",
+      "message": "You've been signed out. Sign back in to pick up right where you left off."
+    },
     "login": {
       "title": "Sign In",
       "subtitle": "Welcome back! Please sign in to continue.",

--- a/apps/frontend/src/lib/stores/auth.ts
+++ b/apps/frontend/src/lib/stores/auth.ts
@@ -3,7 +3,7 @@ import type { User, UserPreferences } from '$shared';
 import * as authApi from '../api/auth.js';
 import { authClient } from '../auth-client.js';
 import { retryWithBackoff } from '../utils/retry.js';
-import { clearSessionExpired, setHasSession } from './session.js';
+import { abandonSessionExpired, resolveSessionExpired, setHasSession } from './session.js';
 
 /** Default user preferences */
 const DEFAULT_PREFERENCES: UserPreferences = {
@@ -83,7 +83,7 @@ function createAuthStore() {
 
         if (userData) {
           setHasSession(true);
-          clearSessionExpired();
+          resolveSessionExpired();
           update((state) => ({
             ...state,
             user: userData,
@@ -130,7 +130,7 @@ function createAuthStore() {
 
         if (userData) {
           setHasSession(true);
-          clearSessionExpired();
+          resolveSessionExpired();
           update((state) => ({
             ...state,
             user: userData,
@@ -165,7 +165,7 @@ function createAuthStore() {
       try {
         await authClient.signOut();
         setHasSession(false);
-        clearSessionExpired();
+        abandonSessionExpired();
         set(initialState);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Logout failed';
@@ -196,7 +196,7 @@ function createAuthStore() {
 
       if (userData) {
         setHasSession(true);
-        clearSessionExpired();
+        resolveSessionExpired();
         update((state) => ({
           ...state,
           user: userData,

--- a/apps/frontend/src/lib/stores/auth.ts
+++ b/apps/frontend/src/lib/stores/auth.ts
@@ -3,6 +3,7 @@ import type { User, UserPreferences } from '$shared';
 import * as authApi from '../api/auth.js';
 import { authClient } from '../auth-client.js';
 import { retryWithBackoff } from '../utils/retry.js';
+import { clearSessionExpired, setHasSession } from './session.js';
 
 /** Default user preferences */
 const DEFAULT_PREFERENCES: UserPreferences = {
@@ -81,6 +82,8 @@ function createAuthStore() {
         const userData = await fetchUserData();
 
         if (userData) {
+          setHasSession(true);
+          clearSessionExpired();
           update((state) => ({
             ...state,
             user: userData,
@@ -126,6 +129,8 @@ function createAuthStore() {
         const userData = await fetchUserData();
 
         if (userData) {
+          setHasSession(true);
+          clearSessionExpired();
           update((state) => ({
             ...state,
             user: userData,
@@ -159,6 +164,8 @@ function createAuthStore() {
 
       try {
         await authClient.signOut();
+        setHasSession(false);
+        clearSessionExpired();
         set(initialState);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Logout failed';
@@ -188,6 +195,8 @@ function createAuthStore() {
       const userData = await fetchUserData();
 
       if (userData) {
+        setHasSession(true);
+        clearSessionExpired();
         update((state) => ({
           ...state,
           user: userData,
@@ -201,6 +210,7 @@ function createAuthStore() {
       }
 
       // No valid session
+      setHasSession(false);
       update((state) => ({
         ...state,
         isLoading: false,

--- a/apps/frontend/src/lib/stores/session.ts
+++ b/apps/frontend/src/lib/stores/session.ts
@@ -8,6 +8,10 @@ import { writable } from 'svelte/store';
  * (or silently swallow the error), the API client funnels that 401 here so the
  * app can surface a re-login dialog *in place* — preserving whatever the user
  * was doing instead of bouncing them out to the login page.
+ *
+ * The client also *awaits* the outcome: if the user re-authenticates, the
+ * original request is replayed transparently; if they log out (or give up), the
+ * request rejects as usual.
  */
 
 // Lightweight snapshot of whether the user currently holds an authenticated
@@ -32,19 +36,50 @@ export function setHasSession(value: boolean): void {
  */
 export const sessionExpired = writable(false);
 
-/**
- * Notify that an API request was rejected as unauthorized (401).
- *
- * Only triggers the re-login prompt if the user actually had a session; a 401
- * while unauthenticated (e.g. the startup session probe) is ignored.
- */
-export function notifyUnauthorized(): void {
-  if (hasSession) {
-    sessionExpired.set(true);
+// Requests that hit a 401 park here, each waiting to learn whether the user
+// re-authenticated (true -> replay the request) or bailed out (false -> reject).
+let waiters: Array<(reAuthenticated: boolean) => void> = [];
+
+function settle(reAuthenticated: boolean): void {
+  const pending = waiters;
+  waiters = [];
+  for (const resolve of pending) {
+    resolve(reAuthenticated);
   }
 }
 
-/** Dismiss the session-expired prompt (e.g. after a successful re-login). */
-export function clearSessionExpired(): void {
+/**
+ * Notify that an API request was rejected as unauthorized (401).
+ *
+ * Resolves with `true` once the user re-authenticates (caller should replay the
+ * request) or `false` if they log out / abandon the prompt (caller should
+ * reject). A 401 while unauthenticated (e.g. the startup session probe) resolves
+ * immediately to `false` and never shows the prompt.
+ */
+export function notifyUnauthorized(): Promise<boolean> {
+  if (!hasSession) {
+    return Promise.resolve(false);
+  }
+  sessionExpired.set(true);
+  return new Promise<boolean>((resolve) => {
+    waiters.push(resolve);
+  });
+}
+
+/**
+ * Re-authentication succeeded: dismiss the prompt and let parked requests
+ * replay.
+ */
+export function resolveSessionExpired(): void {
   sessionExpired.set(false);
+  settle(true);
+}
+
+/**
+ * The user abandoned re-authentication (e.g. logged out): dismiss the prompt and
+ * let parked requests reject.
+ */
+export function abandonSessionExpired(): void {
+  sessionExpired.set(false);
+  settle(false);
 }

--- a/apps/frontend/src/lib/stores/session.ts
+++ b/apps/frontend/src/lib/stores/session.ts
@@ -1,0 +1,50 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Session expiry handling.
+ *
+ * When a previously-authenticated user's session expires server-side, the very
+ * next API call comes back as a 401. Rather than letting individual pages break
+ * (or silently swallow the error), the API client funnels that 401 here so the
+ * app can surface a re-login dialog *in place* — preserving whatever the user
+ * was doing instead of bouncing them out to the login page.
+ */
+
+// Lightweight snapshot of whether the user currently holds an authenticated
+// session. Maintained by the auth store; read by the API client. We keep this
+// as a module-level flag (rather than importing the auth store into the client)
+// to avoid a circular import: auth store -> api -> client.
+//
+// It lets us distinguish an *expired* session (was authenticated, now 401 ->
+// prompt re-login) from an ordinary unauthenticated state (e.g. the initial
+// session check on the login page, where a 401 is expected and harmless).
+let hasSession = false;
+
+/** Called by the auth store whenever the authenticated state changes. */
+export function setHasSession(value: boolean): void {
+  hasSession = value;
+}
+
+/**
+ * True when a previously-authenticated session has expired and we want to
+ * prompt the user to re-authenticate without navigating away from the current
+ * page.
+ */
+export const sessionExpired = writable(false);
+
+/**
+ * Notify that an API request was rejected as unauthorized (401).
+ *
+ * Only triggers the re-login prompt if the user actually had a session; a 401
+ * while unauthenticated (e.g. the startup session probe) is ignored.
+ */
+export function notifyUnauthorized(): void {
+  if (hasSession) {
+    sessionExpired.set(true);
+  }
+}
+
+/** Dismiss the session-expired prompt (e.g. after a successful re-login). */
+export function clearSessionExpired(): void {
+  sessionExpired.set(false);
+}

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -14,6 +14,7 @@ import FabCreateMenu, {
 import Footer from '$lib/components/footer.svelte';
 import GlobalSearch from '$lib/components/global-search.svelte';
 import NavBar from '$lib/components/nav-bar.svelte';
+import SessionExpiredModal from '$lib/components/session-expired-modal.svelte';
 import type { SupportedLanguage } from '$lib/i18n/index.js';
 import { createI18n } from '$lib/i18n/index.js';
 import { KeyboardShortcuts } from '$lib/shortcuts';
@@ -26,6 +27,7 @@ import {
 } from '$lib/stores/auth';
 import { circles } from '$lib/stores/circles';
 import { isLocaleInitialized, locale } from '$lib/stores/locale';
+import { sessionExpired } from '$lib/stores/session';
 
 interface Props {
   children: Snippet;
@@ -155,5 +157,11 @@ function handleCreateSelect(choice: FabCreateChoice) {
 
 	{#if showFab && createMenuOpen}
 		<FabCreateMenu onSelect={handleCreateSelect} onClose={() => (createMenuOpen = false)} />
+	{/if}
+
+	<!-- Session-expired re-login prompt: shown when an API call returns 401 for a
+	     previously-authenticated user, letting them re-authenticate in place. -->
+	{#if $sessionExpired}
+		<SessionExpiredModal />
 	{/if}
 </div>


### PR DESCRIPTION
## Why

When a logged-in user's session expired, the next API call failed with a `401` and the page broke down — losing whatever the user was doing. This makes expiry recoverable in place.

## What

When an API request returns `401` for a previously-authenticated user, a **blocking re-login modal** appears over the current page instead of bouncing the user out. After they re-authenticate, **the failed request is replayed automatically** and they pick up exactly where they left off. A **"Log out instead"** escape hatch is available for when they'd rather start fresh.

### How it works

- **`lib/stores/session.ts`** (new) — funnels `401`s from the API client. It only triggers the prompt for users who actually had a session, so the expected startup session probe (a `401` while logged out) stays silent. Exposes `resolveSessionExpired()` / `abandonSessionExpired()` so parked requests learn whether to replay or reject.
- **`lib/api/client.ts`** — on a `401`, `apiRequest` now *awaits* the outcome rather than throwing immediately. On re-auth it replays the original request **once** (guarded against loops); on logout it rejects as before.
- **`lib/stores/auth.ts`** — keeps the session flag in sync on login/register/initialize/logout; resolves the prompt (→ replay) on successful auth and abandons it (→ reject) on logout.
- **`login-form.svelte`** — made reusable via an optional `onSuccess` callback and `initialEmail` prop. No behavior change on the regular `/auth/login` page.
- **`session-expired-modal.svelte`** (new) — rendered from the root layout when the session is flagged expired. Shows a "Your session expired" banner, reuses the login form (pre-filled with the user's email), traps Escape, sits above other modals (`z-[60]`), and offers "Log out instead".
- i18n copy added for `en` and `de`.

## Tests

`client.test.ts` covers the new paths: prompt + reject on logout, replay-once after re-auth, and no prompt on `401` while unauthenticated.

> [!NOTE]
> The remote environment's network policy blocks the npm registry, so `aube install` failed and I could not run the type-check / lint / test suite locally. I validated the JSON locales, matched existing import/modal conventions, and confirmed the icons used already exist elsewhere — but CI is the real check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2tEhpKrFKkYwu1cRcqP6G)_