### PR TITLE
fix(collectives): make auto-created member relationships visible on both contacts

### DIFF
--- a/apps/backend/src/services/collectives/memberships.service.ts
+++ b/apps/backend/src/services/collectives/memberships.service.ts
@@ -567,7 +567,14 @@ export class MembershipsService {
   }
 
   /**
-   * Create relationships based on a single rule
+   * Create relationships based on a single rule.
+   *
+   * Relationships are stored as directed edges and a contact only sees edges
+   * where it is the "from" friend. To make the relationship visible on both
+   * contacts we always create the reciprocal edge using the relationship
+   * type's inverse, mirroring the manual relationship flow
+   * (RelationshipService.addRelationship). Without the inverse edge the
+   * relationship only shows up on one of the two contacts.
    */
   private async createRelationshipsForRule(
     client: PoolClient,
@@ -578,56 +585,65 @@ export class MembershipsService {
   ): Promise<void> {
     const direction = parseRelationshipDirection(rule.relationship_direction);
 
-    if (direction === 'new_member' || direction === 'both') {
-      // Skip if the inverse relationship already exists (prevents circular chains)
-      const inverseExists = await checkRelationshipExists.run(
+    // Look up the inverse type so we can create the reciprocal edge. Every
+    // seeded relationship type defines an inverse (symmetric types point to
+    // themselves), so this is expected to be present.
+    const typeInfo = await getRelationshipTypeInfo.run(
+      { relationshipTypeId: rule.relationship_type_id },
+      client,
+    );
+    const inverseTypeId = typeInfo[0]?.inverse_type_id ?? null;
+
+    // Determine which contact owns the primary edge. 'both' is only used for
+    // symmetric types (sibling, spouse) whose inverse equals the type itself,
+    // so a single primary + inverse pair yields the correct bidirectional
+    // result without creating duplicate rows.
+    const primaryFromId = direction === 'existing_member' ? existingContactId : newContactId;
+    const primaryToId = direction === 'existing_member' ? newContactId : existingContactId;
+
+    await this.createRelationshipPair(
+      client,
+      primaryFromId,
+      primaryToId,
+      rule.relationship_type_id,
+      inverseTypeId,
+      membershipId,
+    );
+  }
+
+  /**
+   * Create a directed relationship and its reciprocal edge so the relationship
+   * is visible on both contacts. Both inserts use ON CONFLICT DO UPDATE, so
+   * pre-existing edges are tolerated.
+   */
+  private async createRelationshipPair(
+    client: PoolClient,
+    fromContactId: number,
+    toContactId: number,
+    relationshipTypeId: string,
+    inverseTypeId: string | null,
+    membershipId: number,
+  ): Promise<void> {
+    await createRelationshipWithSource.run(
+      {
+        fromFriendId: fromContactId,
+        toFriendId: toContactId,
+        relationshipTypeId,
+        sourceMembershipId: membershipId,
+      },
+      client,
+    );
+
+    if (inverseTypeId) {
+      await createRelationshipWithSource.run(
         {
-          fromFriendId: existingContactId,
-          toFriendId: newContactId,
-          relationshipTypeId: rule.relationship_type_id,
+          fromFriendId: toContactId,
+          toFriendId: fromContactId,
+          relationshipTypeId: inverseTypeId,
+          sourceMembershipId: membershipId,
         },
         client,
       );
-
-      if ((inverseExists[0]?.count ?? 0) === 0) {
-        // New member is the "from" friend
-        await createRelationshipWithSource.run(
-          {
-            fromFriendId: newContactId,
-            toFriendId: existingContactId,
-            relationshipTypeId: rule.relationship_type_id,
-            sourceMembershipId: membershipId,
-          },
-          client,
-        );
-      }
-    }
-
-    if (direction === 'existing_member' || direction === 'both') {
-      // Existing member is the "from" friend - use the rule's relationship type directly
-      // (the rule already specifies the correct type for this direction)
-
-      // Skip if the inverse relationship already exists (prevents circular chains)
-      const inverseExists = await checkRelationshipExists.run(
-        {
-          fromFriendId: newContactId,
-          toFriendId: existingContactId,
-          relationshipTypeId: rule.relationship_type_id,
-        },
-        client,
-      );
-
-      if ((inverseExists[0]?.count ?? 0) === 0) {
-        await createRelationshipWithSource.run(
-          {
-            fromFriendId: existingContactId,
-            toFriendId: newContactId,
-            relationshipTypeId: rule.relationship_type_id,
-            sourceMembershipId: membershipId,
-          },
-          client,
-        );
-      }
     }
   }
 

--- a/apps/backend/tests/integration/collectives.test.ts
+++ b/apps/backend/tests/integration/collectives.test.ts
@@ -168,6 +168,59 @@ describe('Collectives API - Integration', () => {
       const afterRemove = await json(await req('GET', `/api/collectives/${collectiveId}`));
       expect(afterRemove.memberCount).toBe(0);
     });
+
+    it('makes auto-created relationships visible on both contacts', async () => {
+      // Use the Family type, which defines parent/child auto-relationship rules.
+      const types = (await json(await req('GET', '/api/collectives/types'))).types;
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically shaped test JSON
+      const family = types.find((t: any) => t.name === 'Family');
+      expect(family).toBeDefined();
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically shaped test JSON
+      const parentRole = family.roles.find((r: any) => r.roleKey === 'parent');
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically shaped test JSON
+      const childRole = family.roles.find((r: any) => r.roleKey === 'child');
+
+      const res = await req('POST', '/api/collectives', {
+        name: 'The Smiths',
+        collective_type_id: family.id,
+      });
+      expect(res.status).toBe(201);
+      const collectiveId = (await json(res)).id;
+
+      const parentId = await createTestFriend(poolOf(), user.externalId, 'Parent Smith');
+      const childId = await createTestFriend(poolOf(), user.externalId, 'Child Smith');
+
+      const addParent = await req('POST', `/api/collectives/${collectiveId}/members`, {
+        friend_id: parentId,
+        role_id: parentRole.id,
+      });
+      expect(addParent.status).toBe(201);
+
+      const addChild = await req('POST', `/api/collectives/${collectiveId}/members`, {
+        friend_id: childId,
+        role_id: childRole.id,
+      });
+      expect(addChild.status).toBe(201);
+
+      // The existing edge (parent --[parent]--> child) shows on the parent...
+      const parent = await json(await req('GET', `/api/friends/${parentId}`));
+      const parentToChild = parent.relationships.find(
+        // biome-ignore lint/suspicious/noExplicitAny: dynamically shaped test JSON
+        (r: any) => r.relatedFriendId === childId,
+      );
+      expect(parentToChild).toBeDefined();
+      expect(parentToChild.relationshipTypeId).toBe('parent');
+
+      // ...and, critically, the reciprocal edge (child --[child]--> parent) is
+      // now created so the relationship is also visible on the child.
+      const child = await json(await req('GET', `/api/friends/${childId}`));
+      const childToParent = child.relationships.find(
+        // biome-ignore lint/suspicious/noExplicitAny: dynamically shaped test JSON
+        (r: any) => r.relatedFriendId === parentId,
+      );
+      expect(childToParent).toBeDefined();
+      expect(childToParent.relationshipTypeId).toBe('child');
+    });
   });
 
   describe('sub-resources', () => {

--- a/database/migrations/1779667500000_backfill-collective-inverse-relationships.ts
+++ b/database/migrations/1779667500000_backfill-collective-inverse-relationships.ts
@@ -1,0 +1,48 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/**
+ * Backfill missing reciprocal edges for auto-created collective relationships.
+ *
+ * Bug: when adding a member to a collective, the auto-relationship logic only
+ * created a single directed edge (e.g. parent --[parent]--> child) and never
+ * the inverse edge (child --[child]--> parent). Because a contact only sees
+ * relationships where it is the "from" friend, the relationship showed up on
+ * one contact but not the other (e.g. visible on the parent, missing on the
+ * child).
+ *
+ * The service now creates both edges (mirroring the manual relationship flow),
+ * but relationships created before that fix are still one-sided. This migration
+ * inserts the missing inverse edge for every auto-created relationship
+ * (identified by source_membership_id) whose type has an inverse.
+ *
+ * The reciprocal edge inherits the same source_membership_id so that removing
+ * the membership continues to clean up both edges. ON CONFLICT DO NOTHING
+ * preserves any edge the user may have created manually.
+ */
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    INSERT INTO friends.friend_relationships (
+      friend_id,
+      related_friend_id,
+      relationship_type_id,
+      source_membership_id
+    )
+    SELECT
+      fr.related_friend_id,
+      fr.friend_id,
+      rt.inverse_type_id,
+      fr.source_membership_id
+    FROM friends.friend_relationships fr
+    INNER JOIN friends.relationship_types rt ON rt.id = fr.relationship_type_id
+    WHERE fr.source_membership_id IS NOT NULL
+      AND rt.inverse_type_id IS NOT NULL
+    ON CONFLICT (friend_id, related_friend_id, relationship_type_id) DO NOTHING;
+  `);
+}
+
+export async function down(): Promise<void> {
+  // No-op: this is a best-effort data backfill. Backfilled inverse edges are
+  // indistinguishable from legitimately auto-created edges (both carry a
+  // source_membership_id), so we cannot safely remove them without risking the
+  // deletion of valid relationships.
+}


### PR DESCRIPTION
## Problem

Adding a member to a collective creates relationships that only show up on **one** of the two contacts. For example, adding a child to a family collective that already has a parent shows the relationship on the parent but not on the child.

## Root cause

Relationships are stored as **directed edges**, and a contact only sees relationships where it is the "from" friend (`GetRelationshipsByFriendId` filters on `friend_id`). The collective auto-relationship logic in `createRelationshipsForRule` only created a **single** edge per rule (e.g. `parent --[parent]--> child`) and never the reciprocal edge (`child --[child]--> parent`), so the relationship was invisible on the other contact.

The manual "add relationship" flow doesn't have this bug because it always creates the inverse edge via `inverse_type_id` (`RelationshipService.addRelationship` → `createInverseRelationship`). The collective path never did this. The old `'both'` guard ("skip if inverse exists") made it worse — for symmetric types like *sibling*/*spouse* it suppressed the second edge, so those only appeared on one side too.

## Changes

- **`memberships.service.ts`** — `createRelationshipsForRule` now creates the reciprocal edge using the type's `inverse_type_id` (new `createRelationshipPair` helper), mirroring the manual flow. `'both'` is handled as a single primary+inverse pair (correct for symmetric types, no duplicates). The insert already uses `ON CONFLICT DO UPDATE`, so pre-existing edges are tolerated and the fragile guard was removed.
- **`1779667500000_backfill-collective-inverse-relationships.ts`** — backfills the missing inverse edge for relationships already created by the buggy code (identified by `source_membership_id`), so existing data is repaired without re-adding members. The reciprocal inherits the same `source_membership_id` so removing the membership still cleans up both edges; `ON CONFLICT DO NOTHING` preserves manually-added relationships. The `down` is a no-op because backfilled inverses are indistinguishable from legitimately auto-created ones.
- **`collectives.test.ts`** — regression test that adds a parent then a child to a Family collective and asserts the relationship is visible on **both** contacts.

## Testing

⚠️ The type-check and test suite could **not** be run in this environment (no network access; dependency install fails). The test and changes are verified by review only — please confirm CI is green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbtVbxxXkgHtjkgkVFv7a7)_