### PR TITLE
PostGIS-only address lookup + postal-code autocomplete

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -66,7 +66,6 @@ src/
 | `DatabaseConnectionError` | 500 | No database connection |
 | `ConfigurationError` | 500 | Invalid configuration |
 | `OverpassApiError` | 502 | Overpass API errors |
-| `ZipcodeBaseApiError` | 502 | ZipcodeBase API errors |
 
 ### Usage Pattern
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -157,11 +157,6 @@ export async function startServer() {
   // Initialize address caches with database pool for persistence
   initializeAddressCaches(pool, pinoLogger);
 
-  // Validate optional API keys at startup
-  if (!config.ZIPCODEBASE_API_KEY) {
-    pinoLogger.warn('ZIPCODEBASE_API_KEY not configured - address lookup will be disabled');
-  }
-
   // Setup cleanup scheduler for expired sessions, tokens, and cache
   const cleanupTask = setupCleanupScheduler(pool, pinoLogger);
 

--- a/apps/backend/src/routes/address-lookup.ts
+++ b/apps/backend/src/routes/address-lookup.ts
@@ -6,10 +6,10 @@ import { authMiddleware } from '../middleware/auth.js';
 import { onboardingMiddleware } from '../middleware/onboarding.js';
 import { AddressLookupService } from '../services/address-lookup.service.js';
 import { PostGISAddressClient } from '../services/external/postgis-address.client.js';
-import { SUPPORTED_COUNTRIES } from '../services/external/zipcodebase.client.js';
 import type { AppContext } from '../types/context.js';
 import { getConfig } from '../utils/config.js';
-import { ServiceNotConfiguredError, ValidationError } from '../utils/errors.js';
+import { SUPPORTED_COUNTRIES } from '../utils/countries.js';
+import { ValidationError } from '../utils/errors.js';
 
 const app = new Hono<AppContext>();
 
@@ -32,12 +32,8 @@ function getPostGISClient(pool: pg.Pool, logger: Logger): PostGISAddressClient {
 function getAddressService(pool: pg.Pool, logger: Logger): AddressLookupService {
   if (!addressLookupService) {
     const config = getConfig();
-    if (!config.ZIPCODEBASE_API_KEY) {
-      throw new ServiceNotConfiguredError('Address lookup service not configured');
-    }
     addressLookupService = new AddressLookupService(
       {
-        zipcodeApiKey: config.ZIPCODEBASE_API_KEY,
         overpassPrimaryUrl: config.OVERPASS_API_URL,
         overpassFallbackUrl: config.OVERPASS_FALLBACK_URL,
         postgisClient: config.POSTGIS_ADDRESS_ENABLED ? getPostGISClient(pool, logger) : undefined,
@@ -53,23 +49,16 @@ function getAddressService(pool: pg.Pool, logger: Logger): AddressLookupService 
 
 /**
  * Get the AddressLookupService singleton for geocoding.
- * Returns undefined when the service is not configured (e.g., missing API key).
- * Re-throws any other error so genuine bugs are not silently swallowed.
+ *
+ * Address lookup no longer depends on any API key (it uses PostGIS + Overpass +
+ * Nominatim), so this always returns a service instance. The return type stays
+ * optional for backwards compatibility with callers that tolerate `undefined`.
  */
 export function getAddressLookupService(
   pool: pg.Pool,
   logger: Logger,
 ): AddressLookupService | undefined {
-  try {
-    return getAddressService(pool, logger);
-  } catch (error) {
-    if (error instanceof ServiceNotConfiguredError) {
-      logger.debug({ error }, 'Address lookup service not configured, geocoding disabled');
-      return undefined;
-    }
-    logger.error({ error }, 'Unexpected error initializing address lookup service');
-    throw error;
-  }
+  return getAddressService(pool, logger);
 }
 
 // ============================================================================
@@ -84,6 +73,14 @@ const CountryCode = type(/^[A-Za-z]{2}$/);
 const CitiesQuerySchema = type({
   country: CountryCode,
   postal_code: 'string > 0',
+});
+
+// Postal-code prefix for autocomplete. Constrained to alphanumerics/space/dash
+// (real postal-code characters) so it is safe to interpolate into a SQL LIKE
+// prefix, and at least 2 chars to keep short-prefix scans cheap.
+const PostalCodesQuerySchema = type({
+  country: CountryCode,
+  prefix: type(/^[A-Za-z0-9 -]{2,10}$/),
 });
 
 const StreetsQuerySchema = type({
@@ -110,6 +107,25 @@ const HouseNumbersQuerySchema = type({
  */
 app.get('/countries', (c) => {
   return c.json(SUPPORTED_COUNTRIES);
+});
+
+/**
+ * GET /api/address-lookup/postal-codes
+ * Search postal codes by prefix (autocomplete). Returns postal-code/city pairs.
+ */
+app.get('/postal-codes', async (c) => {
+  const logger = c.get('logger');
+  const pool = c.get('db');
+  const query = c.req.query();
+
+  const validated = PostalCodesQuerySchema(query);
+  if (validated instanceof type.errors) {
+    throw new ValidationError('Invalid query parameters', validated);
+  }
+
+  const service = getAddressService(pool, logger);
+  const postalCodes = await service.searchPostalCodes(validated.country, validated.prefix);
+  return c.json(postalCodes);
 });
 
 /**

--- a/apps/backend/src/services/address-lookup.service.ts
+++ b/apps/backend/src/services/address-lookup.service.ts
@@ -1,14 +1,19 @@
 import type { Logger } from 'pino';
+import { type Country, SUPPORTED_COUNTRIES } from '../utils/countries.js';
 import type { GeocodedLocation } from './external/nominatim.client.js';
 import { NominatimClient } from './external/nominatim.client.js';
 import { type HouseNumber, OverpassClient, type Street } from './external/overpass.client.js';
 import type { PostGISAddressClient } from './external/postgis-address.client.js';
-import { type Country, ZipcodeBaseClient } from './external/zipcodebase.client.js';
 
 export interface CityInfo {
   city: string;
   state?: string;
   stateCode?: string;
+}
+
+export interface PostalCodeInfo {
+  postalCode: string;
+  city: string;
 }
 
 export type { Country, Street, HouseNumber };
@@ -17,7 +22,6 @@ export type { Country, Street, HouseNumber };
 const DACH_COUNTRIES = ['DE', 'AT', 'CH'];
 
 export interface AddressLookupServiceOptions {
-  zipcodeApiKey: string;
   overpassPrimaryUrl: string;
   overpassFallbackUrl: string;
   postgisClient?: PostGISAddressClient;
@@ -27,7 +31,6 @@ export interface AddressLookupServiceOptions {
 }
 
 export class AddressLookupService {
-  private zipcodeClient: ZipcodeBaseClient;
   private overpassClient: OverpassClient;
   private nominatimClient: NominatimClient;
   private postgisClient?: PostGISAddressClient;
@@ -38,7 +41,6 @@ export class AddressLookupService {
     options: AddressLookupServiceOptions,
     private logger: Logger,
   ) {
-    this.zipcodeClient = new ZipcodeBaseClient(options.zipcodeApiKey, logger);
     this.overpassClient = new OverpassClient(
       options.overpassPrimaryUrl,
       options.overpassFallbackUrl,
@@ -69,30 +71,57 @@ export class AddressLookupService {
    * Get list of supported countries
    */
   getCountries(): Country[] {
-    return this.zipcodeClient.getCountries();
+    return SUPPORTED_COUNTRIES;
   }
 
   /**
-   * Get cities for a postal code in a country
+   * Get cities for a postal code in a country.
+   *
+   * Backed entirely by PostGIS (DACH OSM data). For non-DACH countries, or when
+   * PostGIS is disabled or has no data for the postal code, an empty list is
+   * returned and the frontend falls back to free-text entry. PostGIS-sourced
+   * cities carry no state/province — the geodata schema has no such column.
    */
   async getCitiesByPostalCode(countryCode: string, postalCode: string): Promise<CityInfo[]> {
-    const results = await this.zipcodeClient.searchByPostalCode(postalCode, countryCode);
-
-    // Deduplicate cities (same postal code might return multiple entries)
-    const cityMap = new Map<string, CityInfo>();
-
-    for (const result of results) {
-      const key = `${result.city}:${result.state || ''}`;
-      if (!cityMap.has(key)) {
-        cityMap.set(key, {
-          city: result.city,
-          state: result.state || result.province,
-          stateCode: result.state_code,
-        });
-      }
+    if (!this.shouldUsePostGIS(countryCode) || !this.postgisClient) {
+      return [];
     }
 
-    return Array.from(cityMap.values());
+    try {
+      const cities = await this.postgisClient.getCitiesByPostalCode(countryCode, postalCode);
+      this.logger.debug(
+        { countryCode, postalCode, count: cities.length },
+        'PostGIS cities lookup completed',
+      );
+      return cities.map((c) => ({ city: c.city }));
+    } catch (error) {
+      this.logger.warn({ error, countryCode, postalCode }, 'PostGIS cities lookup failed');
+      return [];
+    }
+  }
+
+  /**
+   * Search postal codes by prefix for autocomplete (e.g. "55" -> "55116" Mainz).
+   *
+   * Backed entirely by PostGIS (DACH OSM data). Returns an empty list for
+   * non-DACH countries or when PostGIS is disabled / has no matching data.
+   */
+  async searchPostalCodes(countryCode: string, prefix: string): Promise<PostalCodeInfo[]> {
+    if (!this.shouldUsePostGIS(countryCode) || !this.postgisClient) {
+      return [];
+    }
+
+    try {
+      const matches = await this.postgisClient.searchPostalCodes(countryCode, prefix);
+      this.logger.debug(
+        { countryCode, prefix, count: matches.length },
+        'PostGIS postal code search completed',
+      );
+      return matches;
+    } catch (error) {
+      this.logger.warn({ error, countryCode, prefix }, 'PostGIS postal code search failed');
+      return [];
+    }
   }
 
   /**

--- a/apps/backend/src/services/external/postgis-address.client.ts
+++ b/apps/backend/src/services/external/postgis-address.client.ts
@@ -20,6 +20,71 @@ export class PostGISAddressClient {
   ) {}
 
   /**
+   * Get distinct cities for a postal code.
+   *
+   * Uses the `cities_by_postal` materialized view, which already excludes the
+   * `'Unknown'` placeholder used for OSM rows without an `addr:city` tag (see
+   * scripts/osm-import/import-region.sh). The PostGIS data has no
+   * state/province column, so callers get city names only.
+   */
+  async getCitiesByPostalCode(countryCode: string, postalCode: string): Promise<{ city: string }[]> {
+    try {
+      const result = await this.pool.query<{ city: string }>(
+        `SELECT city
+         FROM geodata.cities_by_postal
+         WHERE country_code = $1 AND postal_code = $2
+         ORDER BY city`,
+        [countryCode.toUpperCase(), postalCode],
+      );
+
+      this.logger.debug(
+        { countryCode, postalCode, count: result.rowCount },
+        'PostGIS cities query completed',
+      );
+
+      return result.rows.map((row) => ({ city: row.city }));
+    } catch (error) {
+      this.logger.error({ error, countryCode, postalCode }, 'PostGIS cities query failed');
+      throw error;
+    }
+  }
+
+  /**
+   * Search postal codes by prefix, returning postal-code/city pairs.
+   *
+   * Backs the postal-code autocomplete (e.g. typing "55" suggests "55116 —
+   * Mainz"). Uses the `cities_by_postal` materialized view, which is indexed
+   * with `text_pattern_ops` so the prefix `LIKE` is index-backed. Results are
+   * capped by `limit` to keep short prefixes cheap.
+   */
+  async searchPostalCodes(
+    countryCode: string,
+    prefix: string,
+    limit = 20,
+  ): Promise<{ postalCode: string; city: string }[]> {
+    try {
+      const result = await this.pool.query<{ postal_code: string; city: string }>(
+        `SELECT postal_code, city
+         FROM geodata.cities_by_postal
+         WHERE country_code = $1 AND postal_code LIKE $2 || '%'
+         ORDER BY postal_code, city
+         LIMIT $3`,
+        [countryCode.toUpperCase(), prefix, limit],
+      );
+
+      this.logger.debug(
+        { countryCode, prefix, count: result.rowCount },
+        'PostGIS postal code search completed',
+      );
+
+      return result.rows.map((row) => ({ postalCode: row.postal_code, city: row.city }));
+    } catch (error) {
+      this.logger.error({ error, countryCode, prefix }, 'PostGIS postal code search failed');
+      throw error;
+    }
+  }
+
+  /**
    * Get streets for a postal code.
    * Uses the materialized view for fast distinct lookups.
    */

--- a/apps/backend/src/utils/cache.ts
+++ b/apps/backend/src/utils/cache.ts
@@ -18,22 +18,6 @@ let cacheLogger: Logger | null = null;
 // ============================================================================
 
 /**
- * Schema for ZipcodeResult from ZipcodeBase API
- */
-const ZipcodeResultSchema = type({
-  postal_code: 'string',
-  city: 'string',
-  'state?': 'string',
-  'state_code?': 'string',
-  'province?': 'string',
-  country_code: 'string',
-  'latitude?': 'string',
-  'longitude?': 'string',
-});
-
-const ZipcodeResultArraySchema = type(ZipcodeResultSchema, '[]');
-
-/**
  * Schema for Street from Overpass API
  */
 const StreetSchema = type({
@@ -54,7 +38,6 @@ const HouseNumberSchema = type({
 const HouseNumberArraySchema = type(HouseNumberSchema, '[]');
 
 // Type aliases for the validated types
-export type ZipcodeResultCached = typeof ZipcodeResultSchema.infer;
 export type StreetCached = typeof StreetSchema.infer;
 export type HouseNumberCached = typeof HouseNumberSchema.infer;
 
@@ -83,7 +66,6 @@ function createValidator<T>(
 
 // Pre-built validators for each cache type
 const validators = {
-  cities: createValidator(ZipcodeResultArraySchema, 'ZipcodeResult[]'),
   streets: createValidator(StreetArraySchema, 'Street[]'),
   houseNumbers: createValidator(HouseNumberArraySchema, 'HouseNumber[]'),
 };
@@ -275,14 +257,12 @@ export class AddressCache<T extends object> {
 // Cache configuration constants
 const CACHE_CONFIG = {
   countries: { ttlHours: 24 * 7, maxSize: 10 }, // Countries rarely change, cache 7 days
-  cities: { ttlHours: 24, maxSize: 500 },
   streets: { ttlHours: 24, maxSize: 1000 },
   houseNumbers: { ttlHours: 24, maxSize: 2000 },
 };
 
 // Singleton instances for different cache types
 let countriesCache: AddressCache<object> | null = null;
-let citiesCache: AddressCache<ZipcodeResultCached[]> | null = null;
 let streetsCache: AddressCache<StreetCached[]> | null = null;
 let houseNumbersCache: AddressCache<HouseNumberCached[]> | null = null;
 
@@ -298,20 +278,6 @@ export function getCountriesCache(): AddressCache<object> {
     );
   }
   return countriesCache;
-}
-
-/**
- * Get the cities cache with arktype validation
- */
-export function getCitiesCache(): AddressCache<ZipcodeResultCached[]> {
-  if (!citiesCache) {
-    citiesCache = new AddressCache<ZipcodeResultCached[]>(
-      CACHE_CONFIG.cities.ttlHours,
-      CACHE_CONFIG.cities.maxSize,
-      validators.cities,
-    );
-  }
-  return citiesCache;
 }
 
 /**
@@ -357,13 +323,6 @@ export function initializeAddressCaches(pool: pg.Pool, logger: Logger): void {
       CACHE_CONFIG.countries.maxSize,
     );
   }
-  if (!citiesCache) {
-    citiesCache = new AddressCache<ZipcodeResultCached[]>(
-      CACHE_CONFIG.cities.ttlHours,
-      CACHE_CONFIG.cities.maxSize,
-      validators.cities,
-    );
-  }
   if (!streetsCache) {
     streetsCache = new AddressCache<StreetCached[]>(
       CACHE_CONFIG.streets.ttlHours,
@@ -381,7 +340,6 @@ export function initializeAddressCaches(pool: pg.Pool, logger: Logger): void {
 
   // Set database pool on all caches
   countriesCache.setPool(pool);
-  citiesCache.setPool(pool);
   streetsCache.setPool(pool);
   houseNumbersCache.setPool(pool);
 
@@ -392,7 +350,7 @@ export function initializeAddressCaches(pool: pg.Pool, logger: Logger): void {
  * Cleanup expired entries from all address caches
  */
 export async function cleanupAllAddressCaches(): Promise<void> {
-  const caches = [countriesCache, citiesCache, streetsCache, houseNumbersCache];
+  const caches = [countriesCache, streetsCache, houseNumbersCache];
   for (const cache of caches) {
     if (cache) {
       await cache.cleanupDatabase();

--- a/apps/backend/src/utils/config.ts
+++ b/apps/backend/src/utils/config.ts
@@ -53,7 +53,6 @@ const ConfigSchema = type({
   'SENTRY_DSN?': 'string',
 
   // Address Lookup APIs
-  'ZIPCODEBASE_API_KEY?': 'string',
   OVERPASS_API_URL: 'string = "https://overpass-api.de/api/interpreter"',
   OVERPASS_FALLBACK_URL: 'string = "https://overpass.kumi.systems/api/interpreter"',
   ADDRESS_CACHE_TTL_HOURS: 'string.integer.parse = "24"',

--- a/apps/backend/src/utils/countries.ts
+++ b/apps/backend/src/utils/countries.ts
@@ -1,40 +1,16 @@
-import type { Logger } from 'pino';
-import { type AddressCache, getCitiesCache, type ZipcodeResultCached } from '../../utils/cache.js';
-import { ZipcodeBaseApiError } from '../../utils/errors.js';
+/**
+ * Static list of supported countries for the address-lookup country selector.
+ *
+ * This is a plain ISO 3166-1 alpha-2 reference list — it does not depend on any
+ * external API. (It previously lived alongside the ZipcodeBase client, which has
+ * since been removed in favour of PostGIS-only address lookups.)
+ */
 
 export interface Country {
   code: string; // ISO 3166-1 alpha-2
   name: string;
 }
 
-export type ZipcodeResult = ZipcodeResultCached;
-
-interface ZipcodeBaseSearchResponse {
-  query: {
-    codes: string[];
-    country: string;
-  };
-  results: Record<
-    string,
-    Array<{
-      postal_code: string;
-      country_code: string;
-      city: string;
-      state: string;
-      state_code: string;
-      province: string;
-      province_code: string;
-      community: string;
-      community_code: string;
-      latitude: string;
-      longitude: string;
-    }>
-  >;
-}
-
-// Static list of countries supported by ZipcodeBase
-// This is a subset - ZipcodeBase supports 200+ countries
-// Exported so it can be used directly without API key
 export const SUPPORTED_COUNTRIES: Country[] = [
   { code: 'AF', name: 'Afghanistan' },
   { code: 'AL', name: 'Albania' },
@@ -200,79 +176,3 @@ export const SUPPORTED_COUNTRIES: Country[] = [
   { code: 'ZM', name: 'Zambia' },
   { code: 'ZW', name: 'Zimbabwe' },
 ];
-
-export class ZipcodeBaseClient {
-  private apiKey: string;
-  private baseUrl = 'https://app.zipcodebase.com/api/v1';
-  private zipcodeCache: AddressCache<ZipcodeResultCached[]>;
-
-  constructor(
-    apiKey: string,
-    private logger: Logger,
-  ) {
-    this.apiKey = apiKey;
-    this.zipcodeCache = getCitiesCache();
-  }
-
-  /**
-   * Get list of supported countries
-   * Returns a static list since ZipcodeBase doesn't have a countries endpoint
-   */
-  getCountries(): Country[] {
-    return SUPPORTED_COUNTRIES;
-  }
-
-  /**
-   * Search for location info by postal code
-   */
-  async searchByPostalCode(postalCode: string, countryCode: string): Promise<ZipcodeResult[]> {
-    const cacheKey = `zipcode:${countryCode}:${postalCode}`;
-    const cached = await this.zipcodeCache.get(cacheKey);
-    if (cached) {
-      this.logger.debug({ postalCode, countryCode }, 'ZipcodeBase cache hit');
-      return cached;
-    }
-
-    // Log without exposing API key
-    this.logger.debug({ postalCode, countryCode, endpoint: '/search' }, 'ZipcodeBase API request');
-
-    const url = new URL(`${this.baseUrl}/search`);
-    url.searchParams.set('apikey', this.apiKey);
-    url.searchParams.set('codes', postalCode);
-    url.searchParams.set('country', countryCode);
-
-    const response = await fetch(url.toString());
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      // Log error without URL (which contains API key)
-      this.logger.error(
-        { status: response.status, error: errorText, endpoint: '/search', postalCode, countryCode },
-        'ZipcodeBase API error',
-      );
-      throw new ZipcodeBaseApiError(`ZipcodeBase API error: ${response.status}`, response.status);
-    }
-
-    const data = (await response.json()) as ZipcodeBaseSearchResponse;
-
-    // Extract results from the response
-    const results: ZipcodeResult[] = [];
-    for (const [_code, locations] of Object.entries(data.results)) {
-      for (const loc of locations) {
-        results.push({
-          postal_code: loc.postal_code,
-          city: loc.city,
-          state: loc.state || loc.province || undefined,
-          state_code: loc.state_code || loc.province_code || undefined,
-          province: loc.province || undefined,
-          country_code: loc.country_code,
-          latitude: loc.latitude,
-          longitude: loc.longitude,
-        });
-      }
-    }
-
-    await this.zipcodeCache.set(cacheKey, results);
-    return results;
-  }
-}

--- a/apps/backend/src/utils/country.ts
+++ b/apps/backend/src/utils/country.ts
@@ -1,4 +1,4 @@
-import { SUPPORTED_COUNTRIES } from '../services/external/zipcodebase.client.js';
+import { SUPPORTED_COUNTRIES } from './countries.js';
 
 const SUPPORTED_CODES = new Set(SUPPORTED_COUNTRIES.map((c) => c.code));
 

--- a/apps/backend/src/utils/errors.ts
+++ b/apps/backend/src/utils/errors.ts
@@ -465,15 +465,6 @@ export class OverpassApiError extends ExternalServiceError {
 }
 
 /**
- * Thrown when the ZipcodeBase API returns an error.
- */
-export class ZipcodeBaseApiError extends ExternalServiceError {
-  constructor(message: string, originalStatus?: number) {
-    super('ZipcodeBase', message, originalStatus);
-  }
-}
-
-/**
  * Thrown when a notification delivery to an external messaging platform fails.
  */
 export class NotificationDeliveryError extends ExternalServiceError {

--- a/apps/backend/tests/integration/address-lookup-postgis.test.ts
+++ b/apps/backend/tests/integration/address-lookup-postgis.test.ts
@@ -1,0 +1,127 @@
+import bcrypt from 'bcrypt';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resetAddressService } from '../../src/routes/address-lookup.js';
+import { resetConfig } from '../../src/utils/config.js';
+import {
+  completeTestUserOnboarding,
+  createBetterAuthSession,
+  createTestUser,
+  setupAuthTestSuite,
+} from './auth.helpers.js';
+import { insertTestAddresses } from './postgis.helpers.js';
+
+/**
+ * Full-stack integration tests for the address-lookup endpoints with PostGIS
+ * ENABLED and real OSM-style data seeded into the test database. This exercises
+ * the whole path: HTTP route -> AddressLookupService -> PostGISAddressClient ->
+ * PostGIS DB (including the cities_by_postal materialized view).
+ *
+ * The default address-lookup.test.ts covers the PostGIS-disabled path
+ * (validation + empty-list fallback); this file covers the data path.
+ */
+describe('Address Lookup API - PostGIS full-stack', { timeout: 60000 }, () => {
+  const { getContext } = setupAuthTestSuite();
+
+  let sessionCookies: string;
+
+  beforeAll(async () => {
+    // Enable PostGIS for this file only. The address service is created lazily
+    // on first request, so toggling the env + clearing the singleton here takes
+    // effect before any request is made.
+    vi.stubEnv('POSTGIS_ADDRESS_ENABLED', 'true');
+    vi.stubEnv('POSTGIS_ADDRESS_DACH_ONLY', 'true');
+    resetConfig();
+    resetAddressService();
+
+    const { pool } = getContext();
+
+    // Seed OSM-style address data (includes the 'Unknown' placeholder that the
+    // import uses for rows without an addr:city tag — must be filtered out).
+    await insertTestAddresses(pool, [
+      { countryCode: 'DE', postalCode: '55116', city: 'Mainz', street: 'Schillerstraße' },
+      { countryCode: 'DE', postalCode: '55118', city: 'Mainz', street: 'Goethestraße' },
+      { countryCode: 'DE', postalCode: '55571', city: 'Odernheim am Glan', street: 'Hauptstraße' },
+      { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Torstraße' },
+      { countryCode: 'DE', postalCode: '10115', city: 'Unknown', street: 'Im Tal' },
+      { countryCode: 'US', postalCode: '90210', city: 'Beverly Hills', street: 'Rodeo Drive' },
+    ]);
+
+    const passwordHash = await bcrypt.hash('TestPassword123', 10);
+    const user = await createTestUser(pool, 'addr-postgis@test.com', passwordHash);
+    await completeTestUserOnboarding(pool, user.externalId);
+    sessionCookies = await createBetterAuthSession(pool, user.externalId);
+  });
+
+  afterAll(async () => {
+    const { pool } = getContext();
+    await pool.query('DELETE FROM geodata.addresses');
+    await pool.query('DELETE FROM geodata.import_batches');
+    resetAddressService();
+  });
+
+  function get(path: string) {
+    const { app } = getContext();
+    return app.fetch(
+      new Request(`http://localhost${path}`, {
+        method: 'GET',
+        headers: { Cookie: sessionCookies },
+      }),
+    );
+  }
+
+  describe('GET /cities (PostGIS-backed)', () => {
+    it('resolves a postal code to its city', async () => {
+      const response = await get('/api/address-lookup/cities?country=DE&postal_code=55116');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ city: string }>;
+      expect(body).toEqual([{ city: 'Mainz' }]);
+    });
+
+    it('returns multiple cities for one postal code and excludes the Unknown placeholder', async () => {
+      const response = await get('/api/address-lookup/cities?country=DE&postal_code=10115');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ city: string }>;
+      expect(body.map((c) => c.city)).toEqual(['Berlin']);
+    });
+
+    it('returns an empty list for a non-DACH country (DACH-only gate)', async () => {
+      const response = await get('/api/address-lookup/cities?country=US&postal_code=90210');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ city: string }>;
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe('GET /postal-codes (PostGIS-backed)', () => {
+    it('returns postal-code/city pairs for a prefix', async () => {
+      const response = await get('/api/address-lookup/postal-codes?country=DE&prefix=55');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ postalCode: string; city: string }>;
+      expect(body).toEqual([
+        { postalCode: '55116', city: 'Mainz' },
+        { postalCode: '55118', city: 'Mainz' },
+        { postalCode: '55571', city: 'Odernheim am Glan' },
+      ]);
+    });
+
+    it('excludes the Unknown placeholder from prefix results', async () => {
+      const response = await get('/api/address-lookup/postal-codes?country=DE&prefix=10');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ postalCode: string; city: string }>;
+      expect(body).toEqual([{ postalCode: '10115', city: 'Berlin' }]);
+    });
+
+    it('returns an empty list for a non-DACH country', async () => {
+      const response = await get('/api/address-lookup/postal-codes?country=US&prefix=90');
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ postalCode: string; city: string }>;
+      expect(body).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/tests/integration/address-lookup.test.ts
+++ b/apps/backend/tests/integration/address-lookup.test.ts
@@ -1,6 +1,6 @@
 import bcrypt from 'bcrypt';
 import { describe, expect, it } from 'vitest';
-import { SUPPORTED_COUNTRIES } from '../../src/services/external/zipcodebase.client.js';
+import { SUPPORTED_COUNTRIES } from '../../src/utils/countries.js';
 import {
   completeTestUserOnboarding,
   createBetterAuthSession,
@@ -336,13 +336,14 @@ describe('Address Lookup API - Integration Tests', { timeout: 30000 }, () => {
     });
   });
 
-  describe('Service Configuration', () => {
-    it('should return 503 when ZIPCODEBASE_API_KEY is not configured for cities endpoint', async () => {
+  describe('Cities lookup without PostGIS data', () => {
+    it('should return an empty list (200) when PostGIS is disabled in the test env', async () => {
       const { app } = getContext();
-      const { sessionCookies } = await createUserAndLogin('addr-nokey@test.com', 'TestPassword123');
+      const { sessionCookies } = await createUserAndLogin('addr-nopg@test.com', 'TestPassword123');
 
-      // Note: In test environment, the API key is not configured
-      // This test verifies the error handling when the service is not available
+      // Address lookup is PostGIS-only; with PostGIS disabled (default in the
+      // test env) there is no upstream fallback, so cities resolve to an empty
+      // list and the frontend falls back to free-text entry.
       const response = await app.fetch(
         new Request('http://localhost/api/address-lookup/cities?country=DE&postal_code=12345', {
           method: 'GET',
@@ -352,10 +353,47 @@ describe('Address Lookup API - Integration Tests', { timeout: 30000 }, () => {
         }),
       );
 
-      // Should return 503 when API key is not configured
-      expect(response.status).toBe(503);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ city: string }>;
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe('GET /api/address-lookup/postal-codes - Validation', () => {
+    it('should return 400 when prefix is too short', async () => {
+      const { app } = getContext();
+      const { sessionCookies } = await createUserAndLogin('addr-pc1@test.com', 'TestPassword123');
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/address-lookup/postal-codes?country=DE&prefix=5', {
+          method: 'GET',
+          headers: {
+            Cookie: sessionCookies,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(400);
       const body = (await response.json()) as { error: string };
-      expect(body.error).toBe('Address lookup service not configured');
+      expect(body.error).toBe('Invalid query parameters');
+    });
+
+    it('should return an empty list (200) when PostGIS is disabled in the test env', async () => {
+      const { app } = getContext();
+      const { sessionCookies } = await createUserAndLogin('addr-pc2@test.com', 'TestPassword123');
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/address-lookup/postal-codes?country=DE&prefix=55', {
+          method: 'GET',
+          headers: {
+            Cookie: sessionCookies,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Array<{ postalCode: string; city: string }>;
+      expect(body).toEqual([]);
     });
   });
 });

--- a/apps/backend/tests/integration/postgis-address.test.ts
+++ b/apps/backend/tests/integration/postgis-address.test.ts
@@ -135,6 +135,130 @@ describe('PostGIS Address Client - Integration Tests', { timeout: 60000 }, () =>
     });
   });
 
+  describe('getCitiesByPostalCode', () => {
+    it('should return distinct cities for a postal code', async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Torstraße' },
+        { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Invalidenstraße' },
+        { countryCode: 'DE', postalCode: '10115', city: 'Mitte', street: 'Chausseestraße' },
+      ]);
+
+      const cities = await client.getCitiesByPostalCode('DE', '10115');
+
+      expect(cities.map((c) => c.city)).toEqual(['Berlin', 'Mitte']);
+    });
+
+    it("should filter out the 'Unknown' placeholder city", async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '55571', city: 'Odernheim am Glan', street: 'Hauptstraße' },
+        { countryCode: 'DE', postalCode: '55571', city: 'Unknown', street: 'Im Tal' },
+      ]);
+
+      const cities = await client.getCitiesByPostalCode('DE', '55571');
+
+      expect(cities.map((c) => c.city)).toEqual(['Odernheim am Glan']);
+    });
+
+    it('should return empty array for non-existent postal code', async () => {
+      const { client } = getContext();
+
+      const cities = await client.getCitiesByPostalCode('DE', '99999');
+
+      expect(cities).toHaveLength(0);
+    });
+
+    it('should handle case-insensitive country codes', async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Torstraße' },
+      ]);
+
+      const cities = await client.getCitiesByPostalCode('de', '10115');
+
+      expect(cities.map((c) => c.city)).toEqual(['Berlin']);
+    });
+  });
+
+  describe('searchPostalCodes', () => {
+    it('should return postal-code/city pairs matching a prefix', async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '55116', city: 'Mainz', street: 'Schillerstraße' },
+        { countryCode: 'DE', postalCode: '55118', city: 'Mainz', street: 'Goethestraße' },
+        { countryCode: 'DE', postalCode: '55571', city: 'Odernheim am Glan', street: 'Hauptstraße' },
+        { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Torstraße' },
+      ]);
+
+      const results = await client.searchPostalCodes('DE', '55');
+
+      expect(results).toEqual([
+        { postalCode: '55116', city: 'Mainz' },
+        { postalCode: '55118', city: 'Mainz' },
+        { postalCode: '55571', city: 'Odernheim am Glan' },
+      ]);
+    });
+
+    it("should exclude the 'Unknown' placeholder city", async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '55116', city: 'Mainz', street: 'Schillerstraße' },
+        { countryCode: 'DE', postalCode: '55116', city: 'Unknown', street: 'Im Tal' },
+      ]);
+
+      const results = await client.searchPostalCodes('DE', '55');
+
+      expect(results).toEqual([{ postalCode: '55116', city: 'Mainz' }]);
+    });
+
+    it('should respect the limit', async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '55116', city: 'Mainz', street: 'A' },
+        { countryCode: 'DE', postalCode: '55118', city: 'Mainz', street: 'B' },
+        { countryCode: 'DE', postalCode: '55120', city: 'Mainz', street: 'C' },
+      ]);
+
+      const results = await client.searchPostalCodes('DE', '55', 2);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].postalCode).toBe('55116');
+      expect(results[1].postalCode).toBe('55118');
+    });
+
+    it('should return empty array when nothing matches the prefix', async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Torstraße' },
+      ]);
+
+      const results = await client.searchPostalCodes('DE', '99');
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('should filter by country code', async () => {
+      const { pool, client } = getContext();
+
+      await insertTestAddresses(pool, [
+        { countryCode: 'DE', postalCode: '10115', city: 'Berlin', street: 'Torstraße' },
+        { countryCode: 'AT', postalCode: '10115', city: 'Wien', street: 'Kärntner Straße' },
+      ]);
+
+      const results = await client.searchPostalCodes('at', '10');
+
+      expect(results).toEqual([{ postalCode: '10115', city: 'Wien' }]);
+    });
+  });
+
   describe('getHouseNumbers', () => {
     it('should return house numbers for a street', async () => {
       const { pool, client } = getContext();

--- a/apps/backend/tests/integration/postgis.helpers.ts
+++ b/apps/backend/tests/integration/postgis.helpers.ts
@@ -153,6 +153,7 @@ export async function insertTestAddresses(
   }
 
   // Refresh materialized views
+  await pool.query('REFRESH MATERIALIZED VIEW geodata.cities_by_postal');
   await pool.query('REFRESH MATERIALIZED VIEW geodata.streets_by_postal');
   await pool.query('REFRESH MATERIALIZED VIEW geodata.housenumbers_by_street');
 
@@ -165,6 +166,7 @@ export async function insertTestAddresses(
 export async function clearTestData(pool: pg.Pool): Promise<void> {
   await pool.query('DELETE FROM geodata.addresses');
   await pool.query('DELETE FROM geodata.import_batches');
+  await pool.query('REFRESH MATERIALIZED VIEW geodata.cities_by_postal');
   await pool.query('REFRESH MATERIALIZED VIEW geodata.streets_by_postal');
   await pool.query('REFRESH MATERIALIZED VIEW geodata.housenumbers_by_street');
 }

--- a/apps/frontend/src/lib/api/address-lookup.ts
+++ b/apps/frontend/src/lib/api/address-lookup.ts
@@ -1,4 +1,4 @@
-import type { CityInfo, CountryInfo, HouseNumberInfo, StreetInfo } from '$shared';
+import type { CityInfo, CountryInfo, HouseNumberInfo, PostalCodeInfo, StreetInfo } from '$shared';
 import { apiRequest } from './client.js';
 
 /**
@@ -6,6 +6,20 @@ import { apiRequest } from './client.js';
  */
 export async function getCountries(): Promise<CountryInfo[]> {
   return apiRequest('/api/address-lookup/countries');
+}
+
+/**
+ * Search postal codes by prefix (autocomplete), returning postal-code/city pairs
+ */
+export async function getPostalCodes(
+  countryCode: string,
+  prefix: string,
+): Promise<PostalCodeInfo[]> {
+  const params = new URLSearchParams({
+    country: countryCode,
+    prefix,
+  });
+  return apiRequest(`/api/address-lookup/postal-codes?${params}`);
 }
 
 /**

--- a/apps/frontend/src/lib/components/friends/hierarchical-address-input.svelte
+++ b/apps/frontend/src/lib/components/friends/hierarchical-address-input.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import * as addressApi from '$lib/api/address-lookup';
-import type { AddressType, CityInfo, CountryInfo, HouseNumberInfo, StreetInfo } from '$shared';
+import type {
+  AddressType,
+  CityInfo,
+  CountryInfo,
+  HouseNumberInfo,
+  PostalCodeInfo,
+  StreetInfo,
+} from '$shared';
 import CitySelect from './city-select.svelte';
 import CountrySelect from './country-select.svelte';
 import HouseNumberInput from './house-number-input.svelte';
@@ -69,6 +76,7 @@ let streetLine2 = $state((() => initialStreetLine2)());
 
 // Data from APIs
 let countries = $state<CountryInfo[]>([]);
+let postalCodeSuggestions = $state<PostalCodeInfo[]>([]);
 let cities = $state<CityInfo[]>([]);
 let streets = $state<StreetInfo[]>([]);
 let houseNumbers = $state<HouseNumberInfo[]>([]);
@@ -85,6 +93,7 @@ let houseNumberFreeText = $state(false);
 
 // Debounce timers
 let postalCodeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let postalSuggestDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let streetDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let houseNumberDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -263,6 +272,7 @@ function handleCountryChange(code: string, name: string, viaKeyboard: boolean = 
   selectedState = '';
   selectedStreet = '';
   houseNumber = '';
+  postalCodeSuggestions = [];
   cities = [];
   streets = [];
   houseNumbers = [];
@@ -275,6 +285,20 @@ function handleCountryChange(code: string, name: string, viaKeyboard: boolean = 
     requestAnimationFrame(() => {
       postalCodeInputRef?.focus();
     });
+  }
+}
+
+async function loadPostalCodeSuggestions() {
+  if (!selectedCountryCode || postalCode.length < 2) {
+    postalCodeSuggestions = [];
+    return;
+  }
+
+  try {
+    postalCodeSuggestions = await addressApi.getPostalCodes(selectedCountryCode, postalCode);
+  } catch (error) {
+    console.error('Failed to load postal code suggestions:', error);
+    postalCodeSuggestions = [];
   }
 }
 
@@ -295,6 +319,29 @@ function handlePostalCodeChange(value: string) {
     }, 300);
   }
 
+  // Debounce the postal-code prefix suggestions (separate, shorter trigger)
+  if (postalSuggestDebounceTimer) {
+    clearTimeout(postalSuggestDebounceTimer);
+  }
+  if (value.length >= 2 && selectedCountryCode) {
+    postalSuggestDebounceTimer = setTimeout(() => {
+      loadPostalCodeSuggestions();
+    }, 300);
+  } else {
+    postalCodeSuggestions = [];
+  }
+
+  emitChange();
+}
+
+function handlePostalCodeSuggestionSelect(code: string, city: string) {
+  postalCode = code;
+  postalCodeSuggestions = [];
+  selectedCity = city;
+  selectedState = '';
+  // Populate the city list for this postal code and load downstream data
+  loadCities();
+  scheduleStreetLoad();
   emitChange();
 }
 
@@ -372,8 +419,10 @@ function emitChange() {
     bind:this={postalCodeInputRef}
     bind:value={postalCode}
     isLoading={isLoadingCities}
+    suggestions={postalCodeSuggestions}
     {disabled}
     onChange={handlePostalCodeChange}
+    onSuggestionSelect={handlePostalCodeSuggestionSelect}
   />
 
   <!-- City -->

--- a/apps/frontend/src/lib/components/friends/postal-code-input.svelte
+++ b/apps/frontend/src/lib/components/friends/postal-code-input.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import MagnifyingGlass from 'svelte-heros-v2/MagnifyingGlass.svelte';
+import type { PostalCodeInfo } from '$shared';
+
 interface Props {
   /** Current postal code value */
   value: string;
@@ -6,18 +9,88 @@ interface Props {
   isLoading?: boolean;
   /** Whether the input is disabled */
   disabled?: boolean;
+  /** Postal-code suggestions for the current prefix */
+  suggestions?: PostalCodeInfo[];
   /** Called when the postal code changes */
   onChange?: (value: string) => void;
+  /** Called when a suggestion is picked */
+  onSuggestionSelect?: (postalCode: string, city: string) => void;
 }
 
-let { value = $bindable(), isLoading = false, disabled = false, onChange }: Props = $props();
+let {
+  value = $bindable(),
+  isLoading = false,
+  disabled = false,
+  suggestions = [],
+  onChange,
+  onSuggestionSelect,
+}: Props = $props();
 
 let inputElement: HTMLInputElement;
+let showDropdown = $state(false);
+let highlightedIndex = $state(-1);
 
 function handleInput(e: Event) {
   const target = e.target as HTMLInputElement;
   value = target.value;
+  showDropdown = true;
+  highlightedIndex = -1;
   onChange?.(target.value);
+}
+
+function selectSuggestion(suggestion: PostalCodeInfo) {
+  value = suggestion.postalCode;
+  showDropdown = false;
+  highlightedIndex = -1;
+  onSuggestionSelect?.(suggestion.postalCode, suggestion.city);
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (!showDropdown || suggestions.length === 0) {
+    if (e.key === 'ArrowDown' && suggestions.length > 0) {
+      e.preventDefault();
+      showDropdown = true;
+    }
+    return;
+  }
+
+  switch (e.key) {
+    case 'ArrowDown':
+      e.preventDefault();
+      highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1);
+      break;
+    case 'ArrowUp':
+      e.preventDefault();
+      highlightedIndex = Math.max(highlightedIndex - 1, -1);
+      break;
+    case 'Enter':
+      if (highlightedIndex >= 0 && highlightedIndex < suggestions.length) {
+        e.preventDefault();
+        selectSuggestion(suggestions[highlightedIndex]);
+      }
+      break;
+    case 'Escape':
+      showDropdown = false;
+      highlightedIndex = -1;
+      break;
+    case 'Tab':
+      showDropdown = false;
+      highlightedIndex = -1;
+      break;
+  }
+}
+
+function handleFocus() {
+  if (suggestions.length > 0) {
+    showDropdown = true;
+  }
+}
+
+function handleBlur() {
+  setTimeout(() => {
+    showDropdown = false;
+    highlightedIndex = -1;
+  }, 200);
 }
 
 // Expose focus method for parent component
@@ -36,10 +109,17 @@ export function focus() {
       bind:this={inputElement}
       {value}
       oninput={handleInput}
+      onkeydown={handleKeydown}
+      onfocus={handleFocus}
+      onblur={handleBlur}
       placeholder="Enter postal code"
       {disabled}
       class="w-full px-3 py-2 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-      autocomplete="postal-code"
+      autocomplete="off"
+      role="combobox"
+      aria-expanded={showDropdown}
+      aria-haspopup="listbox"
+      aria-autocomplete="list"
     />
 
     {#if isLoading}
@@ -65,8 +145,30 @@ export function focus() {
           />
         </svg>
       </div>
+    {:else if suggestions.length > 0}
+      <MagnifyingGlass class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth="2" />
     {/if}
   </div>
+
+  {#if showDropdown && !isLoading && suggestions.length > 0}
+    <ul
+      class="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto"
+      role="listbox"
+    >
+      {#each suggestions as suggestion, index}
+        <li role="option" aria-selected={highlightedIndex === index} class="cursor-pointer">
+          <button
+            type="button"
+            onclick={() => selectSuggestion(suggestion)}
+            class="w-full flex items-center gap-2 px-3 py-2 hover:bg-gray-50 transition-colors text-left {highlightedIndex === index ? 'bg-gray-100' : ''}"
+          >
+            <span class="font-body text-sm font-medium text-gray-900">{suggestion.postalCode}</span>
+            <span class="font-body text-sm text-gray-500">{suggestion.city}</span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
 
   {#if value && value.length < 3 && !disabled}
     <p class="mt-1 text-xs text-gray-500 font-body">Enter at least 3 characters</p>

--- a/database/migrations/1779667500000_geodata-cities-view.ts
+++ b/database/migrations/1779667500000_geodata-cities-view.ts
@@ -1,0 +1,38 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/**
+ * Materialized view of distinct postal-code -> city pairs, backing the city
+ * lookup and the postal-code prefix autocomplete.
+ *
+ * The OSM import stores rows without an `addr:city` tag as the placeholder city
+ * `'Unknown'` (see scripts/osm-import/import-region.sh); those are excluded here
+ * so they never surface as suggestions.
+ */
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    CREATE MATERIALIZED VIEW geodata.cities_by_postal AS
+    SELECT DISTINCT country_code, postal_code, city
+    FROM geodata.addresses
+    WHERE city <> 'Unknown';
+
+    COMMENT ON MATERIALIZED VIEW geodata.cities_by_postal IS 'Pre-computed distinct cities by postal code (excludes the Unknown placeholder)';
+  `);
+
+  // Unique index: required for REFRESH MATERIALIZED VIEW CONCURRENTLY and serves
+  // exact (country_code, postal_code) lookups for the city query.
+  pgm.sql(`
+    CREATE UNIQUE INDEX idx_cities_by_postal
+      ON geodata.cities_by_postal (country_code, postal_code, city);
+  `);
+
+  // text_pattern_ops index so the postal-code prefix `LIKE 'NN%'` is index-backed
+  // regardless of the database's default collation.
+  pgm.sql(`
+    CREATE INDEX idx_cities_by_postal_prefix
+      ON geodata.cities_by_postal (country_code, postal_code text_pattern_ops);
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP MATERIALIZED VIEW IF EXISTS geodata.cities_by_postal CASCADE');
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       JWT_EXPIRY: 604800
       SESSION_SECRET: invisible-carrot-black-drums-medium
       LOG_LEVEL: debug
-      ZIPCODEBASE_API_KEY: c1716d60-e731-11f0-b6a5-e7c811a3e296
       # PostGIS Address Lookup (enable after running OSM import)
       POSTGIS_ADDRESS_ENABLED: ${POSTGIS_ADDRESS_ENABLED:-false}
       POSTGIS_ADDRESS_DACH_ONLY: ${POSTGIS_ADDRESS_DACH_ONLY:-true}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,9 +73,9 @@ freundebuch2/
 Routes delegate to services, services handle business logic and database access. Sub-resources (addresses, emails, phones, URLs, dates) follow a consistent base pattern across both friends and collectives.
 
 **External integrations:**
-- PostGIS for spatial address queries
-- OpenStreetMap Overpass API for geocoding
-- ZipcodeBase for zip code validation
+- PostGIS for spatial address queries, city lookup and postal-code autocomplete (DACH OSM data)
+- OpenStreetMap Overpass API for street/house-number lookups
+- Nominatim for geocoding
 - Sentry for error tracking
 
 **Infrastructure:**

--- a/docs/postgis-address-autocomplete.md
+++ b/docs/postgis-address-autocomplete.md
@@ -75,9 +75,27 @@ docker compose -f docker-compose.prod.yml up -d backend
 
 ## How It Works
 
-1. **PostGIS First:** For DACH countries (DE, AT, CH), the system queries the local PostGIS database first
-2. **Automatic Fallback:** If PostGIS returns no results or fails, it falls back to the Overpass API
-3. **Non-DACH Countries:** Continue to use Overpass API directly
+City and postal-code lookups are served **entirely by PostGIS** (there is no
+external address API — ZipcodeBase was removed). Street and house-number lookups
+use PostGIS first and fall back to Overpass.
+
+1. **PostGIS First:** For DACH countries (DE, AT, CH), the system queries the local PostGIS database
+2. **Streets / house numbers:** fall back to the Overpass API when PostGIS has no data
+3. **Cities / postal codes:** PostGIS-only — when there is no data (non-DACH, un-imported postal code, or PostGIS disabled) the API returns an empty list and the frontend falls back to free-text entry
+
+### Lookups served by PostGIS
+
+| Lookup | PostGIS source | Fallback |
+|--------|----------------|----------|
+| Cities by postal code | `geodata.cities_by_postal` (distinct `city`, excludes the `'Unknown'` placeholder) | none (free text) |
+| Postal codes by prefix | `geodata.cities_by_postal` (prefix `LIKE`, returns code + city) | none (free text) |
+| Streets by postal code | `geodata.streets_by_postal` | Overpass |
+| House numbers by street | `geodata.housenumbers_by_street` | Overpass |
+
+> **Note:** PostGIS-sourced cities carry no state/province — the `geodata`
+> schema has no such column, so `state_province` is left empty for those
+> addresses. Non-DACH countries and un-imported postal codes have no city/postal
+> suggestions at all; users enter the city by hand.
 
 ## Maintenance
 
@@ -114,6 +132,7 @@ After imports, materialized views are automatically refreshed. To manually refre
 ```bash
 docker compose -f docker-compose.prod.yml exec postgres \
   psql -U freundebuch -d freundebuch -c "
+    REFRESH MATERIALIZED VIEW CONCURRENTLY geodata.cities_by_postal;
     REFRESH MATERIALIZED VIEW CONCURRENTLY geodata.streets_by_postal;
     REFRESH MATERIALIZED VIEW CONCURRENTLY geodata.housenumbers_by_street;
   "

--- a/packages/shared/src/address-lookup.ts
+++ b/packages/shared/src/address-lookup.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * Country information from ZipcodeBase
+ * Country information (static ISO 3166-1 alpha-2 list)
  */
 export interface CountryInfo {
   code: string; // ISO 3166-1 alpha-2 code (e.g., "DE", "US")
@@ -12,12 +12,22 @@ export interface CountryInfo {
 }
 
 /**
- * City information from ZipcodeBase postal code lookup
+ * City information from a postal code lookup (PostGIS / OSM address data).
+ * `state`/`stateCode` are optional and currently unpopulated — the geodata
+ * source has no state/province column.
  */
 export interface CityInfo {
   city: string;
   state?: string;
   stateCode?: string;
+}
+
+/**
+ * Postal-code suggestion for prefix autocomplete (PostGIS / OSM address data).
+ */
+export interface PostalCodeInfo {
+  postalCode: string;
+  city: string;
 }
 
 /**

--- a/scripts/osm-import/import-region.sh
+++ b/scripts/osm-import/import-region.sh
@@ -290,6 +290,7 @@ EOSQL
 refresh_views() {
     log_info "Refreshing materialized views..."
 
+    psql "$DATABASE_URL" -q -c "REFRESH MATERIALIZED VIEW CONCURRENTLY geodata.cities_by_postal;"
     psql "$DATABASE_URL" -q -c "REFRESH MATERIALIZED VIEW CONCURRENTLY geodata.streets_by_postal;"
     psql "$DATABASE_URL" -q -c "REFRESH MATERIALIZED VIEW CONCURRENTLY geodata.housenumbers_by_street;"
 


### PR DESCRIPTION
## Background

City resolution broke in production: ZipcodeBase returned `403 {"error":"Not enough requests."}` because the account's monthly request quota was exhausted. Rather than patch around the quota, this PR removes ZipcodeBase entirely and serves address lookup from the local PostGIS/OSM data we already import for DACH — which is free, fast, and (unlike ZipcodeBase) supports postal-code prefix search.

> **Decision:** address lookup is now PostGIS-only. For non-DACH countries, un-imported DACH postal codes, or when PostGIS is disabled, the city/postal endpoints return an empty list and the frontend falls back to free-text entry. PostGIS-sourced cities carry no state/province (the geodata schema has no such column; there is no state input field in the UI anyway).

## Changes

### Remove ZipcodeBase
- Delete `ZipcodeBaseClient`, its error classes, the `ZIPCODEBASE_API_KEY` config + docker-compose env, and the now-unused cities cache.
- Relocate the static country list to `utils/countries.ts` (it never required an API).
- `getAddressLookupService` no longer depends on an API key — geocoding falls back to Nominatim as before.

### Cities — PostGIS only
- `getCitiesByPostalCode` now reads from PostGIS (`cities_by_postal`), returning `[]` when there's no data.

### Postal-code autocomplete (new)
- New `geodata.cities_by_postal` materialized view: distinct `(country_code, postal_code, city)`, excluding the `'Unknown'` import placeholder, indexed with `text_pattern_ops` so prefix `LIKE` is index-backed. Refreshed by the OSM import script.
- New `PostGISAddressClient.searchPostalCodes` + `AddressLookupService.searchPostalCodes` + `GET /api/address-lookup/postal-codes?country=&prefix=`.
- Frontend `PostalCodeInput` gains a suggestions dropdown ("55116 — Mainz"); selecting one fills the postal code and city.

### Docs
- Updated `postgis-address-autocomplete.md` and `architecture.md` to reflect PostGIS-only lookups.

## Tests
- **Client ↔ real PostGIS DB:** `getCitiesByPostalCode`, `searchPostalCodes` (prefix match, `Unknown` filtering, limit, country filter).
- **Route ↔ service (PostGIS disabled):** validation + empty-list fallback for `/cities` and `/postal-codes`.
- **Full stack (HTTP → service → PostGIS with seeded data):** new `address-lookup-postgis.test.ts` — real cities/postal-code results, `Unknown` filtering through the stack, and the DACH-only gate.

## ⚠️ Notes for the reviewer
- **Could not run `tsc`/`vitest` in the authoring environment** (npm registry was unreachable, so deps wouldn't install). Changes were reviewed by hand; please rely on CI for type-check + tests.
- The previous `docker-compose.yml` committed a real ZipcodeBase API key — it's removed here, but it remains in git history and should be considered compromised/rotated (it's over quota regardless).
- Branch history was rewritten (force-push): the earlier "429 quota mapping" / "PostGIS-before-ZipcodeBase" commits are superseded by this single coherent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)