### PR TITLE
fix(frontend): Select top match on Enter in search dropdowns

### DIFF
--- a/apps/frontend/src/lib/components/encounters/friend-multi-select.svelte
+++ b/apps/frontend/src/lib/components/encounters/friend-multi-select.svelte
@@ -104,6 +104,10 @@ function handleKeydown(e: KeyboardEvent) {
       e.preventDefault();
       if (highlightedIndex >= 0 && highlightedIndex < filteredResults.length) {
         addFriend(filteredResults[highlightedIndex]);
+      } else if (query.trim() && filteredResults.length > 0) {
+        // No explicit highlight, but the user searched and there are matches:
+        // add the top match so Enter confirms the visible result.
+        addFriend(filteredResults[0]);
       }
       break;
     case 'Escape':

--- a/apps/frontend/src/lib/components/friends/country-select.svelte
+++ b/apps/frontend/src/lib/components/friends/country-select.svelte
@@ -77,6 +77,10 @@ function handleKeydown(e: KeyboardEvent) {
       e.preventDefault();
       if (highlightedIndex >= 0 && highlightedIndex < list.length) {
         selectCountry(list[highlightedIndex], true);
+      } else if (query.trim() && list.length > 0) {
+        // No explicit highlight, but the user searched and there are matches:
+        // select the top match so Enter confirms the visible result.
+        selectCountry(list[0], true);
       }
       break;
     case 'Escape':

--- a/apps/frontend/src/lib/components/friends/house-number-input.svelte
+++ b/apps/frontend/src/lib/components/friends/house-number-input.svelte
@@ -93,6 +93,10 @@ function handleKeydown(e: KeyboardEvent) {
         showDropdown = false;
       } else if (highlightedIndex >= 0 && highlightedIndex < list.length) {
         selectNumber(list[highlightedIndex]);
+      } else if (query.trim() && list.length > 0) {
+        // No explicit highlight, but the user searched and there are matches:
+        // select the top match so Enter confirms the visible result.
+        selectNumber(list[0]);
       }
       break;
     case 'Escape':

--- a/apps/frontend/src/lib/components/friends/relationship-type-input.svelte
+++ b/apps/frontend/src/lib/components/friends/relationship-type-input.svelte
@@ -115,6 +115,10 @@ function handleKeydown(e: KeyboardEvent) {
       e.preventDefault();
       if (highlightedIndex >= 0 && highlightedIndex < types.length) {
         selectType(types[highlightedIndex], true);
+      } else if (query.trim() && types.length > 0) {
+        // No explicit highlight, but the user searched and there are matches:
+        // select the top match so Enter confirms the visible result.
+        selectType(types[0], true);
       }
       break;
     case 'Escape':

--- a/apps/frontend/src/lib/components/friends/street-input.svelte
+++ b/apps/frontend/src/lib/components/friends/street-input.svelte
@@ -93,6 +93,10 @@ function handleKeydown(e: KeyboardEvent) {
         showDropdown = false;
       } else if (highlightedIndex >= 0 && highlightedIndex < list.length) {
         selectStreet(list[highlightedIndex]);
+      } else if (query.trim() && list.length > 0) {
+        // No explicit highlight, but the user searched and there are matches:
+        // select the top match so Enter confirms the visible result.
+        selectStreet(list[0]);
       }
       break;
     case 'Escape':


### PR DESCRIPTION
## Problem

When adding a relation to a friend and searching for a relationship type (e.g. typing `frie` to find `friend`), pressing Enter did nothing — the match was visible but couldn't be confirmed by keyboard.

## Root cause

These search dropdowns reset their highlighted-item index to `-1` on every keystroke, but the Enter handler only selected an item when the index was `>= 0`. So after typing a query, nothing was highlighted and pressing Enter was a no-op.

## Fix

When Enter is pressed with a non-empty query and matching results but no explicit arrow-key highlight, select the **top match**. Existing arrow-key navigation behavior is unchanged.

I audited every search/combobox component in the frontend. Fixes applied:

| Component | Form |
|---|---|
| `relationship-type-input.svelte` | Add relation (original report) |
| `country-select.svelte` | Address modal |
| `street-input.svelte` | Address modal |
| `house-number-input.svelte` | Address modal |
| `friend-multi-select.svelte` | Encounter participants |

**Not affected** (they already default the highlight to the first result): `friend-search-input.svelte`, `global-search.svelte`.

**Intentionally left unchanged:** `postal-code-input.svelte` — there the typed text *is* the value (captured live), so auto-picking a suggestion on Enter could silently overwrite user input.

## Testing

`svelte-check` and Biome lint pass via the pre-commit hooks. Backend integration tests (which require a Docker/Postgres container) were not runnable in the authoring environment and are unrelated to these frontend-only changes — CI will cover them here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeHiw689oEEoTxKdEtjXsg)_