### PR TITLE
fix(frontend): Fix and align the friend selector in modals

### DIFF
--- a/apps/frontend/src/lib/components/collectives/add-member-form.svelte
+++ b/apps/frontend/src/lib/components/collectives/add-member-form.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-import XMark from 'svelte-heros-v2/XMark.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { previewMemberRelationships } from '$lib/stores/collectives';
 import type { CollectiveRole, FriendSearchResult, RelationshipPreviewResponse } from '$shared';
-import FriendAvatar from '../friends/friend-avatar.svelte';
 import FriendSearchInput from '../friends/friend-search-input.svelte';
 import RelationshipPreview from './relationship-preview.svelte';
 
@@ -139,38 +137,21 @@ async function handleSubmit(e: Event) {
       {$i18n.t('collectives.addMember.friendLabel')} <span class="text-red-500">*</span>
     </label>
 
-    {#if selectedFriend}
-      <!-- Selected friend display -->
-      <div class="flex items-center justify-between bg-forest/5 border border-forest/20 rounded-lg p-3">
-        <div class="flex items-center gap-3">
-          <FriendAvatar
-            displayName={selectedFriend.displayName}
-            photoUrl={selectedFriend.photoThumbnailUrl}
-            size="sm"
-          />
-          <span class="font-body text-sm text-gray-900">{selectedFriend.displayName}</span>
-        </div>
-        <button
-          type="button"
-          onclick={clearSelection}
-          class="text-gray-400 hover:text-gray-600 transition-colors"
-        >
-          <XMark class="w-4 h-4" strokeWidth="2" />
-        </button>
-      </div>
-    {:else}
-      <FriendSearchInput
-        id="member-search"
-        placeholder={$i18n.t('collectives.addMember.searchPlaceholder')}
-        disabled={isSubmitting}
-        autofocus
-        disabledCheck={(friend) =>
-          existingMemberSet.has(friend.id)
-            ? $i18n.t('collectives.addMember.alreadyMember')
-            : null
-        }
-        onSelect={handleFriendSelect}
-      />
+    <FriendSearchInput
+      id="member-search"
+      placeholder={$i18n.t('collectives.addMember.searchPlaceholder')}
+      disabled={isSubmitting}
+      autofocus
+      selected={selectedFriend}
+      disabledCheck={(friend) =>
+        existingMemberSet.has(friend.id)
+          ? $i18n.t('collectives.addMember.alreadyMember')
+          : null
+      }
+      onSelect={handleFriendSelect}
+      onClear={clearSelection}
+    />
+    {#if !selectedFriend}
       <a
         href={createNewFriendHref}
         class="inline-block mt-2 text-sm text-forest hover:text-forest-light font-body underline"

--- a/apps/frontend/src/lib/components/friends/add-relationship-form.svelte
+++ b/apps/frontend/src/lib/components/friends/add-relationship-form.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import XMark from 'svelte-heros-v2/XMark.svelte';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
 import type { FriendSearchResult, RelationshipTypeId, RelationshipTypesGrouped } from '$shared';
@@ -106,27 +105,15 @@ async function handleSubmit(e: Event) {
       {$i18n.t('relationshipSection.relatedFriend')}
     </span>
 
-    {#if selectedFriend}
-      <div class="flex items-center justify-between bg-gray-50 p-3 rounded-lg">
-        <span class="font-body text-sm text-gray-900">{selectedFriend.displayName}</span>
-        <button
-          type="button"
-          onclick={clearSelectedFriend}
-          class="text-gray-400 hover:text-gray-600"
-          aria-label={$i18n.t('common.clear')}
-        >
-          <XMark class="w-5 h-5" strokeWidth="2" />
-        </button>
-      </div>
-    {:else}
-      <FriendSearchInput
-        placeholder={$i18n.t('relationshipSection.searchPlaceholder')}
-        excludeFriendId={friendId}
-        disabled={isSubmitting}
-        {autofocus}
-        onSelect={handleFriendSelect}
-      />
-    {/if}
+    <FriendSearchInput
+      placeholder={$i18n.t('relationshipSection.searchPlaceholder')}
+      excludeFriendId={friendId}
+      disabled={isSubmitting}
+      {autofocus}
+      selected={selectedFriend}
+      onSelect={handleFriendSelect}
+      onClear={clearSelectedFriend}
+    />
   </div>
 
   <!-- Relationship Type -->

--- a/apps/frontend/src/lib/components/friends/friend-search-input.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-search-input.svelte
@@ -242,6 +242,7 @@ function handleFocus() {
       <div class="flex items-center gap-2">
         <button
           type="button"
+          {id}
           onclick={activateInput}
           onkeydown={handleButtonKeydown}
           {disabled}
@@ -271,6 +272,7 @@ function handleFocus() {
     {:else}
       <input
         type="text"
+        {id}
         use:autoFocus={autofocus && !selected}
         bind:this={inputElement}
         bind:value={query}

--- a/apps/frontend/src/lib/components/friends/friend-search-input.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-search-input.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { onMount } from 'svelte';
 import MagnifyingGlass from 'svelte-heros-v2/MagnifyingGlass.svelte';
+import { autoFocus } from '$lib/actions/auto-focus';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
 import type { FriendSearchResult } from '$shared';
@@ -41,21 +41,11 @@ let {
   id = 'friend-search',
 }: Props = $props();
 
-onMount(() => {
-  if (autofocus && inputElement) {
-    // Small delay to ensure the element is fully rendered
-    requestAnimationFrame(() => {
-      inputElement?.focus();
-    });
-  }
-});
-
 let query = $state('');
 let results = $state<FriendSearchResult[]>([]);
 let isSearching = $state(false);
 let showDropdown = $state(false);
 let highlightedIndex = $state(-1);
-let inputElement: HTMLInputElement;
 let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
 
 function isItemDisabled(friend: FriendSearchResult): string | null {
@@ -165,7 +155,7 @@ function handleFocus() {
   <div class="relative">
     <input
       type="text"
-      bind:this={inputElement}
+      use:autoFocus={autofocus}
       bind:value={query}
       oninput={handleInput}
       onkeydown={handleKeydown}

--- a/apps/frontend/src/lib/components/friends/friend-search-input.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-search-input.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+import ChevronDown from 'svelte-heros-v2/ChevronDown.svelte';
 import MagnifyingGlass from 'svelte-heros-v2/MagnifyingGlass.svelte';
+import XMark from 'svelte-heros-v2/XMark.svelte';
 import { autoFocus } from '$lib/actions/auto-focus';
+import { listFriends } from '$lib/api/friends';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
 import type { FriendSearchResult } from '$shared';
@@ -19,8 +22,12 @@ interface Props {
   disabled?: boolean;
   /** Whether to autofocus the input on mount */
   autofocus?: boolean;
+  /** Currently selected friend, shown inline as the combobox value */
+  selected?: FriendSearchResult | null;
   /** Called when a friend is selected (viaKeyboard is true if Enter was used) */
   onSelect?: (friend: FriendSearchResult, viaKeyboard: boolean) => void;
+  /** Called when the current selection is cleared */
+  onClear?: () => void;
   /** Returns a disabled label for a friend (e.g. "Already a member"), or null if enabled */
   disabledCheck?: (friend: FriendSearchResult) => string | null;
   /** Override the "no results" text (defaults to i18n friendSearch.noResults) */
@@ -35,7 +42,9 @@ let {
   limit = 10,
   disabled = false,
   autofocus = false,
+  selected = null,
   onSelect,
+  onClear,
   disabledCheck,
   noResultsText,
   id = 'friend-search',
@@ -43,10 +52,19 @@ let {
 
 let query = $state('');
 let results = $state<FriendSearchResult[]>([]);
+let suggestions = $state<FriendSearchResult[]>([]);
+let suggestionsLoaded = $state(false);
 let isSearching = $state(false);
+let isLoadingSuggestions = $state(false);
 let showDropdown = $state(false);
 let highlightedIndex = $state(-1);
+let inputElement = $state<HTMLInputElement | undefined>(undefined);
 let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+
+// When there is no query, show the suggestion list (like the relationship-type
+// and postal-code dropdowns, which surface options on focus).
+let displayResults = $derived(query.trim() ? results : suggestions);
+let isLoading = $derived(query.trim() ? isSearching : isLoadingSuggestions);
 
 function isItemDisabled(friend: FriendSearchResult): string | null {
   return disabledCheck?.(friend) ?? null;
@@ -54,8 +72,8 @@ function isItemDisabled(friend: FriendSearchResult): string | null {
 
 function findNextSelectableIndex(current: number, direction: 1 | -1): number {
   let next = current + direction;
-  while (next >= 0 && next < results.length) {
-    if (!isItemDisabled(results[next])) {
+  while (next >= 0 && next < displayResults.length) {
+    if (!isItemDisabled(displayResults[next])) {
       return next;
     }
     next += direction;
@@ -65,15 +83,44 @@ function findNextSelectableIndex(current: number, direction: 1 | -1): number {
   return current;
 }
 
+// Load an initial list of friends to show before the user types anything.
+async function loadSuggestions() {
+  if (suggestionsLoaded || isLoadingSuggestions) return;
+
+  isLoadingSuggestions = true;
+  try {
+    const { friends: list } = await listFriends({
+      pageSize: limit,
+      sortBy: 'display_name',
+      sortOrder: 'asc',
+    });
+    suggestions = list
+      .filter((f) => f.id !== excludeFriendId)
+      .map((f) => ({
+        id: f.id,
+        displayName: f.displayName,
+        photoThumbnailUrl: f.photoThumbnailUrl,
+      }));
+    suggestionsLoaded = true;
+  } catch {
+    suggestions = [];
+  } finally {
+    isLoadingSuggestions = false;
+    if (!query.trim()) highlightedIndex = findNextSelectableIndex(-1, 1);
+  }
+}
+
 // Debounced search
 function handleInput() {
   if (debounceTimeout) {
     clearTimeout(debounceTimeout);
   }
 
+  showDropdown = true;
+
   if (!query.trim()) {
     results = [];
-    showDropdown = false;
+    highlightedIndex = findNextSelectableIndex(-1, 1);
     return;
   }
 
@@ -85,18 +132,16 @@ function handleInput() {
 async function performSearch() {
   if (!query.trim()) {
     results = [];
-    showDropdown = false;
     return;
   }
 
   isSearching = true;
   try {
     results = await friends.searchFriends(query, excludeFriendId, limit);
-    showDropdown = results.length > 0;
-    highlightedIndex = showDropdown ? findNextSelectableIndex(-1, 1) : -1;
+    showDropdown = true;
+    highlightedIndex = findNextSelectableIndex(-1, 1);
   } catch {
     results = [];
-    showDropdown = false;
   } finally {
     isSearching = false;
   }
@@ -111,8 +156,44 @@ function selectFriend(friend: FriendSearchResult, viaKeyboard = false) {
   onSelect?.(friend, viaKeyboard);
 }
 
+function clearSelection() {
+  if (disabled) return;
+  onClear?.();
+  // Re-open the search so the user can pick another friend straight away.
+  query = '';
+  requestAnimationFrame(() => {
+    inputElement?.focus();
+  });
+}
+
+// Open the search input and dropdown from the inline selected-value button.
+function activateInput() {
+  if (disabled) return;
+  query = '';
+  showDropdown = true;
+  loadSuggestions();
+  requestAnimationFrame(() => {
+    inputElement?.focus();
+  });
+}
+
+function handleButtonKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+    e.preventDefault();
+    activateInput();
+  }
+}
+
 function handleKeydown(e: KeyboardEvent) {
-  if (!showDropdown) return;
+  if (!showDropdown) {
+    // Match the relationship-type / postal-code dropdowns: open on ArrowDown/Enter.
+    if (e.key === 'ArrowDown' || e.key === 'Enter') {
+      e.preventDefault();
+      showDropdown = true;
+      if (!query.trim()) loadSuggestions();
+    }
+    return;
+  }
 
   switch (e.key) {
     case 'ArrowDown':
@@ -125,11 +206,15 @@ function handleKeydown(e: KeyboardEvent) {
       break;
     case 'Enter':
       e.preventDefault();
-      if (highlightedIndex >= 0 && highlightedIndex < results.length) {
-        selectFriend(results[highlightedIndex], true);
+      if (highlightedIndex >= 0 && highlightedIndex < displayResults.length) {
+        selectFriend(displayResults[highlightedIndex], true);
       }
       break;
     case 'Escape':
+      showDropdown = false;
+      highlightedIndex = -1;
+      break;
+    case 'Tab':
       showDropdown = false;
       highlightedIndex = -1;
       break;
@@ -145,39 +230,72 @@ function handleBlur() {
 }
 
 function handleFocus() {
-  if (results.length > 0) {
-    showDropdown = true;
-  }
+  showDropdown = true;
+  if (!query.trim()) loadSuggestions();
 }
 </script>
 
 <div class="relative">
   <div class="relative">
-    <input
-      type="text"
-      use:autoFocus={autofocus}
-      bind:value={query}
-      oninput={handleInput}
-      onkeydown={handleKeydown}
-      onblur={handleBlur}
-      onfocus={handleFocus}
-      {placeholder}
-      {disabled}
-      class="w-full px-3 py-2 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-      autocomplete="off"
-      role="combobox"
-      aria-expanded={showDropdown}
-      aria-controls="{id}-listbox"
-      aria-haspopup="listbox"
-      aria-autocomplete="list"
-    />
-
-    {#if isSearching}
-      <div class="absolute right-3 top-1/2 -translate-y-1/2">
-        <div class="animate-spin rounded-full h-4 w-4 border-2 border-forest border-t-transparent"></div>
+    {#if selected && !showDropdown}
+      <!-- Selected friend shown inline (click to change, like the relationship-type dropdown) -->
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          onclick={activateInput}
+          onkeydown={handleButtonKeydown}
+          {disabled}
+          class="flex-1 min-w-0 px-3 py-2 border border-gray-300 rounded-lg font-body text-sm flex items-center justify-between text-left focus:ring-2 focus:ring-forest focus:border-transparent {disabled ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'bg-white cursor-pointer hover:border-gray-400'}"
+          aria-haspopup="listbox"
+        >
+          <span class="flex items-center gap-3 min-w-0">
+            <FriendAvatar
+              displayName={selected.displayName}
+              photoUrl={selected.photoThumbnailUrl}
+              size="sm"
+            />
+            <span class="truncate text-gray-900">{selected.displayName}</span>
+          </span>
+          <ChevronDown class="w-4 h-4 text-gray-400 flex-shrink-0" strokeWidth="2" />
+        </button>
+        <button
+          type="button"
+          onclick={clearSelection}
+          {disabled}
+          class="p-2 text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-50"
+          aria-label={$i18n.t('common.clear')}
+        >
+          <XMark class="w-4 h-4" strokeWidth="2" />
+        </button>
       </div>
     {:else}
-      <MagnifyingGlass class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth="2" />
+      <input
+        type="text"
+        use:autoFocus={autofocus && !selected}
+        bind:this={inputElement}
+        bind:value={query}
+        oninput={handleInput}
+        onkeydown={handleKeydown}
+        onblur={handleBlur}
+        onfocus={handleFocus}
+        {placeholder}
+        {disabled}
+        class="w-full px-3 py-2 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+        autocomplete="off"
+        role="combobox"
+        aria-expanded={showDropdown}
+        aria-controls="{id}-listbox"
+        aria-haspopup="listbox"
+        aria-autocomplete="list"
+      />
+
+      {#if isLoading}
+        <div class="absolute right-3 top-1/2 -translate-y-1/2">
+          <div class="animate-spin rounded-full h-4 w-4 border-2 border-forest border-t-transparent"></div>
+        </div>
+      {:else}
+        <MagnifyingGlass class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth="2" />
+      {/if}
     {/if}
   </div>
 
@@ -187,7 +305,7 @@ function handleFocus() {
       class="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto"
       role="listbox"
     >
-      {#each results as friend, index}
+      {#each displayResults as friend, index (friend.id)}
         {@const disabledLabel = isItemDisabled(friend)}
         <li
           role="option"
@@ -213,7 +331,7 @@ function handleFocus() {
         </li>
       {/each}
 
-      {#if results.length === 0 && query.trim() && !isSearching}
+      {#if displayResults.length === 0 && !isLoading}
         <li class="px-3 py-2 text-sm text-gray-500 font-body">
           {noResultsText ?? $i18n.t('friendSearch.noResults')}
         </li>

--- a/apps/frontend/src/lib/components/friends/subresources/relationship-edit-form.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/relationship-edit-form.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import XMark from 'svelte-heros-v2/XMark.svelte';
 import { createDirtyTracker, FormTextarea, formClasses } from '$lib/components/ui';
 import { createI18n } from '$lib/i18n/index.js';
 import { friends } from '$lib/stores/friends';
@@ -101,28 +100,15 @@ export function isValid(): boolean {
       {$i18n.t('relationshipSection.relatedFriend')} <span class="text-red-500">*</span>
     </span>
 
-    {#if selectedFriend}
-      <div class="flex items-center justify-between bg-gray-50 p-3 rounded-lg">
-        <span class="font-body text-sm text-gray-900">{selectedFriend.displayName}</span>
-        <button
-          type="button"
-          onclick={clearSelectedFriend}
-          {disabled}
-          class="text-gray-400 hover:text-gray-600 disabled:opacity-50"
-          aria-label={$i18n.t('common.clear')}
-        >
-          <XMark class="w-5 h-5" strokeWidth="2" />
-        </button>
-      </div>
-    {:else}
-      <FriendSearchInput
-        placeholder={$i18n.t('relationshipSection.searchPlaceholder')}
-        excludeFriendId={friendId}
-        {disabled}
-        autofocus={true}
-        onSelect={handleFriendSelect}
-      />
-    {/if}
+    <FriendSearchInput
+      placeholder={$i18n.t('relationshipSection.searchPlaceholder')}
+      excludeFriendId={friendId}
+      {disabled}
+      autofocus={true}
+      selected={selectedFriend}
+      onSelect={handleFriendSelect}
+      onClear={clearSelectedFriend}
+    />
   </div>
 
   <!-- Relationship Type -->


### PR DESCRIPTION
## Problem

When adding a friend to a collective (the "Add member" modal), the friend search field was **not focused** and **search-by-typing did not work** — typed characters never reached the input.

While fixing that, the friend selector also turned out to **behave inconsistently** with the other dropdowns in the app (relationship-type selection, postal-code/zipcode dropdown): it showed nothing on focus, ignored the arrow keys until results existed, and replaced the whole control with a separate card once a friend was picked.

## Changes

### 1. Reliable autofocus (the original bug)

`FriendSearchInput` focused its input via an `onMount` + `requestAnimationFrame` callback. Inside `DetailEditModal` that focus never landed, so the field stayed unfocused — and since it wasn't focused, keystrokes never reached it (the global keyboard-shortcut layer also suppresses keys while a modal is open).

Switched to the shared `use:autoFocus` Svelte action already used by every other form in that modal, which focuses the element synchronously on mount.

### 2. Align the friend selector with the combobox pattern

Reworked `FriendSearchInput` into a self-contained combobox consistent with `relationship-type-input` and `postal-code-input`:

- **Suggestions on focus** — focusing the empty field loads and shows a list of friends (first page, alphabetical, up to `limit`) before any typing; typing switches to the live search.
- **Keyboard parity** — `ArrowDown`/`Enter` open the dropdown when closed, `Tab` dismisses it.
- **Inline selected value** — the chosen friend is shown inline in the same control (avatar + chevron, click to change, plus a clear button) instead of swapping the control out for a separate card.

Consumers (`add-member-form`, `relationship-edit-form`, `add-relationship-form`) now pass the selection via the new `selected`/`onClear` props and no longer render their own selected-state markup, so all three are consistent automatically.

## Notes

- The on-focus list uses the existing friends-list endpoint (the `/search` endpoint rejects an empty query), so suggestions are the first `limit` friends alphabetically rather than recency-ranked. Switching to recency would require a small backend addition.

## Verification

- `svelte-check` (frontend type-check): 0 errors
- Production build: succeeds
- Pre-commit hooks (biome, type-check, commitlint): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fp6QSZWuwkP1hnK8yB2x2v)_