### PR TITLE
fix(frontend): Make autofocus work on mobile keyboards

### DIFF
--- a/apps/frontend/src/lib/actions/auto-focus.ts
+++ b/apps/frontend/src/lib/actions/auto-focus.ts
@@ -1,12 +1,91 @@
 /**
+ * Mobile keyboard focus helpers.
+ *
+ * On iOS Safari the on-screen keyboard only opens when `.focus()` runs
+ * synchronously inside a user gesture (tap/click). Modals and views mount their
+ * input *after* the gesture has unwound, so focusing on mount is too late and
+ * the keyboard stays closed. To work around this, a tap handler that will open
+ * such a view calls {@link primeKeyboardFocus} synchronously: it focuses a
+ * throwaway off-screen input during the gesture, claiming the keyboard. When the
+ * real input mounts, the {@link autoFocus} action moves focus to it and the
+ * keyboard stays open.
+ */
+
+let primedInput: HTMLInputElement | null = null;
+
+function isTouchDevice(): boolean {
+  return (
+    typeof window !== 'undefined' && (navigator.maxTouchPoints > 0 || 'ontouchstart' in window)
+  );
+}
+
+/** Remove any input created by {@link primeKeyboardFocus}. */
+function releasePrimedInput(): void {
+  if (primedInput) {
+    primedInput.remove();
+    primedInput = null;
+  }
+}
+
+/**
+ * Call this synchronously inside a tap/click handler that opens a modal or view
+ * whose input is auto-focused on mount. On touch devices it primes the
+ * on-screen keyboard by focusing a throwaway off-screen input during the
+ * gesture, so the keyboard stays open once focus transfers to the real input
+ * (see {@link autoFocus}). It is a no-op on non-touch devices.
+ */
+export function primeKeyboardFocus(): void {
+  if (!isTouchDevice()) return;
+  releasePrimedInput();
+
+  const input = document.createElement('input');
+  input.setAttribute('aria-hidden', 'true');
+  input.tabIndex = -1;
+  // The element must stay focusable, so it can't use display:none or
+  // visibility:hidden. A 16px font-size keeps iOS from auto-zooming.
+  input.style.cssText =
+    'position:fixed;top:0;left:0;width:1px;height:1px;padding:0;border:0;' +
+    'margin:0;opacity:0;font-size:16px;pointer-events:none;z-index:-1;';
+  document.body.appendChild(input);
+  input.focus();
+  primedInput = input;
+
+  // Safety net: if no auto-focused input claims it (e.g. the target focuses
+  // itself without the action), remove the throwaway input shortly after.
+  setTimeout(() => {
+    if (primedInput === input) releasePrimedInput();
+  }, 1500);
+}
+
+/**
  * Svelte action that focuses an element on mount.
  * Use with `use:autoFocus` on any focusable element.
  * Pass `false` to skip focusing.
+ *
+ * Focus is deferred to the next animation frame so the element is laid out and
+ * visible (e.g. inside a modal or transition) before focusing — this makes
+ * autofocus reliable on mobile, where focusing a not-yet-painted element is a
+ * silent no-op. If the keyboard was primed via {@link primeKeyboardFocus}, the
+ * throwaway input is released once the real element takes focus.
  *
  * @example
  * <input use:autoFocus type="text" />
  * <input use:autoFocus={shouldFocus} type="text" />
  */
-export function autoFocus(node: HTMLElement, enabled: boolean = true): void {
-  if (enabled) node.focus();
+export function autoFocus(node: HTMLElement, enabled: boolean = true) {
+  if (!enabled) {
+    releasePrimedInput();
+    return;
+  }
+
+  const frame = requestAnimationFrame(() => {
+    node.focus();
+    releasePrimedInput();
+  });
+
+  return {
+    destroy() {
+      cancelAnimationFrame(frame);
+    },
+  };
 }

--- a/apps/frontend/src/lib/actions/auto-focus.ts
+++ b/apps/frontend/src/lib/actions/auto-focus.ts
@@ -73,10 +73,11 @@ export function primeKeyboardFocus(): void {
  * <input use:autoFocus={shouldFocus} type="text" />
  */
 export function autoFocus(node: HTMLElement, enabled: boolean = true) {
-  if (!enabled) {
-    releasePrimedInput();
-    return;
-  }
+  // A disabled autofocus must be a pure no-op: it must not touch the global
+  // priming state, or a sibling non-autofocused field mounting first would
+  // release the throwaway input before the intended field takes focus. Stale
+  // primed inputs are handled by the timeout safety-net in primeKeyboardFocus().
+  if (!enabled) return;
 
   const frame = requestAnimationFrame(() => {
     node.focus();

--- a/apps/frontend/src/lib/components/circles/circle-edit-modal.svelte
+++ b/apps/frontend/src/lib/components/circles/circle-edit-modal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import ExclamationTriangle from 'svelte-heros-v2/ExclamationTriangle.svelte';
 import XMark from 'svelte-heros-v2/XMark.svelte';
+import { autoFocus } from '$lib/actions/auto-focus';
 import { createI18n } from '$lib/i18n/index.js';
 import { circles, circlesList } from '$lib/stores/circles';
 import { isModalOpen } from '$lib/stores/ui';
@@ -25,7 +26,6 @@ let formColor = $state<string>(CIRCLE_COLORS[5]);
 let formParentId = $state<string | null>(null);
 let formError = $state('');
 let isSubmitting = $state(false);
-let nameInputRef = $state<HTMLInputElement | null>(null);
 let showUnsavedWarning = $state(false);
 
 // Track which circle we initialized for (to detect when circle prop changes)
@@ -47,13 +47,6 @@ $effect(() => {
 $effect(() => {
   isModalOpen.set(true);
   return () => isModalOpen.set(false);
-});
-
-// Focus the name input when the modal opens
-$effect(() => {
-  if (nameInputRef) {
-    nameInputRef.focus();
-  }
 });
 
 // Get valid parent options (exclude the current circle and its children to prevent circular references)
@@ -217,7 +210,7 @@ function handleBackdropClick(e: MouseEvent) {
             {$i18n.t('circles.form.name')}
           </label>
           <input
-            bind:this={nameInputRef}
+            use:autoFocus
             type="text"
             id="circle-name"
             bind:value={formName}

--- a/apps/frontend/src/lib/components/fab-create-menu.svelte
+++ b/apps/frontend/src/lib/components/fab-create-menu.svelte
@@ -2,6 +2,7 @@
 import { get } from 'svelte/store';
 import { goto } from '$app/navigation';
 import { page } from '$app/stores';
+import { primeKeyboardFocus } from '$lib/actions/auto-focus';
 
 export type FabCreateChoice = 'friend' | 'encounter' | 'circle' | 'collective';
 
@@ -21,6 +22,10 @@ export function navigateForCreateChoice(choice: FabCreateChoice): void {
       // Circles are created via a modal. Open it in place when already on /circles,
       // otherwise navigate there with a flag the circles page uses to auto-open it.
       if (get(page).url.pathname === '/circles') {
+        // This runs inside the FAB tap, so prime the keyboard for the modal's
+        // auto-focused input (the page's event handler can't, as it's also
+        // reachable from non-gesture keyboard shortcuts).
+        primeKeyboardFocus();
         window.dispatchEvent(new CustomEvent('shortcut:new-circle'));
       } else {
         goto('/circles?new=1');

--- a/apps/frontend/src/lib/components/friends/friend-detail.svelte
+++ b/apps/frontend/src/lib/components/friends/friend-detail.svelte
@@ -4,6 +4,7 @@ import Heart from 'svelte-heros-v2/Heart.svelte';
 import Plus from 'svelte-heros-v2/Plus.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { goto } from '$app/navigation';
+import { primeKeyboardFocus } from '$lib/actions/auto-focus';
 import { longPress } from '$lib/actions/long-press';
 import { getCollectivesForFriend } from '$lib/api/friends';
 import FabCreateMenu, {
@@ -406,6 +407,9 @@ onMount(() => {
   <MobileAddDetailModal
     onSelect={(type) => {
       showMobileAddModal = false;
+      // Prime the keyboard within this tap so iOS keeps it open when the
+      // auto-focused edit form mounts.
+      primeKeyboardFocus();
       dispatchAddEvent(type);
     }}
     onClose={() => showMobileAddModal = false}

--- a/apps/frontend/src/routes/circles/+page.svelte
+++ b/apps/frontend/src/routes/circles/+page.svelte
@@ -5,6 +5,7 @@ import Plus from 'svelte-heros-v2/Plus.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { replaceState } from '$app/navigation';
 import { page } from '$app/stores';
+import { primeKeyboardFocus } from '$lib/actions/auto-focus';
 import AlertBanner from '$lib/components/alert-banner.svelte';
 import CircleEditModal from '$lib/components/circles/circle-edit-modal.svelte';
 import DeleteConfirmModal from '$lib/components/friends/subresources/delete-confirm-modal.svelte';
@@ -81,11 +82,15 @@ onMount(() => {
 });
 
 function openCreateModal() {
+  // Prime the keyboard within this gesture so iOS keeps it open once the
+  // modal's auto-focused name input mounts.
+  primeKeyboardFocus();
   editingCircle = null;
   showEditModal = true;
 }
 
 function openEditModal(circle: Circle) {
+  primeKeyboardFocus();
   editingCircle = circle;
   showEditModal = true;
 }

--- a/apps/frontend/src/routes/circles/+page.svelte
+++ b/apps/frontend/src/routes/circles/+page.svelte
@@ -81,16 +81,18 @@ onMount(() => {
   };
 });
 
-function openCreateModal() {
-  // Prime the keyboard within this gesture so iOS keeps it open once the
-  // modal's auto-focused name input mounts.
-  primeKeyboardFocus();
+// `prime` should only be true when called from a real tap/click/swipe gesture,
+// so iOS keeps the keyboard open once the modal's auto-focused name input
+// mounts. Non-gesture callers (?new=1 auto-open, keyboard shortcuts) leave it
+// false to avoid stealing focus.
+function openCreateModal(prime = false) {
+  if (prime) primeKeyboardFocus();
   editingCircle = null;
   showEditModal = true;
 }
 
-function openEditModal(circle: Circle) {
-  primeKeyboardFocus();
+function openEditModal(circle: Circle, prime = false) {
+  if (prime) primeKeyboardFocus();
   editingCircle = circle;
   showEditModal = true;
 }
@@ -187,7 +189,7 @@ function getActualDepth(circle: Circle): number {
           <p class="text-gray-600 font-body mt-1">{$i18n.t('circles.subtitle')}</p>
         </div>
         <button
-          onclick={openCreateModal}
+          onclick={() => openCreateModal(true)}
           class="inline-flex items-center gap-2 bg-forest text-white px-4 py-2 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
           data-shortcut="n c"
           data-shortcut-label="shortcuts.newCircle"
@@ -250,7 +252,7 @@ function getActualDepth(circle: Circle): number {
           <h3 class="text-lg font-heading text-gray-600 mb-2">{$i18n.t('circles.noCircles')}</h3>
           <p class="text-gray-500 font-body mb-4">{$i18n.t('circles.noCirclesSubtitle')}</p>
           <button
-            onclick={openCreateModal}
+            onclick={() => openCreateModal(true)}
             class="inline-flex items-center gap-2 bg-forest text-white px-4 py-2 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
           >
             <Plus class="w-5 h-5" strokeWidth="2" />
@@ -273,7 +275,7 @@ function getActualDepth(circle: Circle): number {
             <!-- Mobile: Swipeable row -->
             <div class="sm:hidden" style:margin-left="{actualDepth * 16}px">
               <SwipeableRow
-                onSwipeRight={() => openEditModal(circle)}
+                onSwipeRight={() => openEditModal(circle, true)}
                 onSwipeLeft={() => openDeleteConfirm(circle)}
                 disabled={isDeleting}
               >
@@ -316,7 +318,7 @@ function getActualDepth(circle: Circle): number {
 
                   <!-- Actions (visible on mobile for accessibility) -->
                   <DetailActions
-                    onEdit={() => openEditModal(circle)}
+                    onEdit={() => openEditModal(circle, true)}
                     onDelete={() => openDeleteConfirm(circle)}
                     {isDeleting}
                     editLabel={$i18n.t('common.edit') + ' ' + circle.name}
@@ -371,7 +373,7 @@ function getActualDepth(circle: Circle): number {
 
                 <!-- Actions -->
                 <DetailActions
-                  onEdit={() => openEditModal(circle)}
+                  onEdit={() => openEditModal(circle, true)}
                   onDelete={() => openDeleteConfirm(circle)}
                   {isDeleting}
                   editLabel={$i18n.t('common.edit') + ' ' + circle.name}


### PR DESCRIPTION
Programmatic focus on mount was unreliable on mobile: the input is often
not yet laid out when the action runs (silent no-op on Android), and on
iOS Safari the on-screen keyboard only opens when focus() runs inside a
user gesture, which modals lose by the time their input mounts.

Defer the shared autoFocus action to the next animation frame so the
element is painted before focusing, and add primeKeyboardFocus(): a
helper that focuses a throwaway off-screen input synchronously inside the
opening tap, claiming the keyboard so it stays open when focus transfers
to the real input on mount. Wire it into the tap handlers that open the
circle modal and the mobile add-detail edit forms, and convert the circle
modal's name input to use the shared action so it releases the primed
input.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UXwpQgWdMQsra9nxATH4YV