### PR TITLE
refactor(frontend): Split collective-detail into data-driven sections (#187)

### DIFF
--- a/apps/frontend/src/lib/components/collectives/collective-detail.svelte
+++ b/apps/frontend/src/lib/components/collectives/collective-detail.svelte
@@ -1,78 +1,21 @@
 <script lang="ts">
-import { onMount } from 'svelte';
 import BuildingOffice from 'svelte-heros-v2/BuildingOffice.svelte';
 import DocumentText from 'svelte-heros-v2/DocumentText.svelte';
-import Envelope from 'svelte-heros-v2/Envelope.svelte';
 import Heart from 'svelte-heros-v2/Heart.svelte';
 import Home from 'svelte-heros-v2/Home.svelte';
-import Link from 'svelte-heros-v2/Link.svelte';
 import MapPin from 'svelte-heros-v2/MapPin.svelte';
-import PhoneIcon from 'svelte-heros-v2/Phone.svelte';
-import Plus from 'svelte-heros-v2/Plus.svelte';
-import UserPlus from 'svelte-heros-v2/UserPlus.svelte';
 import Users from 'svelte-heros-v2/Users.svelte';
 import { goto } from '$app/navigation';
-import { ApiError } from '$lib/api/client';
-import {
-  type AvailableCircleInfo,
-  addAddress,
-  addCollectiveToCircle,
-  addEmail,
-  addPhone,
-  addUrl,
-  type CollectiveCircleInfo,
-  deleteAddress,
-  deleteEmail,
-  deletePhone,
-  deleteUrl,
-  getAvailableCircles,
-  getCollectiveCircles,
-  listAddresses,
-  listEmails,
-  listPhones,
-  listUrls,
-  removeCollectiveFromCircle,
-  updateAddress,
-  updateEmail,
-  updatePhone,
-  updateUrl,
-} from '$lib/api/collectives';
 import { createI18n } from '$lib/i18n/index.js';
 import { collectives } from '$lib/stores/collectives';
-import { isModalOpen, visibleMemberContactIds } from '$lib/stores/ui';
+import { isModalOpen } from '$lib/stores/ui';
 import { collectiveTypeI18nKey } from '$lib/utils/collective-types';
-import type {
-  Address,
-  AddressInput,
-  Collective,
-  Email,
-  EmailInput,
-  MembershipDeactivate,
-  Phone,
-  PhoneInput,
-  Url,
-  UrlInput,
-} from '$shared';
-import {
-  AddressEditForm,
-  AddressRow,
-  CircleEditForm,
-  CircleRow,
-  DeleteConfirmModal,
-  DetailEditModal,
-  EmailEditForm,
-  EmailRow,
-  PhoneEditForm,
-  PhoneRow,
-  UrlEditForm,
-  UrlRow,
-} from '../friends/subresources';
-import AddMemberForm from './add-member-form.svelte';
-import MemberList from './member-list.svelte';
+import type { Collective } from '$shared';
+import MemberSection from './member-section.svelte';
+import { circleDescriptor, contactDescriptors } from './subresource-descriptors';
+import SubresourceSection from './subresource-section.svelte';
 
 const i18n = createI18n();
-
-type SubresourceType = 'phone' | 'email' | 'address' | 'url' | 'circle' | 'member';
 
 interface Props {
   collective: Collective;
@@ -85,81 +28,14 @@ let { collective, onEdit }: Props = $props();
 let isDeleting = $state(false);
 let showDeleteConfirm = $state(false);
 
-// Member management
-let showAddMember = $state(false);
-let showDeactivateModal = $state(false);
-let deactivatingMemberId = $state<string | null>(null);
-let deactivateReason = $state('');
-let deactivateDate = $state(new Date().toISOString().split('T')[0]);
+function openDeleteConfirm() {
+  showDeleteConfirm = true;
+  isModalOpen.set(true);
+}
 
-// Sub-resource state
-let phones = $state<Phone[]>([]);
-let emails = $state<Email[]>([]);
-let addresses = $state<Address[]>([]);
-let urls = $state<Url[]>([]);
-let circles = $state<CollectiveCircleInfo[]>([]);
-let availableCircles = $state<AvailableCircleInfo[]>([]);
-
-// Editing state
-let editingType = $state<SubresourceType | null>(null);
-let editingId = $state<string | null>(null);
-let editingData = $state<Phone | Email | Address | Url | null>(null);
-let isEditLoading = $state(false);
-let editError = $state<string | null>(null);
-let isDirty = $state(false);
-
-// Subresource deletion state
-let deleteType = $state<SubresourceType | null>(null);
-let deleteId = $state<string | null>(null);
-let deleteName = $state('');
-let deletingPhoneId = $state<string | null>(null);
-let deletingEmailId = $state<string | null>(null);
-let deletingAddressId = $state<string | null>(null);
-let deletingUrlId = $state<string | null>(null);
-let deletingCircleId = $state<string | null>(null);
-
-// Form refs
-let phoneFormRef = $state<{ getData: () => PhoneInput; isValid: () => boolean } | null>(null);
-let emailFormRef = $state<{ getData: () => EmailInput; isValid: () => boolean } | null>(null);
-let addressFormRef = $state<{ getData: () => AddressInput; isValid: () => boolean } | null>(null);
-let urlFormRef = $state<{ getData: () => UrlInput; isValid: () => boolean } | null>(null);
-let circleFormRef = $state<{ getData: () => { circleId: string }; isValid: () => boolean } | null>(
-  null,
-);
-
-// Load sub-resources on mount
-$effect(() => {
-  if (collective.id) {
-    loadSubresources();
-  }
-});
-
-async function loadSubresources() {
-  try {
-    const [
-      phonesResult,
-      emailsResult,
-      addressesResult,
-      urlsResult,
-      circlesResult,
-      availableResult,
-    ] = await Promise.all([
-      listPhones(collective.id),
-      listEmails(collective.id),
-      listAddresses(collective.id),
-      listUrls(collective.id),
-      getCollectiveCircles(collective.id),
-      getAvailableCircles(collective.id),
-    ]);
-    phones = phonesResult;
-    emails = emailsResult;
-    addresses = addressesResult;
-    urls = urlsResult;
-    circles = circlesResult;
-    availableCircles = availableResult;
-  } catch (err) {
-    console.error('Failed to load sub-resources:', err);
-  }
+function closeDeleteConfirm() {
+  showDeleteConfirm = false;
+  isModalOpen.set(false);
 }
 
 // Icon component mapping for collective types
@@ -204,276 +80,25 @@ function formatAddress(c: Collective): string | null {
   return parts.length > 0 ? parts.join(', ') : null;
 }
 
-// Collective CRUD
 async function handleDelete() {
   isDeleting = true;
   try {
     await collectives.deleteCollective(collective.id);
+    // Clear the modal flag before navigating; goto() may not unmount us
+    // (or could fail), which would otherwise leave shortcuts suppressed.
+    closeDeleteConfirm();
     goto('/collectives');
   } catch (err) {
     console.error('Failed to delete collective:', err);
-    isDeleting = false;
-    showDeleteConfirm = false;
-  }
-}
-
-// Member management
-async function handleAddMember(contactId: string, roleId: string, skipAutoRelationships?: boolean) {
-  await collectives.addMember(collective.id, {
-    friend_id: contactId,
-    role_id: roleId,
-    skip_auto_relationships: skipAutoRelationships,
-  });
-  showAddMember = false;
-  isModalOpen.set(false);
-}
-
-function handleDeactivateClick(memberId: string) {
-  deactivatingMemberId = memberId;
-  deactivateReason = '';
-  deactivateDate = new Date().toISOString().split('T')[0];
-  showDeactivateModal = true;
-}
-
-async function handleDeactivateConfirm() {
-  if (!deactivatingMemberId) return;
-  const input: MembershipDeactivate = {
-    reason: deactivateReason.trim() || null,
-    inactive_date: deactivateDate || null,
-  };
-  try {
-    await collectives.deactivateMember(collective.id, deactivatingMemberId, input);
-    showDeactivateModal = false;
-    deactivatingMemberId = null;
-  } catch (err) {
-    console.error('Failed to deactivate member:', err);
-  }
-}
-
-async function handleReactivate(memberId: string) {
-  try {
-    await collectives.reactivateMember(collective.id, memberId);
-  } catch (err) {
-    console.error('Failed to reactivate member:', err);
-  }
-}
-
-async function handleRemove(memberId: string) {
-  if (!confirm($i18n.t('collectives.removeMemberConfirm'))) return;
-  try {
-    await collectives.removeMember(collective.id, memberId);
-  } catch (err) {
-    console.error('Failed to remove member:', err);
-  }
-}
-
-// Open edit modal
-function openEditModal(type: SubresourceType, id?: string, data?: Phone | Email | Address | Url) {
-  editingType = type;
-  editingId = id ?? null;
-  editingData = data ?? null;
-  editError = null;
-  isDirty = false;
-  isModalOpen.set(true);
-}
-
-// Close edit modal
-function closeEditModal() {
-  editingType = null;
-  editingId = null;
-  editingData = null;
-  editError = null;
-  isDirty = false;
-  isEditLoading = false;
-  isModalOpen.set(false);
-}
-
-// Open delete confirmation
-function openDeleteConfirm(type: SubresourceType, id: string, name: string) {
-  deleteType = type;
-  deleteId = id;
-  deleteName = name;
-}
-
-// Close delete confirmation
-function closeDeleteConfirm() {
-  deleteType = null;
-  deleteId = null;
-  deleteName = '';
-}
-
-// Get modal title
-function getModalTitle(): string {
-  if (!editingType) return '';
-  const action = editingId ? $i18n.t('friendDetail.modal.edit') : $i18n.t('friendDetail.modal.add');
-  const typeNames: Record<string, string> = {
-    phone: $i18n.t('friendDetail.modal.phoneNumber'),
-    email: $i18n.t('friendDetail.modal.emailAddress'),
-    address: $i18n.t('friendDetail.modal.address'),
-    url: $i18n.t('friendDetail.modal.websiteUrl'),
-    circle: 'Circle',
-    member: $i18n.t('collectives.addMember.title'),
-  };
-  if (editingType === 'member') return typeNames.member;
-  if (editingType === 'circle') return `${$i18n.t('friendDetail.modal.add')} ${typeNames.circle}`;
-  return `${action} ${typeNames[editingType] ?? editingType}`;
-}
-
-// Handle save
-async function handleSave() {
-  isEditLoading = true;
-  editError = null;
-  try {
-    if (editingType === 'phone' && phoneFormRef?.isValid()) {
-      const data = phoneFormRef.getData();
-      if (editingId) {
-        const updated = await updatePhone(collective.id, editingId, data);
-        phones = phones.map((p) => (p.id === editingId ? updated : p));
-      } else {
-        const created = await addPhone(collective.id, data);
-        phones = [...phones, created];
-      }
-    } else if (editingType === 'email' && emailFormRef?.isValid()) {
-      const data = emailFormRef.getData();
-      if (editingId) {
-        const updated = await updateEmail(collective.id, editingId, data);
-        emails = emails.map((e) => (e.id === editingId ? updated : e));
-      } else {
-        const created = await addEmail(collective.id, data);
-        emails = [...emails, created];
-      }
-    } else if (editingType === 'address' && addressFormRef?.isValid()) {
-      const data = addressFormRef.getData();
-      if (editingId) {
-        const updated = await updateAddress(collective.id, editingId, data);
-        addresses = addresses.map((a) => (a.id === editingId ? updated : a));
-      } else {
-        const created = await addAddress(collective.id, data);
-        addresses = [...addresses, created];
-      }
-      // Geocoding runs asynchronously on the backend; refetch a few times to
-      // pick up coordinates once they land.
-      for (const delay of [800, 2000, 4500]) {
-        setTimeout(() => {
-          loadSubresources().catch(() => undefined);
-        }, delay);
-      }
-    } else if (editingType === 'url' && urlFormRef?.isValid()) {
-      const data = urlFormRef.getData();
-      if (editingId) {
-        const updated = await updateUrl(collective.id, editingId, data);
-        urls = urls.map((u) => (u.id === editingId ? updated : u));
-      } else {
-        const created = await addUrl(collective.id, data);
-        urls = [...urls, created];
-      }
-    } else if (editingType === 'circle' && circleFormRef?.isValid()) {
-      const data = circleFormRef.getData();
-      await addCollectiveToCircle(collective.id, data.circleId);
-      await loadSubresources();
-    } else {
-      return;
-    }
-    closeEditModal();
-  } catch (err) {
-    if (err instanceof ApiError && err.code === 'PHONE_COUNTRY_UNKNOWN') {
-      editError = $i18n.t('subresources.phone.unknownCountry');
-    } else {
-      editError = (err as Error).message || $i18n.t('subresources.common.failedToSave');
-    }
-  } finally {
-    isEditLoading = false;
-  }
-}
-
-// Handle subresource delete
-async function handleSubresourceDelete() {
-  if (!deleteType || !deleteId) return;
-  try {
-    switch (deleteType) {
-      case 'phone':
-        deletingPhoneId = deleteId;
-        await deletePhone(collective.id, deleteId);
-        phones = phones.filter((p) => p.id !== deleteId);
-        break;
-      case 'email':
-        deletingEmailId = deleteId;
-        await deleteEmail(collective.id, deleteId);
-        emails = emails.filter((e) => e.id !== deleteId);
-        break;
-      case 'address':
-        deletingAddressId = deleteId;
-        await deleteAddress(collective.id, deleteId);
-        addresses = addresses.filter((a) => a.id !== deleteId);
-        break;
-      case 'url':
-        deletingUrlId = deleteId;
-        await deleteUrl(collective.id, deleteId);
-        urls = urls.filter((u) => u.id !== deleteId);
-        break;
-      case 'circle':
-        deletingCircleId = deleteId;
-        await removeCollectiveFromCircle(collective.id, deleteId);
-        await loadSubresources();
-        break;
-    }
-  } finally {
-    deletingPhoneId = null;
-    deletingEmailId = null;
-    deletingAddressId = null;
-    deletingUrlId = null;
-    deletingCircleId = null;
     closeDeleteConfirm();
+  } finally {
+    // Reset independently of navigation: if goto() fails or doesn't unmount
+    // us, the UI must not stay stuck in a permanently-deleting state.
+    isDeleting = false;
   }
 }
 
 let address = $derived(formatAddress(collective));
-
-// Track visible member contact IDs for keyboard open mode
-$effect(() => {
-  const activeMembers = collective.members.filter((m) => m.isActive);
-  const ids = activeMembers.map((m) => m.contact.id);
-  visibleMemberContactIds.set(ids);
-});
-
-// Keyboard shortcut event listeners
-onMount(() => {
-  function handleAddPhoneShortcut() {
-    openEditModal('phone');
-  }
-  function handleAddEmailShortcut() {
-    openEditModal('email');
-  }
-  function handleAddAddressShortcut() {
-    openEditModal('address');
-  }
-  function handleAddUrlShortcut() {
-    openEditModal('url');
-  }
-  function handleAddCircleShortcut() {
-    openEditModal('circle');
-  }
-  function handleAddMemberShortcut() {
-    showAddMember = true;
-    isModalOpen.set(true);
-  }
-
-  window.addEventListener('shortcut:collective-add-phone', handleAddPhoneShortcut);
-  window.addEventListener('shortcut:collective-add-email', handleAddEmailShortcut);
-  window.addEventListener('shortcut:collective-add-address', handleAddAddressShortcut);
-  window.addEventListener('shortcut:collective-add-url', handleAddUrlShortcut);
-  window.addEventListener('shortcut:collective-add-circle', handleAddCircleShortcut);
-  window.addEventListener('shortcut:collective-add-member', handleAddMemberShortcut);
-
-  return () => {
-    window.removeEventListener('shortcut:collective-add-phone', handleAddPhoneShortcut);
-    window.removeEventListener('shortcut:collective-add-email', handleAddEmailShortcut);
-    window.removeEventListener('shortcut:collective-add-address', handleAddAddressShortcut);
-    window.removeEventListener('shortcut:collective-add-url', handleAddUrlShortcut);
-    window.removeEventListener('shortcut:collective-add-circle', handleAddCircleShortcut);
-    window.removeEventListener('shortcut:collective-add-member', handleAddMemberShortcut);
-  };
-});
 </script>
 
 <div class="space-y-6">
@@ -513,7 +138,7 @@ onMount(() => {
         {$i18n.t('common.edit')}
       </button>
       <button
-        onclick={() => showDeleteConfirm = true}
+        onclick={openDeleteConfirm}
         class="px-4 py-2 border border-red-300 text-red-600 rounded-lg font-body font-semibold hover:bg-red-50 transition-colors"
       >
         {$i18n.t('common.delete')}
@@ -536,199 +161,16 @@ onMount(() => {
 
   <!-- ==================== CONTACT DETAILS SECTION ==================== -->
   <div class="space-y-4">
-    <!-- Phone Numbers -->
-    {#if phones.length > 0}
-      <section class="space-y-2">
-        <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
-          <h2 class="text-lg font-heading flex items-center gap-2">
-            <PhoneIcon class="w-5 h-5" strokeWidth="2" />
-            {$i18n.t('friendDetail.sections.phoneNumbers')}
-          </h2>
-          <button
-            type="button"
-            onclick={() => openEditModal('phone')}
-            class="text-sm font-body font-semibold text-white/90 hover:text-white
-                   flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
-            data-shortcut="a p"
-            data-shortcut-label="shortcuts.add.phone"
-          >
-            <Plus class="w-4 h-4" strokeWidth="2" />
-            {$i18n.t('friendDetail.actions.addPhone')}
-          </button>
-        </div>
-        <div class="space-y-2">
-          {#each phones as phone (phone.id)}
-            <PhoneRow
-              {phone}
-              onEdit={() => openEditModal('phone', phone.id, phone)}
-              onDelete={() => openDeleteConfirm('phone', phone.id, phone.phoneNumber)}
-              isDeleting={deletingPhoneId === phone.id}
-            />
-          {/each}
-        </div>
-      </section>
-    {/if}
-
-    <!-- Email Addresses -->
-    {#if emails.length > 0}
-      <section class="space-y-2">
-        <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
-          <h2 class="text-lg font-heading flex items-center gap-2">
-            <Envelope class="w-5 h-5" strokeWidth="2" />
-            {$i18n.t('friendDetail.sections.emailAddresses')}
-          </h2>
-          <button
-            type="button"
-            onclick={() => openEditModal('email')}
-            class="text-sm font-body font-semibold text-white/90 hover:text-white
-                   flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
-            data-shortcut="a e"
-            data-shortcut-label="shortcuts.add.email"
-          >
-            <Plus class="w-4 h-4" strokeWidth="2" />
-            {$i18n.t('friendDetail.actions.addEmail')}
-          </button>
-        </div>
-        <div class="space-y-2">
-          {#each emails as email (email.id)}
-            <EmailRow
-              {email}
-              onEdit={() => openEditModal('email', email.id, email)}
-              onDelete={() => openDeleteConfirm('email', email.id, email.emailAddress)}
-              isDeleting={deletingEmailId === email.id}
-            />
-          {/each}
-        </div>
-      </section>
-    {/if}
-
-    <!-- Addresses -->
-    {#if addresses.length > 0}
-      <section class="space-y-2">
-        <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
-          <h2 class="text-lg font-heading flex items-center gap-2">
-            <MapPin class="w-5 h-5" strokeWidth="2" />
-            {$i18n.t('friendDetail.sections.addresses')}
-          </h2>
-          <button
-            type="button"
-            onclick={() => openEditModal('address')}
-            class="text-sm font-body font-semibold text-white/90 hover:text-white
-                   flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
-            data-shortcut="a a"
-            data-shortcut-label="shortcuts.add.address"
-          >
-            <Plus class="w-4 h-4" strokeWidth="2" />
-            {$i18n.t('friendDetail.actions.addAddress')}
-          </button>
-        </div>
-        <div class="space-y-2">
-          {#each addresses as addr (addr.id)}
-            <AddressRow
-              address={addr}
-              onEdit={() => openEditModal('address', addr.id, addr)}
-              onDelete={() => openDeleteConfirm('address', addr.id, addr.streetLine1 || addr.city || $i18n.t('subresources.address.thisAddress'))}
-              isDeleting={deletingAddressId === addr.id}
-            />
-          {/each}
-        </div>
-      </section>
-    {/if}
-
-    <!-- URLs -->
-    {#if urls.length > 0}
-      <section class="space-y-2">
-        <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
-          <h2 class="text-lg font-heading flex items-center gap-2">
-            <Link class="w-5 h-5" strokeWidth="2" />
-            {$i18n.t('friendDetail.sections.websites')}
-          </h2>
-          <button
-            type="button"
-            onclick={() => openEditModal('url')}
-            class="text-sm font-body font-semibold text-white/90 hover:text-white
-                   flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
-            data-shortcut="a u"
-            data-shortcut-label="shortcuts.add.url"
-          >
-            <Plus class="w-4 h-4" strokeWidth="2" />
-            {$i18n.t('friendDetail.actions.addUrl')}
-          </button>
-        </div>
-        <div class="space-y-2">
-          {#each urls as urlItem (urlItem.id)}
-            <UrlRow
-              url={urlItem}
-              onEdit={() => openEditModal('url', urlItem.id, urlItem)}
-              onDelete={() => openDeleteConfirm('url', urlItem.id, urlItem.url)}
-              isDeleting={deletingUrlId === urlItem.id}
-            />
-          {/each}
-        </div>
-      </section>
-    {/if}
+    {#each contactDescriptors as descriptor (descriptor.key)}
+      <SubresourceSection {descriptor} collectiveId={collective.id} collectiveName={collective.name} />
+    {/each}
   </div>
 
   <!-- ==================== CIRCLES SECTION ==================== -->
-  {#if circles.length > 0}
-    <section class="space-y-2">
-      <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
-        <h2 class="text-lg font-heading flex items-center gap-2">
-          <Users class="w-5 h-5" strokeWidth="2" />
-          {$i18n.t('friendDetail.sections.circles')}
-        </h2>
-        <button
-          type="button"
-          onclick={() => openEditModal('circle')}
-          class="text-sm font-body font-semibold text-white/90 hover:text-white
-                 flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
-          data-shortcut="a c"
-          data-shortcut-label="shortcuts.add.circle"
-        >
-          <Plus class="w-4 h-4" strokeWidth="2" />
-          {$i18n.t('friendDetail.actions.addCircle')}
-        </button>
-      </div>
-      <div class="space-y-2">
-        {#each circles as circle (circle.id)}
-          <CircleRow
-            {circle}
-            onDelete={() => openDeleteConfirm('circle', circle.id, circle.name)}
-            isDeleting={deletingCircleId === circle.id}
-          />
-        {/each}
-      </div>
-    </section>
-  {/if}
+  <SubresourceSection descriptor={circleDescriptor} collectiveId={collective.id} collectiveName={collective.name} />
 
   <!-- ==================== MEMBERS SECTION ==================== -->
-  <section class="space-y-2">
-    <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
-      <h2 class="text-lg font-heading flex items-center gap-2">
-        <UserPlus class="w-5 h-5" strokeWidth="2" />
-        {$i18n.t('collectives.detail.members')}
-        <span class="text-sm font-body font-normal text-white/80">({collective.activeMemberCount})</span>
-      </h2>
-      <button
-        type="button"
-        onclick={() => { showAddMember = true; isModalOpen.set(true); }}
-        class="text-sm font-body font-semibold text-white/90 hover:text-white
-               flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
-        data-shortcut="a m"
-        data-shortcut-label="shortcuts.add.member"
-      >
-        <Plus class="w-4 h-4" strokeWidth="2" />
-        {$i18n.t('collectives.addMember.button')}
-      </button>
-    </div>
-
-    <MemberList
-      members={collective.members}
-      onDeactivate={handleDeactivateClick}
-      onReactivate={handleReactivate}
-      onRemove={handleRemove}
-    />
-  </section>
+  <MemberSection {collective} />
 
   <!-- ==================== METADATA FOOTER ==================== -->
   <section class="text-sm text-gray-500 font-body">
@@ -738,68 +180,6 @@ onMount(() => {
     </div>
   </section>
 </div>
-
-<!-- Add Member modal -->
-{#if showAddMember}
-  <DetailEditModal
-    title={$i18n.t('collectives.addMember.title')}
-    subtitle={collective.name}
-    isLoading={false}
-    onSave={() => {}}
-    onClose={() => { showAddMember = false; isModalOpen.set(false); }}
-    hideFooter
-  >
-    <AddMemberForm
-      collectiveId={collective.id}
-      collectiveName={collective.name}
-      roles={collective.type.roles}
-      existingMemberContactIds={collective.members.map((m) => m.contact.id)}
-      onAdd={handleAddMember}
-      onCancel={() => { showAddMember = false; isModalOpen.set(false); }}
-    />
-  </DetailEditModal>
-{/if}
-
-<!-- Edit subresource modal -->
-{#if editingType && editingType !== 'member'}
-  <DetailEditModal
-    title={getModalTitle()}
-    subtitle={collective.name}
-    isLoading={isEditLoading}
-    error={editError}
-    {isDirty}
-    onSave={handleSave}
-    onClose={closeEditModal}
-  >
-    {#if editingType === 'phone'}
-      <PhoneEditForm bind:this={phoneFormRef} initialData={editingData as Phone | undefined} defaultPrimary={!editingId && phones.length === 0} />
-    {:else if editingType === 'email'}
-      <EmailEditForm bind:this={emailFormRef} initialData={editingData as Email | undefined} defaultPrimary={!editingId && emails.length === 0} />
-    {:else if editingType === 'address'}
-      <AddressEditForm bind:this={addressFormRef} initialData={editingData as Address | undefined} defaultPrimary={!editingId && addresses.length === 0} />
-    {:else if editingType === 'url'}
-      <UrlEditForm bind:this={urlFormRef} initialData={editingData as Url | undefined} />
-    {:else if editingType === 'circle'}
-      <CircleEditForm
-        bind:this={circleFormRef}
-        existingCircles={circles}
-        disabled={isEditLoading}
-        onchange={() => isDirty = true}
-      />
-    {/if}
-  </DetailEditModal>
-{/if}
-
-<!-- Delete subresource confirmation -->
-{#if deleteType && deleteId}
-  <DeleteConfirmModal
-    title="{deleteType === 'circle' ? 'Remove from' : 'Delete'} {deleteType === 'phone' ? 'Phone Number' : deleteType === 'email' ? 'Email Address' : deleteType === 'address' ? 'Address' : deleteType === 'url' ? 'Website' : 'Circle'}"
-    description={deleteType === 'circle' ? 'Are you sure you want to remove this collective from this circle?' : `Are you sure you want to delete this ${deleteType}?`}
-    itemPreview={deleteName}
-    onConfirm={handleSubresourceDelete}
-    onClose={closeDeleteConfirm}
-  />
-{/if}
 
 <!-- Delete collective confirmation -->
 {#if showDeleteConfirm}
@@ -811,7 +191,7 @@ onMount(() => {
       </p>
       <div class="flex gap-3">
         <button
-          onclick={() => showDeleteConfirm = false}
+          onclick={closeDeleteConfirm}
           disabled={isDeleting}
           class="flex-1 px-4 py-2 border border-gray-300 rounded-lg font-body font-semibold text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
         >
@@ -823,69 +203,6 @@ onMount(() => {
           class="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg font-body font-semibold hover:bg-red-700 transition-colors disabled:opacity-50"
         >
           {isDeleting ? $i18n.t('collectives.detail.deleting') : $i18n.t('collectives.detail.delete')}
-        </button>
-      </div>
-    </div>
-  </div>
-{/if}
-
-<!-- Deactivate member modal -->
-{#if showDeactivateModal}
-  <div
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="deactivate-modal-title"
-  >
-    <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
-      <h3 id="deactivate-modal-title" class="text-lg font-heading font-semibold text-gray-900">
-        {$i18n.t('collectives.deactivate.title')}
-      </h3>
-      <p class="mt-2 text-sm text-gray-600 font-body">
-        {$i18n.t('collectives.deactivate.message')}
-      </p>
-
-      <div class="mt-4 space-y-4">
-        <div>
-          <label for="deactivate-reason" class="block text-sm font-body font-medium text-gray-700 mb-1">
-            {$i18n.t('collectives.deactivate.reasonLabel')} <span class="text-gray-400">{$i18n.t('collectives.form.optional')}</span>
-          </label>
-          <input
-            id="deactivate-reason"
-            type="text"
-            bind:value={deactivateReason}
-            placeholder={$i18n.t('collectives.deactivate.reasonPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm"
-          />
-        </div>
-
-        <div>
-          <label for="deactivate-date" class="block text-sm font-body font-medium text-gray-700 mb-1">
-            {$i18n.t('collectives.deactivate.dateLabel')}
-          </label>
-          <input
-            id="deactivate-date"
-            type="date"
-            bind:value={deactivateDate}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm"
-          />
-        </div>
-      </div>
-
-      <div class="mt-6 flex gap-3 justify-end">
-        <button
-          type="button"
-          onclick={() => { showDeactivateModal = false; deactivatingMemberId = null; }}
-          class="px-4 py-2 border border-gray-300 rounded-lg font-body text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-        >
-          {$i18n.t('collectives.form.cancel')}
-        </button>
-        <button
-          type="button"
-          onclick={handleDeactivateConfirm}
-          class="px-4 py-2 bg-amber-600 text-white rounded-lg font-body text-sm font-semibold hover:bg-amber-700 transition-colors"
-        >
-          {$i18n.t('collectives.deactivate.confirm')}
         </button>
       </div>
     </div>

--- a/apps/frontend/src/lib/components/collectives/collective-detail.test.ts
+++ b/apps/frontend/src/lib/components/collectives/collective-detail.test.ts
@@ -1,0 +1,162 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isModalOpen } from '$lib/stores/ui';
+import { aCollective, aCollectiveMember, fireEvent, render, screen, waitFor } from '$lib/test';
+import CollectiveDetail from './collective-detail.svelte';
+
+vi.mock('$lib/i18n/index.js', () => ({
+  createI18n: () => ({
+    subscribe: (run: (v: { t: (k: string) => string }) => void) => {
+      run({ t: (k: string) => k });
+      return () => undefined;
+    },
+  }),
+}));
+
+const goto = vi.fn();
+vi.mock('$app/navigation', () => ({ goto: (...args: unknown[]) => goto(...args) }));
+
+const deleteCollective = vi.fn().mockResolvedValue(undefined);
+vi.mock('$lib/stores/collectives', () => ({
+  collectives: {
+    deleteCollective: (...args: unknown[]) => deleteCollective(...args),
+    // MemberSection (child) touches these; no-op them.
+    addMember: vi.fn(),
+    deactivateMember: vi.fn(),
+    reactivateMember: vi.fn(),
+    removeMember: vi.fn(),
+  },
+  previewMemberRelationships: vi.fn().mockResolvedValue({ relationships: [] }),
+}));
+
+// SubresourceSection children call descriptor.load (list*) on mount.
+vi.mock('$lib/api/collectives', () => ({
+  listPhones: vi.fn().mockResolvedValue([]),
+  listEmails: vi.fn().mockResolvedValue([]),
+  listAddresses: vi.fn().mockResolvedValue([]),
+  listUrls: vi.fn().mockResolvedValue([]),
+  getCollectiveCircles: vi.fn().mockResolvedValue([]),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  isModalOpen.set(false);
+});
+
+describe('CollectiveDetail', () => {
+  it('renders the name, type badge and notes', () => {
+    const collective = aCollective({ name: 'Book Club', notes: 'Meets monthly' });
+    render(CollectiveDetail, { collective });
+
+    expect(screen.getByText('Book Club')).toBeTruthy();
+    expect(screen.getByText('Meets monthly')).toBeTruthy();
+    expect(screen.getByText('collectives.detail.notes')).toBeTruthy();
+  });
+
+  it('renders a formatted address when one is present', () => {
+    const collective = aCollective({
+      address: {
+        streetLine1: '1 Main St',
+        streetLine2: null,
+        city: 'Berlin',
+        stateProvince: null,
+        postalCode: '10115',
+        country: 'DE',
+      },
+    });
+    render(CollectiveDetail, { collective });
+
+    expect(screen.getByText('1 Main St, 10115 Berlin, DE')).toBeTruthy();
+  });
+
+  it('invokes onEdit from the edit button', async () => {
+    const onEdit = vi.fn();
+    render(CollectiveDetail, { collective: aCollective(), onEdit });
+
+    await fireEvent.click(screen.getByText('common.edit'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the delete confirmation and flags the global modal state', async () => {
+    render(CollectiveDetail, { collective: aCollective() });
+
+    expect(get(isModalOpen)).toBe(false);
+    await fireEvent.click(screen.getByText('common.delete'));
+    expect(screen.getByText('collectives.detail.deleteConfirmTitle')).toBeTruthy();
+    expect(get(isModalOpen)).toBe(true);
+  });
+
+  it('clears the modal state when delete is cancelled', async () => {
+    render(CollectiveDetail, { collective: aCollective() });
+
+    await fireEvent.click(screen.getByText('common.delete'));
+    await fireEvent.click(screen.getByText('collectives.form.cancel'));
+    expect(get(isModalOpen)).toBe(false);
+    expect(screen.queryByText('collectives.detail.deleteConfirmTitle')).toBeNull();
+  });
+
+  it('deletes the collective and navigates away on confirm', async () => {
+    const collective = aCollective();
+    render(CollectiveDetail, { collective });
+
+    await fireEvent.click(screen.getByText('common.delete'));
+    await fireEvent.click(screen.getByText('collectives.detail.delete'));
+
+    await waitFor(() => expect(deleteCollective).toHaveBeenCalledWith(collective.id));
+    await waitFor(() => expect(goto).toHaveBeenCalledWith('/collectives'));
+    // Flag must be cleared before navigation so shortcuts aren't left suppressed.
+    await waitFor(() => expect(get(isModalOpen)).toBe(false));
+  });
+
+  it('closes the confirmation and clears the modal flag when deletion fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    deleteCollective.mockRejectedValueOnce(new Error('boom'));
+    render(CollectiveDetail, { collective: aCollective() });
+
+    await fireEvent.click(screen.getByText('common.delete'));
+    await fireEvent.click(screen.getByText('collectives.detail.delete'));
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(goto).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.queryByText('collectives.detail.deleteConfirmTitle')).toBeNull(),
+    );
+    expect(get(isModalOpen)).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it('resets the deleting state after a successful delete even if navigation does not unmount', async () => {
+    const collective = aCollective();
+    render(CollectiveDetail, { collective });
+
+    await fireEvent.click(screen.getByText('common.delete'));
+    await fireEvent.click(screen.getByText('collectives.detail.delete'));
+    await waitFor(() => expect(goto).toHaveBeenCalledWith('/collectives'));
+
+    // goto() is a no-op here, so the component stays mounted. Re-opening the
+    // dialog must offer an actionable button, not one stuck in "deleting".
+    await fireEvent.click(screen.getByText('common.delete'));
+    const confirm = screen.getByText('collectives.detail.delete') as HTMLButtonElement;
+    expect(confirm.disabled).toBe(false);
+  });
+
+  it('renders each collective type with its icon variant', () => {
+    for (const name of ['Family', 'Company', 'Club', 'Friend Group', 'Other']) {
+      const { unmount } = render(CollectiveDetail, {
+        collective: aCollective({ type: { ...aCollective().type, name } }),
+      });
+      unmount();
+    }
+    // Reaching here means all icon/badge switch branches rendered without error.
+    expect(true).toBe(true);
+  });
+
+  it('shows the active member count from a populated roster', () => {
+    const collective = aCollective({
+      members: [aCollectiveMember({ isActive: true })],
+      activeMemberCount: 1,
+    });
+    render(CollectiveDetail, { collective });
+    expect(screen.getByText('collectives.detail.members')).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/lib/components/collectives/member-section.svelte
+++ b/apps/frontend/src/lib/components/collectives/member-section.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import Plus from 'svelte-heros-v2/Plus.svelte';
+import UserPlus from 'svelte-heros-v2/UserPlus.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+import { collectives } from '$lib/stores/collectives';
+import { isModalOpen, visibleMemberContactIds } from '$lib/stores/ui';
+import type { Collective, MembershipDeactivate } from '$shared';
+import { DetailEditModal } from '../friends/subresources';
+import AddMemberForm from './add-member-form.svelte';
+import MemberList from './member-list.svelte';
+
+const i18n = createI18n();
+
+interface Props {
+  collective: Collective;
+}
+
+let { collective }: Props = $props();
+
+// Member management
+let showAddMember = $state(false);
+let showDeactivateModal = $state(false);
+let deactivatingMemberId = $state<string | null>(null);
+let deactivateReason = $state('');
+let deactivateDate = $state(new Date().toISOString().split('T')[0]);
+
+// Track visible member contact IDs for keyboard open mode
+$effect(() => {
+  const activeMembers = collective.members.filter((m) => m.isActive);
+  const ids = activeMembers.map((m) => m.contact.id);
+  visibleMemberContactIds.set(ids);
+});
+
+// Reset modal state when the collective changes. The route can swap the
+// collective prop without unmounting this component; a lingering add/deactivate
+// modal would otherwise show stale member IDs and confirm against the new
+// collective.id.
+let activeCollectiveId: string | undefined;
+$effect(() => {
+  const id = collective.id;
+  if (activeCollectiveId !== undefined && id !== activeCollectiveId) {
+    const hadModalOpen = showAddMember || showDeactivateModal;
+    showAddMember = false;
+    showDeactivateModal = false;
+    deactivatingMemberId = null;
+    deactivateReason = '';
+    if (hadModalOpen) isModalOpen.set(false);
+  }
+  activeCollectiveId = id;
+});
+
+async function handleAddMember(contactId: string, roleId: string, skipAutoRelationships?: boolean) {
+  await collectives.addMember(collective.id, {
+    friend_id: contactId,
+    role_id: roleId,
+    skip_auto_relationships: skipAutoRelationships,
+  });
+  showAddMember = false;
+  isModalOpen.set(false);
+}
+
+function handleDeactivateClick(memberId: string) {
+  deactivatingMemberId = memberId;
+  deactivateReason = '';
+  deactivateDate = new Date().toISOString().split('T')[0];
+  showDeactivateModal = true;
+  isModalOpen.set(true);
+}
+
+function closeDeactivateModal() {
+  showDeactivateModal = false;
+  deactivatingMemberId = null;
+  isModalOpen.set(false);
+}
+
+async function handleDeactivateConfirm() {
+  if (!deactivatingMemberId) return;
+  const trimmedReason = deactivateReason.trim();
+  const input: MembershipDeactivate = {
+    reason: trimmedReason.length > 0 ? trimmedReason : null,
+    inactive_date: deactivateDate === '' ? null : deactivateDate,
+  };
+  try {
+    await collectives.deactivateMember(collective.id, deactivatingMemberId, input);
+    closeDeactivateModal();
+  } catch (err) {
+    console.error('Failed to deactivate member:', err);
+  }
+}
+
+async function handleReactivate(memberId: string) {
+  try {
+    await collectives.reactivateMember(collective.id, memberId);
+  } catch (err) {
+    console.error('Failed to reactivate member:', err);
+  }
+}
+
+async function handleRemove(memberId: string) {
+  if (!confirm($i18n.t('collectives.removeMemberConfirm'))) return;
+  try {
+    await collectives.removeMember(collective.id, memberId);
+  } catch (err) {
+    console.error('Failed to remove member:', err);
+  }
+}
+
+// Keyboard shortcut: open the add-member modal
+onMount(() => {
+  function handleAddMemberShortcut() {
+    showAddMember = true;
+    isModalOpen.set(true);
+  }
+  window.addEventListener('shortcut:collective-add-member', handleAddMemberShortcut);
+  return () => {
+    window.removeEventListener('shortcut:collective-add-member', handleAddMemberShortcut);
+  };
+});
+</script>
+
+<section class="space-y-2">
+  <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
+    <h2 class="text-lg font-heading flex items-center gap-2">
+      <UserPlus class="w-5 h-5" strokeWidth="2" />
+      {$i18n.t('collectives.detail.members')}
+      <span class="text-sm font-body font-normal text-white/80">({collective.activeMemberCount})</span>
+    </h2>
+    <button
+      type="button"
+      onclick={() => { showAddMember = true; isModalOpen.set(true); }}
+      class="text-sm font-body font-semibold text-white/90 hover:text-white
+             flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+      data-shortcut="a m"
+      data-shortcut-label="shortcuts.add.member"
+    >
+      <Plus class="w-4 h-4" strokeWidth="2" />
+      {$i18n.t('collectives.addMember.button')}
+    </button>
+  </div>
+
+  <MemberList
+    members={collective.members}
+    onDeactivate={handleDeactivateClick}
+    onReactivate={handleReactivate}
+    onRemove={handleRemove}
+  />
+</section>
+
+<!-- Add Member modal -->
+{#if showAddMember}
+  <DetailEditModal
+    title={$i18n.t('collectives.addMember.title')}
+    subtitle={collective.name}
+    isLoading={false}
+    onSave={() => {}}
+    onClose={() => { showAddMember = false; isModalOpen.set(false); }}
+    hideFooter
+    asForm={false}
+  >
+    <AddMemberForm
+      collectiveId={collective.id}
+      collectiveName={collective.name}
+      roles={collective.type.roles}
+      existingMemberContactIds={collective.members.map((m) => m.contact.id)}
+      onAdd={handleAddMember}
+      onCancel={() => { showAddMember = false; isModalOpen.set(false); }}
+    />
+  </DetailEditModal>
+{/if}
+
+<!-- Deactivate member modal -->
+{#if showDeactivateModal}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="deactivate-modal-title"
+  >
+    <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+      <h3 id="deactivate-modal-title" class="text-lg font-heading font-semibold text-gray-900">
+        {$i18n.t('collectives.deactivate.title')}
+      </h3>
+      <p class="mt-2 text-sm text-gray-600 font-body">
+        {$i18n.t('collectives.deactivate.message')}
+      </p>
+
+      <div class="mt-4 space-y-4">
+        <div>
+          <label for="deactivate-reason" class="block text-sm font-body font-medium text-gray-700 mb-1">
+            {$i18n.t('collectives.deactivate.reasonLabel')} <span class="text-gray-400">{$i18n.t('collectives.form.optional')}</span>
+          </label>
+          <input
+            id="deactivate-reason"
+            type="text"
+            bind:value={deactivateReason}
+            placeholder={$i18n.t('collectives.deactivate.reasonPlaceholder')}
+            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm"
+          />
+        </div>
+
+        <div>
+          <label for="deactivate-date" class="block text-sm font-body font-medium text-gray-700 mb-1">
+            {$i18n.t('collectives.deactivate.dateLabel')}
+          </label>
+          <input
+            id="deactivate-date"
+            type="date"
+            bind:value={deactivateDate}
+            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-forest focus:border-transparent font-body text-sm"
+          />
+        </div>
+      </div>
+
+      <div class="mt-6 flex gap-3 justify-end">
+        <button
+          type="button"
+          onclick={closeDeactivateModal}
+          class="px-4 py-2 border border-gray-300 rounded-lg font-body text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          {$i18n.t('collectives.form.cancel')}
+        </button>
+        <button
+          type="button"
+          onclick={handleDeactivateConfirm}
+          class="px-4 py-2 bg-amber-600 text-white rounded-lg font-body text-sm font-semibold hover:bg-amber-700 transition-colors"
+        >
+          {$i18n.t('collectives.deactivate.confirm')}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/frontend/src/lib/components/collectives/member-section.test.ts
+++ b/apps/frontend/src/lib/components/collectives/member-section.test.ts
@@ -1,0 +1,204 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isModalOpen } from '$lib/stores/ui';
+import { aCollective, aCollectiveMember, fireEvent, render, screen, waitFor } from '$lib/test';
+import MemberSection from './member-section.svelte';
+
+vi.mock('$lib/i18n/index.js', () => ({
+  createI18n: () => ({
+    subscribe: (run: (v: { t: (k: string) => string }) => void) => {
+      run({ t: (k: string) => k });
+      return () => undefined;
+    },
+  }),
+}));
+
+const addMember = vi.fn().mockResolvedValue(undefined);
+const deactivateMember = vi.fn().mockResolvedValue(undefined);
+const reactivateMember = vi.fn().mockResolvedValue(undefined);
+const removeMember = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('$lib/stores/collectives', () => ({
+  collectives: {
+    addMember: (...args: unknown[]) => addMember(...args),
+    deactivateMember: (...args: unknown[]) => deactivateMember(...args),
+    reactivateMember: (...args: unknown[]) => reactivateMember(...args),
+    removeMember: (...args: unknown[]) => removeMember(...args),
+  },
+  // AddMemberForm imports this from the same module.
+  previewMemberRelationships: vi.fn().mockResolvedValue({ relationships: [] }),
+}));
+
+function aCollectiveWithMembers() {
+  const active = aCollectiveMember({ isActive: true });
+  const inactive = aCollectiveMember({ isActive: false, inactiveDate: '2026-01-01' });
+  return {
+    collective: aCollective({ members: [active, inactive], activeMemberCount: 1 }),
+    active,
+    inactive,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  isModalOpen.set(false);
+});
+
+describe('MemberSection', () => {
+  it('renders the active and inactive members', () => {
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    expect(screen.getAllByText('Test Friend').length).toBe(2);
+    expect(screen.getByText('collectives.detail.members')).toBeTruthy();
+  });
+
+  it('opens the deactivate modal and confirms deactivation through the store', async () => {
+    const { collective, active } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByTitle('collectives.deactivateMember'));
+    expect(await screen.findByText('collectives.deactivate.title')).toBeTruthy();
+
+    await fireEvent.click(screen.getByText('collectives.deactivate.confirm'));
+    await waitFor(() => expect(deactivateMember).toHaveBeenCalledTimes(1));
+    expect(deactivateMember).toHaveBeenCalledWith(
+      collective.id,
+      active.id,
+      expect.objectContaining({ reason: null }),
+    );
+  });
+
+  it('flags the global modal state while the deactivate dialog is open and clears it on confirm', async () => {
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    expect(get(isModalOpen)).toBe(false);
+    await fireEvent.click(screen.getByTitle('collectives.deactivateMember'));
+    expect(get(isModalOpen)).toBe(true);
+
+    await fireEvent.click(screen.getByText('collectives.deactivate.confirm'));
+    await waitFor(() => expect(deactivateMember).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(get(isModalOpen)).toBe(false));
+  });
+
+  it('clears the modal state when the deactivate dialog is cancelled', async () => {
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByTitle('collectives.deactivateMember'));
+    expect(get(isModalOpen)).toBe(true);
+
+    await fireEvent.click(screen.getByText('collectives.form.cancel'));
+    expect(get(isModalOpen)).toBe(false);
+    expect(deactivateMember).not.toHaveBeenCalled();
+  });
+
+  it('keeps the deactivate dialog open and logs when the store rejects', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    deactivateMember.mockRejectedValueOnce(new Error('boom'));
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByTitle('collectives.deactivateMember'));
+    await fireEvent.click(screen.getByText('collectives.deactivate.confirm'));
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    // Modal stays open so the user can retry.
+    expect(screen.queryByText('collectives.deactivate.title')).toBeTruthy();
+    expect(get(isModalOpen)).toBe(true);
+    errorSpy.mockRestore();
+  });
+
+  it('logs when reactivation rejects', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    reactivateMember.mockRejectedValueOnce(new Error('boom'));
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByTitle('collectives.reactivateMember'));
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    errorSpy.mockRestore();
+  });
+
+  it('logs when removal rejects', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    removeMember.mockRejectedValueOnce(new Error('boom'));
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getAllByTitle('collectives.removeMember')[0]);
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    confirmSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('reactivates an inactive member through the store', async () => {
+    const { collective, inactive } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByTitle('collectives.reactivateMember'));
+    await waitFor(() => expect(reactivateMember).toHaveBeenCalledWith(collective.id, inactive.id));
+  });
+
+  it('removes a member after the confirm prompt', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const { collective, active } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getAllByTitle('collectives.removeMember')[0]);
+    await waitFor(() => expect(removeMember).toHaveBeenCalledWith(collective.id, active.id));
+    confirmSpy.mockRestore();
+  });
+
+  it('does not remove a member when the confirm prompt is cancelled', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getAllByTitle('collectives.removeMember')[0]);
+    expect(removeMember).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('opens the add-member modal', async () => {
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByText('collectives.addMember.button'));
+    expect(await screen.findByText('collectives.addMember.title')).toBeTruthy();
+  });
+
+  it('closes an open modal and clears the global flag when the collective changes', async () => {
+    const { collective } = aCollectiveWithMembers();
+    const other = aCollective({
+      id: 'other-collective',
+      members: [aCollectiveMember({ isActive: true })],
+      activeMemberCount: 1,
+    });
+    const { rerender } = render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByTitle('collectives.deactivateMember'));
+    expect(get(isModalOpen)).toBe(true);
+    expect(screen.queryByText('collectives.deactivate.title')).toBeTruthy();
+
+    // Route swaps the collective without unmounting; the stale modal must close.
+    await rerender({ collective: other });
+
+    await waitFor(() => expect(screen.queryByText('collectives.deactivate.title')).toBeNull());
+    expect(get(isModalOpen)).toBe(false);
+  });
+
+  it('does not nest the add-member form inside the modal form (valid HTML)', async () => {
+    const { collective } = aCollectiveWithMembers();
+    render(MemberSection, { collective });
+
+    await fireEvent.click(screen.getByText('collectives.addMember.button'));
+    await screen.findByText('collectives.addMember.title');
+
+    // DetailEditModal renders with asForm={false} here, so AddMemberForm's own
+    // <form> is the only one — nested forms are invalid HTML.
+    expect(document.querySelectorAll('form')).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/lib/components/collectives/subresource-descriptors.api.test.ts
+++ b/apps/frontend/src/lib/components/collectives/subresource-descriptors.api.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as api from '$lib/api/collectives';
+import { aPhone, aUrl } from '$lib/test';
+import { circleDescriptor, contactDescriptors } from './subresource-descriptors';
+
+// Every descriptor closure just delegates to one API function; mock the whole
+// module so we can assert the wiring (load/create/update/remove) per type.
+vi.mock('$lib/api/collectives', () => ({
+  listPhones: vi.fn().mockResolvedValue([]),
+  addPhone: vi.fn(),
+  updatePhone: vi.fn(),
+  deletePhone: vi.fn(),
+  listEmails: vi.fn().mockResolvedValue([]),
+  addEmail: vi.fn(),
+  updateEmail: vi.fn(),
+  deleteEmail: vi.fn(),
+  listAddresses: vi.fn().mockResolvedValue([]),
+  addAddress: vi.fn(),
+  updateAddress: vi.fn(),
+  deleteAddress: vi.fn(),
+  listUrls: vi.fn().mockResolvedValue([]),
+  addUrl: vi.fn(),
+  updateUrl: vi.fn(),
+  deleteUrl: vi.fn(),
+  getCollectiveCircles: vi.fn().mockResolvedValue([]),
+  addCollectiveToCircle: vi.fn(),
+  removeCollectiveFromCircle: vi.fn(),
+}));
+
+const byKey = Object.fromEntries(contactDescriptors.map((d) => [d.key, d]));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('descriptor CRUD delegation', () => {
+  it('wires phone load/create/update/remove to the phone API', async () => {
+    const data = { phone_number: '+1 555 0100' } as never;
+    await byKey.phone.load('c1');
+    await byKey.phone.create('c1', data);
+    await byKey.phone.update?.('c1', 'p1', data);
+    await byKey.phone.remove('c1', 'p1');
+    expect(api.listPhones).toHaveBeenCalledWith('c1');
+    expect(api.addPhone).toHaveBeenCalledWith('c1', data);
+    expect(api.updatePhone).toHaveBeenCalledWith('c1', 'p1', data);
+    expect(api.deletePhone).toHaveBeenCalledWith('c1', 'p1');
+  });
+
+  it('wires email load/create/update/remove to the email API', async () => {
+    const data = { email_address: 'a@b.com' } as never;
+    await byKey.email.load('c1');
+    await byKey.email.create('c1', data);
+    await byKey.email.update?.('c1', 'e1', data);
+    await byKey.email.remove('c1', 'e1');
+    expect(api.listEmails).toHaveBeenCalledWith('c1');
+    expect(api.addEmail).toHaveBeenCalledWith('c1', data);
+    expect(api.updateEmail).toHaveBeenCalledWith('c1', 'e1', data);
+    expect(api.deleteEmail).toHaveBeenCalledWith('c1', 'e1');
+  });
+
+  it('wires address load/create/update/remove to the address API', async () => {
+    const data = { street_line_1: '1 Main St' } as never;
+    await byKey.address.load('c1');
+    await byKey.address.create('c1', data);
+    await byKey.address.update?.('c1', 'a1', data);
+    await byKey.address.remove('c1', 'a1');
+    expect(api.listAddresses).toHaveBeenCalledWith('c1');
+    expect(api.addAddress).toHaveBeenCalledWith('c1', data);
+    expect(api.updateAddress).toHaveBeenCalledWith('c1', 'a1', data);
+    expect(api.deleteAddress).toHaveBeenCalledWith('c1', 'a1');
+  });
+
+  it('wires url load/create/update/remove to the url API', async () => {
+    const data = { url: 'https://x.dev' } as never;
+    await byKey.url.load('c1');
+    await byKey.url.create('c1', data);
+    await byKey.url.update?.('c1', 'u1', data);
+    await byKey.url.remove('c1', 'u1');
+    expect(api.listUrls).toHaveBeenCalledWith('c1');
+    expect(api.addUrl).toHaveBeenCalledWith('c1', data);
+    expect(api.updateUrl).toHaveBeenCalledWith('c1', 'u1', data);
+    expect(api.deleteUrl).toHaveBeenCalledWith('c1', 'u1');
+  });
+
+  it('unwraps the circle id on create and delegates load/remove (add-only)', async () => {
+    await circleDescriptor.load('c1');
+    await circleDescriptor.create('c1', { circleId: 'circle-9' } as never);
+    await circleDescriptor.remove('c1', 'circle-9');
+    expect(api.getCollectiveCircles).toHaveBeenCalledWith('c1');
+    expect(api.addCollectiveToCircle).toHaveBeenCalledWith('c1', 'circle-9');
+    expect(api.removeCollectiveFromCircle).toHaveBeenCalledWith('c1', 'circle-9');
+  });
+});
+
+describe('descriptor formProps', () => {
+  const ctx = (over = {}) => ({
+    editingData: null,
+    editingId: null,
+    itemCount: 0,
+    items: [],
+    isLoading: false,
+    ...over,
+  });
+
+  it('defaults primary on for the first phone/email/address but not when editing', () => {
+    for (const d of [byKey.phone, byKey.email, byKey.address]) {
+      expect(d.formProps(ctx()).defaultPrimary).toBe(true);
+      expect(d.formProps(ctx({ itemCount: 2 })).defaultPrimary).toBe(false);
+      expect(d.formProps(ctx({ editingId: 'x' })).defaultPrimary).toBe(false);
+    }
+  });
+
+  it('passes initialData and disabled through, and url omits defaultPrimary', () => {
+    const phone = aPhone();
+    expect(byKey.phone.formProps(ctx({ editingData: phone, isLoading: true }))).toMatchObject({
+      initialData: phone,
+      disabled: true,
+    });
+    const url = aUrl();
+    const urlProps = byKey.url.formProps(ctx({ editingData: url }));
+    expect(urlProps).toMatchObject({ initialData: url });
+    expect(urlProps.defaultPrimary).toBeUndefined();
+  });
+
+  it('hands circle the current items as existingCircles', () => {
+    const items = [{ id: 'c', name: 'Inner', color: null }] as never;
+    expect(circleDescriptor.formProps(ctx({ items }))).toMatchObject({
+      existingCircles: items,
+      disabled: false,
+    });
+  });
+});
+
+describe('address afterSave geocoding refetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reloads three times on the geocoding backoff schedule', () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    byKey.address.afterSave?.(reload);
+    expect(reload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(800);
+    expect(reload).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2000);
+    expect(reload).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(4500);
+    expect(reload).toHaveBeenCalledTimes(3);
+  });
+
+  it('is only defined for the address descriptor', () => {
+    expect(byKey.phone.afterSave).toBeUndefined();
+    expect(byKey.email.afterSave).toBeUndefined();
+    expect(byKey.url.afterSave).toBeUndefined();
+    expect(circleDescriptor.afterSave).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/lib/components/collectives/subresource-descriptors.test.ts
+++ b/apps/frontend/src/lib/components/collectives/subresource-descriptors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { CollectiveCircleInfo } from '$lib/api/collectives';
+import { anAddress, anEmail, aPhone, aUrl } from '$lib/test';
+import { circleDescriptor, contactDescriptors } from './subresource-descriptors';
+
+// i18n is stubbed here as an echo so the address fallback key is observable.
+const t = (key: string) => key;
+
+const byKey = Object.fromEntries(contactDescriptors.map((d) => [d.key, d]));
+
+const aCircle = (overrides: Partial<CollectiveCircleInfo> = {}): CollectiveCircleInfo => ({
+  id: 'circle-1',
+  name: 'Inner Circle',
+  color: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('collective subresource descriptors', () => {
+  it('extracts the delete-preview name per type', () => {
+    expect(byKey.phone.deleteName(aPhone({ phoneNumber: '+1 555 0100' }), t)).toBe('+1 555 0100');
+    expect(byKey.email.deleteName(anEmail({ emailAddress: 'a@b.com' }), t)).toBe('a@b.com');
+    expect(byKey.url.deleteName(aUrl({ url: 'https://x.dev' }), t)).toBe('https://x.dev');
+    expect(circleDescriptor.deleteName(aCircle({ name: 'Family' }), t)).toBe('Family');
+  });
+
+  it('falls back to a translated label when an address has no street or city', () => {
+    const blank = anAddress({ streetLine1: '', city: '' });
+    expect(byKey.address.deleteName(blank, t)).toBe('subresources.address.thisAddress');
+    expect(byKey.address.deleteName(anAddress({ streetLine1: '1 Main St' }), t)).toBe('1 Main St');
+  });
+
+  it('maps each item under the prop name its Row component expects', () => {
+    const phone = aPhone();
+    const email = anEmail();
+    const address = anAddress();
+    const url = aUrl();
+    const circle = aCircle();
+    expect(byKey.phone.rowProps(phone)).toEqual({ phone });
+    expect(byKey.email.rowProps(email)).toEqual({ email });
+    expect(byKey.address.rowProps(address)).toEqual({ address });
+    expect(byKey.url.rowProps(url)).toEqual({ url });
+    expect(circleDescriptor.rowProps(circle)).toEqual({ circle });
+  });
+
+  it('marks circle as add-only and the contact types as editable', () => {
+    expect(circleDescriptor.editable).toBe(false);
+    expect(circleDescriptor.update).toBeUndefined();
+    expect(circleDescriptor.reloadAfterMutate).toBe(true);
+    for (const d of contactDescriptors) {
+      expect(d.editable).toBe(true);
+      expect(d.update).toBeTypeOf('function');
+    }
+  });
+
+  it('maps the phone unknown-country error and only registers it on the phone descriptor', async () => {
+    const { ApiError } = await import('$lib/api/client');
+    const err = new ApiError(422, 'nope', 'PHONE_COUNTRY_UNKNOWN');
+    expect(byKey.phone.mapError?.(err, t)).toBe('subresources.phone.unknownCountry');
+    expect(byKey.phone.mapError?.(new Error('other'), t)).toBeUndefined();
+    expect(byKey.email.mapError).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/lib/components/collectives/subresource-descriptors.ts
+++ b/apps/frontend/src/lib/components/collectives/subresource-descriptors.ts
@@ -1,0 +1,296 @@
+// biome-ignore-all lint/correctness/useImportExtensions: Svelte imports need .svelte extension
+/**
+ * Data-driven descriptors for a collective's CRUD sub-resources
+ * (phones / emails / addresses / urls / circles).
+ *
+ * Each descriptor captures everything that varies between the five types — the
+ * icon, i18n keys, API calls, row/form components, and the per-type quirks
+ * (address geocoding refetch, circle being add-only) — so that
+ * `subresource-section.svelte` can drive all of them with a single, branch-free
+ * implementation. This replaces the former central `editingType` discriminator
+ * with its parallel `if/else` save chain and `switch` delete chain.
+ */
+import type { Component } from 'svelte';
+import Envelope from 'svelte-heros-v2/Envelope.svelte';
+import Link from 'svelte-heros-v2/Link.svelte';
+import MapPin from 'svelte-heros-v2/MapPin.svelte';
+import PhoneIcon from 'svelte-heros-v2/Phone.svelte';
+import Users from 'svelte-heros-v2/Users.svelte';
+import { ApiError } from '$lib/api/client';
+import {
+  addAddress,
+  addCollectiveToCircle,
+  addEmail,
+  addPhone,
+  addUrl,
+  type CollectiveCircleInfo,
+  deleteAddress,
+  deleteEmail,
+  deletePhone,
+  deleteUrl,
+  getCollectiveCircles,
+  listAddresses,
+  listEmails,
+  listPhones,
+  listUrls,
+  removeCollectiveFromCircle,
+  updateAddress,
+  updateEmail,
+  updatePhone,
+  updateUrl,
+} from '$lib/api/collectives';
+import type {
+  Address,
+  AddressInput,
+  Email,
+  EmailInput,
+  Phone,
+  PhoneInput,
+  Url,
+  UrlInput,
+} from '$shared';
+import {
+  AddressEditForm,
+  AddressRow,
+  CircleEditForm,
+  CircleRow,
+  EmailEditForm,
+  EmailRow,
+  PhoneEditForm,
+  PhoneRow,
+  UrlEditForm,
+  UrlRow,
+} from '../friends/subresources';
+
+/** Translation function (`$i18n.t`), passed in so descriptors stay UI-framework agnostic. */
+type Translate = (key: string, params?: Record<string, unknown>) => string;
+
+export type SubresourceItem = Phone | Email | Address | Url | CollectiveCircleInfo;
+type SubresourceInput = PhoneInput | EmailInput | AddressInput | UrlInput | { circleId: string };
+
+/** Methods every edit form exposes via `bind:this`. */
+export type SubresourceFormExports = { getData: () => unknown; isValid: () => boolean };
+/** Edit form component whose instance (`bind:this`) exposes {@link SubresourceFormExports}. */
+type SubresourceFormComponent = Component<Record<string, unknown>, SubresourceFormExports>;
+const asFormComponent = (component: unknown): SubresourceFormComponent =>
+  component as SubresourceFormComponent;
+
+/** Context handed to `formProps` so it can build the right props for each edit form. */
+export interface FormPropsContext {
+  editingData: SubresourceItem | null;
+  editingId: string | null;
+  itemCount: number;
+  items: SubresourceItem[];
+  isLoading: boolean;
+}
+
+export interface SubresourceDescriptor {
+  key: 'phone' | 'email' | 'address' | 'url' | 'circle';
+  /** Window event the keyboard system dispatches to open this section's add modal. */
+  shortcutEvent: string;
+  icon: Component;
+  /** i18n key for the section heading. */
+  sectionTitleKey: string;
+  /** i18n key for the "Add …" button label. */
+  addLabelKey: string;
+  /** `data-shortcut` chord shown on the add button (e.g. "a p"). */
+  addShortcut: string;
+  /** `data-shortcut-label` i18n key for the add button. */
+  addShortcutLabel: string;
+  /** Circle is add-only (no inline edit). */
+  editable: boolean;
+  /** i18n key for the type name in the add/edit modal title; falls back to `modalTypeNameLiteral`. */
+  modalTypeNameKey?: string;
+  /** Literal type name when there is no i18n key (circle preserves the original 'Circle'). */
+  modalTypeNameLiteral?: string;
+  load: (collectiveId: string) => Promise<SubresourceItem[]>;
+  create: (
+    collectiveId: string,
+    data: SubresourceInput,
+  ) => Promise<SubresourceItem | { message: string }>;
+  update?: (collectiveId: string, id: string, data: SubresourceInput) => Promise<SubresourceItem>;
+  remove: (collectiveId: string, id: string) => Promise<unknown>;
+  /** When the create/remove API returns only a message (circle), reload instead of patching locally. */
+  reloadAfterMutate?: boolean;
+  /**
+   * Wire the edit form's `onchange` to dirty-tracking, so `DetailEditModal`
+   * prompts about unsaved changes on close. Pre-refactor only the circle form
+   * did this; phone/email/address/url intentionally never prompted.
+   */
+  tracksDirty?: boolean;
+  /** Side effect scheduled after a successful save (address geocoding refetch). */
+  afterSave?: (reload: () => Promise<void>) => void;
+  FormComponent: SubresourceFormComponent;
+  formProps: (ctx: FormPropsContext) => Record<string, unknown>;
+  RowComponent: Component;
+  rowProps: (item: SubresourceItem) => Record<string, unknown>;
+  /** Preview text shown in the delete-confirm modal. */
+  deleteName: (item: SubresourceItem, t: Translate) => string;
+  /** Literal delete-modal title (preserves the original hardcoded English). */
+  deleteTitle: string;
+  /** Literal delete-modal description. */
+  deleteDescription: string;
+  /** Optional type-specific error mapping (phone unknown-country hint). */
+  mapError?: (err: unknown, t: Translate) => string | undefined;
+}
+
+const phoneDescriptor: SubresourceDescriptor = {
+  key: 'phone',
+  shortcutEvent: 'shortcut:collective-add-phone',
+  icon: PhoneIcon,
+  sectionTitleKey: 'friendDetail.sections.phoneNumbers',
+  addLabelKey: 'friendDetail.actions.addPhone',
+  addShortcut: 'a p',
+  addShortcutLabel: 'shortcuts.add.phone',
+  editable: true,
+  modalTypeNameKey: 'friendDetail.modal.phoneNumber',
+  load: (cid) => listPhones(cid),
+  create: (cid, data) => addPhone(cid, data as PhoneInput),
+  update: (cid, id, data) => updatePhone(cid, id, data as PhoneInput),
+  remove: (cid, id) => deletePhone(cid, id),
+  FormComponent: asFormComponent(PhoneEditForm),
+  formProps: ({ editingData, editingId, itemCount, isLoading }) => ({
+    initialData: (editingData as Phone | null) ?? undefined,
+    defaultPrimary: !editingId && itemCount === 0,
+    disabled: isLoading,
+  }),
+  RowComponent: PhoneRow,
+  rowProps: (item) => ({ phone: item as Phone }),
+  deleteName: (item) => (item as Phone).phoneNumber,
+  deleteTitle: 'Delete Phone Number',
+  deleteDescription: 'Are you sure you want to delete this phone?',
+  mapError: (err, t) =>
+    err instanceof ApiError && err.code === 'PHONE_COUNTRY_UNKNOWN'
+      ? t('subresources.phone.unknownCountry')
+      : undefined,
+};
+
+const emailDescriptor: SubresourceDescriptor = {
+  key: 'email',
+  shortcutEvent: 'shortcut:collective-add-email',
+  icon: Envelope,
+  sectionTitleKey: 'friendDetail.sections.emailAddresses',
+  addLabelKey: 'friendDetail.actions.addEmail',
+  addShortcut: 'a e',
+  addShortcutLabel: 'shortcuts.add.email',
+  editable: true,
+  modalTypeNameKey: 'friendDetail.modal.emailAddress',
+  load: (cid) => listEmails(cid),
+  create: (cid, data) => addEmail(cid, data as EmailInput),
+  update: (cid, id, data) => updateEmail(cid, id, data as EmailInput),
+  remove: (cid, id) => deleteEmail(cid, id),
+  FormComponent: asFormComponent(EmailEditForm),
+  formProps: ({ editingData, editingId, itemCount, isLoading }) => ({
+    initialData: (editingData as Email | null) ?? undefined,
+    defaultPrimary: !editingId && itemCount === 0,
+    disabled: isLoading,
+  }),
+  RowComponent: EmailRow,
+  rowProps: (item) => ({ email: item as Email }),
+  deleteName: (item) => (item as Email).emailAddress,
+  deleteTitle: 'Delete Email Address',
+  deleteDescription: 'Are you sure you want to delete this email?',
+};
+
+const addressDescriptor: SubresourceDescriptor = {
+  key: 'address',
+  shortcutEvent: 'shortcut:collective-add-address',
+  icon: MapPin,
+  sectionTitleKey: 'friendDetail.sections.addresses',
+  addLabelKey: 'friendDetail.actions.addAddress',
+  addShortcut: 'a a',
+  addShortcutLabel: 'shortcuts.add.address',
+  editable: true,
+  modalTypeNameKey: 'friendDetail.modal.address',
+  load: (cid) => listAddresses(cid),
+  create: (cid, data) => addAddress(cid, data as AddressInput),
+  update: (cid, id, data) => updateAddress(cid, id, data as AddressInput),
+  remove: (cid, id) => deleteAddress(cid, id),
+  // Geocoding runs asynchronously on the backend; refetch a few times to pick up
+  // coordinates once they land.
+  afterSave: (reload) => {
+    for (const delay of [800, 2000, 4500]) {
+      setTimeout(() => {
+        reload().catch(() => undefined);
+      }, delay);
+    }
+  },
+  FormComponent: asFormComponent(AddressEditForm),
+  formProps: ({ editingData, editingId, itemCount, isLoading }) => ({
+    initialData: (editingData as Address | null) ?? undefined,
+    defaultPrimary: !editingId && itemCount === 0,
+    disabled: isLoading,
+  }),
+  RowComponent: AddressRow,
+  rowProps: (item) => ({ address: item as Address }),
+  deleteName: (item, t) => {
+    const address = item as Address;
+    return address.streetLine1 || address.city || t('subresources.address.thisAddress');
+  },
+  deleteTitle: 'Delete Address',
+  deleteDescription: 'Are you sure you want to delete this address?',
+};
+
+const urlDescriptor: SubresourceDescriptor = {
+  key: 'url',
+  shortcutEvent: 'shortcut:collective-add-url',
+  icon: Link,
+  sectionTitleKey: 'friendDetail.sections.websites',
+  addLabelKey: 'friendDetail.actions.addUrl',
+  addShortcut: 'a u',
+  addShortcutLabel: 'shortcuts.add.url',
+  editable: true,
+  modalTypeNameKey: 'friendDetail.modal.websiteUrl',
+  load: (cid) => listUrls(cid),
+  create: (cid, data) => addUrl(cid, data as UrlInput),
+  update: (cid, id, data) => updateUrl(cid, id, data as UrlInput),
+  remove: (cid, id) => deleteUrl(cid, id),
+  FormComponent: asFormComponent(UrlEditForm),
+  formProps: ({ editingData, isLoading }) => ({
+    initialData: (editingData as Url | null) ?? undefined,
+    disabled: isLoading,
+  }),
+  RowComponent: UrlRow,
+  rowProps: (item) => ({ url: item as Url }),
+  deleteName: (item) => (item as Url).url,
+  deleteTitle: 'Delete Website',
+  deleteDescription: 'Are you sure you want to delete this url?',
+};
+
+const circleDescriptor: SubresourceDescriptor = {
+  key: 'circle',
+  shortcutEvent: 'shortcut:collective-add-circle',
+  icon: Users,
+  sectionTitleKey: 'friendDetail.sections.circles',
+  addLabelKey: 'friendDetail.actions.addCircle',
+  addShortcut: 'a c',
+  addShortcutLabel: 'shortcuts.add.circle',
+  editable: false,
+  modalTypeNameLiteral: 'Circle',
+  load: (cid) => getCollectiveCircles(cid),
+  create: (cid, data) => addCollectiveToCircle(cid, (data as { circleId: string }).circleId),
+  remove: (cid, id) => removeCollectiveFromCircle(cid, id),
+  reloadAfterMutate: true,
+  tracksDirty: true,
+  FormComponent: asFormComponent(CircleEditForm),
+  formProps: ({ items, isLoading }) => ({
+    existingCircles: items as CollectiveCircleInfo[],
+    disabled: isLoading,
+  }),
+  RowComponent: CircleRow,
+  rowProps: (item) => ({ circle: item as CollectiveCircleInfo }),
+  deleteName: (item) => (item as CollectiveCircleInfo).name,
+  deleteTitle: 'Remove from Circle',
+  deleteDescription: 'Are you sure you want to remove this collective from this circle?',
+};
+
+/** Phone/email/address/url — rendered inside the contact-details wrapper, in this order. */
+export const contactDescriptors: SubresourceDescriptor[] = [
+  phoneDescriptor,
+  emailDescriptor,
+  addressDescriptor,
+  urlDescriptor,
+];
+
+/** Circle — rendered as its own top-level section, matching the original layout. */
+export { circleDescriptor };

--- a/apps/frontend/src/lib/components/collectives/subresource-section.svelte
+++ b/apps/frontend/src/lib/components/collectives/subresource-section.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import Plus from 'svelte-heros-v2/Plus.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+import { DeleteConfirmModal, DetailEditModal } from '../friends/subresources';
+import type {
+  SubresourceDescriptor,
+  SubresourceFormExports,
+  SubresourceItem,
+} from './subresource-descriptors';
+
+const i18n = createI18n();
+
+interface Props {
+  descriptor: SubresourceDescriptor;
+  collectiveId: string;
+  collectiveName: string;
+}
+
+let { descriptor, collectiveId, collectiveName }: Props = $props();
+
+// Local helper so descriptors (plain modules) can resolve translations.
+const translate = (key: string, params?: Record<string, unknown>): string => $i18n.t(key, params);
+
+// Loaded items for this sub-resource type
+let items = $state<SubresourceItem[]>([]);
+
+// Edit modal state
+let editingId = $state<string | null>(null);
+let editingData = $state<SubresourceItem | null>(null);
+let isAdding = $state(false);
+let isEditLoading = $state(false);
+let editError = $state<string | null>(null);
+let isDirty = $state(false);
+let formRef = $state<SubresourceFormExports | null>(null);
+
+// Delete state
+let deletingId = $state<string | null>(null);
+let deleteConfirmId = $state<string | null>(null);
+let deleteConfirmName = $state('');
+
+let showModal = $derived(isAdding || editingId !== null);
+
+// Dynamic components (Svelte 5 renders capitalised reactive values as components)
+let Icon = $derived(descriptor.icon);
+let RowComponent = $derived(descriptor.RowComponent);
+let FormComponent = $derived(descriptor.FormComponent);
+
+let modalTypeName = $derived(
+  descriptor.modalTypeNameKey
+    ? $i18n.t(descriptor.modalTypeNameKey)
+    : (descriptor.modalTypeNameLiteral ?? ''),
+);
+let modalTitle = $derived(
+  `${editingId ? $i18n.t('friendDetail.modal.edit') : $i18n.t('friendDetail.modal.add')} ${modalTypeName}`,
+);
+
+// Monotonic reload counter. Several reloads can be in flight for the *same*
+// collective (address afterSave schedules a few, reloadAfterMutate triggers
+// more), so an earlier slow response must not clobber a later one.
+let reloadSeq = 0;
+
+async function reload() {
+  const seq = ++reloadSeq;
+  const requestedId = collectiveId;
+  const loaded = await descriptor.load(requestedId);
+  // Drop stale responses: ignore this load if a newer one has since started, or
+  // if the collective changed while it was in flight. The latest reload wins.
+  if (seq !== reloadSeq || requestedId !== collectiveId) return;
+  items = loaded;
+}
+
+// Reset and reload whenever the collective changes. The parent keys this
+// component only by descriptor.key, so navigating between collectives reuses
+// the instance without unmounting — without a reset the previous collective's
+// items and any open edit/delete modal would linger (and mutations would then
+// target the new collectiveId).
+let loadedCollectiveId: string | undefined;
+$effect(() => {
+  const id = collectiveId;
+  if (id && id !== loadedCollectiveId) {
+    loadedCollectiveId = id;
+    items = [];
+    closeModal();
+    closeDeleteConfirm();
+    reload().catch((err) => console.error('Failed to load sub-resources:', err));
+  }
+});
+
+function openAdd() {
+  editingId = null;
+  editingData = null;
+  isAdding = true;
+  editError = null;
+  isDirty = false;
+}
+
+function openEdit(item: SubresourceItem) {
+  editingId = item.id;
+  editingData = item;
+  isAdding = false;
+  editError = null;
+  isDirty = false;
+}
+
+function closeModal() {
+  editingId = null;
+  editingData = null;
+  isAdding = false;
+  editError = null;
+  isDirty = false;
+  isEditLoading = false;
+}
+
+async function handleSave() {
+  if (!formRef || !formRef.isValid()) return;
+  isEditLoading = true;
+  editError = null;
+  try {
+    const data = formRef.getData() as Parameters<SubresourceDescriptor['create']>[1];
+    if (editingId && descriptor.update) {
+      const updated = await descriptor.update(collectiveId, editingId, data);
+      items = items.map((item) => (item.id === editingId ? updated : item));
+    } else if (descriptor.reloadAfterMutate) {
+      await descriptor.create(collectiveId, data);
+      await reload();
+    } else {
+      const created = (await descriptor.create(collectiveId, data)) as SubresourceItem;
+      items = [...items, created];
+    }
+    descriptor.afterSave?.(reload);
+    closeModal();
+  } catch (err) {
+    editError =
+      descriptor.mapError?.(err, translate) ??
+      (err as Error).message ??
+      $i18n.t('subresources.common.failedToSave');
+  } finally {
+    isEditLoading = false;
+  }
+}
+
+function openDeleteConfirm(item: SubresourceItem) {
+  deleteConfirmId = item.id;
+  deleteConfirmName = descriptor.deleteName(item, translate);
+}
+
+function closeDeleteConfirm() {
+  deleteConfirmId = null;
+  deleteConfirmName = '';
+}
+
+async function handleDelete() {
+  if (!deleteConfirmId) return;
+  const id = deleteConfirmId;
+  deletingId = id;
+  try {
+    await descriptor.remove(collectiveId, id);
+    if (descriptor.reloadAfterMutate) {
+      await reload();
+    } else {
+      items = items.filter((item) => item.id !== id);
+    }
+  } finally {
+    deletingId = null;
+  }
+}
+
+// Keyboard shortcut: open this section's add modal
+onMount(() => {
+  function handleAddShortcut() {
+    openAdd();
+  }
+  window.addEventListener(descriptor.shortcutEvent, handleAddShortcut);
+  return () => {
+    window.removeEventListener(descriptor.shortcutEvent, handleAddShortcut);
+  };
+});
+</script>
+
+{#if items.length > 0}
+  <section class="space-y-2">
+    <div class="flex items-center justify-between bg-forest text-white px-3 py-1.5 rounded-lg">
+      <h2 class="text-lg font-heading flex items-center gap-2">
+        <Icon class="w-5 h-5" strokeWidth="2" />
+        {$i18n.t(descriptor.sectionTitleKey)}
+      </h2>
+      <button
+        type="button"
+        onclick={openAdd}
+        class="text-sm font-body font-semibold text-white/90 hover:text-white
+               flex items-center gap-1 px-2 py-1 rounded hover:bg-white/10 transition-colors"
+        data-shortcut={descriptor.addShortcut}
+        data-shortcut-label={descriptor.addShortcutLabel}
+      >
+        <Plus class="w-4 h-4" strokeWidth="2" />
+        {$i18n.t(descriptor.addLabelKey)}
+      </button>
+    </div>
+    <div class="space-y-2">
+      {#each items as item (item.id)}
+        <RowComponent
+          {...descriptor.rowProps(item)}
+          onEdit={descriptor.editable ? () => openEdit(item) : undefined}
+          onDelete={() => openDeleteConfirm(item)}
+          isDeleting={deletingId === item.id}
+        />
+      {/each}
+    </div>
+  </section>
+{/if}
+
+{#if showModal}
+  <DetailEditModal
+    title={modalTitle}
+    subtitle={collectiveName}
+    isLoading={isEditLoading}
+    error={editError}
+    {isDirty}
+    onSave={handleSave}
+    onClose={closeModal}
+  >
+    <FormComponent
+      bind:this={formRef}
+      {...descriptor.formProps({
+        editingData,
+        editingId,
+        itemCount: items.length,
+        items,
+        isLoading: isEditLoading,
+      })}
+      onchange={descriptor.tracksDirty ? () => (isDirty = true) : undefined}
+    />
+  </DetailEditModal>
+{/if}
+
+{#if deleteConfirmId}
+  <DeleteConfirmModal
+    title={descriptor.deleteTitle}
+    description={descriptor.deleteDescription}
+    itemPreview={deleteConfirmName}
+    onConfirm={handleDelete}
+    onClose={closeDeleteConfirm}
+  />
+{/if}

--- a/apps/frontend/src/lib/components/collectives/subresource-section.test.ts
+++ b/apps/frontend/src/lib/components/collectives/subresource-section.test.ts
@@ -1,0 +1,333 @@
+import PhoneIcon from 'svelte-heros-v2/Phone.svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { aPhone, fireEvent, render, screen, waitFor } from '$lib/test';
+import { CircleRow, PhoneEditForm, PhoneRow } from '../friends/subresources';
+import type { SubresourceDescriptor, SubresourceItem } from './subresource-descriptors';
+import SubresourceSection from './subresource-section.svelte';
+
+// Echo i18n keys so titles/labels are assertable without translation files.
+vi.mock('$lib/i18n/index.js', () => ({
+  createI18n: () => ({
+    subscribe: (run: (v: { t: (k: string) => string }) => void) => {
+      run({ t: (k: string) => k });
+      return () => undefined;
+    },
+  }),
+}));
+
+/**
+ * The generic section is driven entirely by its descriptor, so tests inject a
+ * fake one: real Row/Form components for rendering, but vi.fn() CRUD closures —
+ * no API module mocking required.
+ */
+function fakePhoneDescriptor(
+  overrides: Partial<SubresourceDescriptor> = {},
+): SubresourceDescriptor {
+  return {
+    key: 'phone',
+    shortcutEvent: 'shortcut:test-add',
+    icon: PhoneIcon,
+    sectionTitleKey: 'section.title',
+    addLabelKey: 'section.add',
+    addShortcut: 'a p',
+    addShortcutLabel: 'shortcuts.add.phone',
+    editable: true,
+    modalTypeNameKey: 'modal.type',
+    load: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn().mockResolvedValue({ message: 'ok' }),
+    FormComponent: PhoneEditForm as unknown as SubresourceDescriptor['FormComponent'],
+    formProps: ({ editingData }) => ({ initialData: editingData ?? undefined }),
+    RowComponent: PhoneRow as unknown as SubresourceDescriptor['RowComponent'],
+    rowProps: (item) => ({ phone: item }),
+    deleteName: (item) => (item as ReturnType<typeof aPhone>).phoneNumber,
+    deleteTitle: 'Delete Phone Number',
+    deleteDescription: 'Are you sure?',
+    ...overrides,
+  } as SubresourceDescriptor;
+}
+
+function renderSection(descriptor: SubresourceDescriptor) {
+  return render(SubresourceSection, {
+    descriptor,
+    collectiveId: 'c1',
+    collectiveName: 'Test Collective',
+  });
+}
+
+describe('SubresourceSection', () => {
+  it('renders loaded items as rows under the section heading', async () => {
+    const descriptor = fakePhoneDescriptor({
+      load: vi.fn().mockResolvedValue([aPhone({ phoneNumber: '+1 555 0100' })]),
+    });
+    renderSection(descriptor);
+
+    expect(await screen.findByText('section.title')).toBeTruthy();
+    expect((await screen.findAllByText('+1 555 0100')).length).toBeGreaterThan(0);
+    expect(descriptor.load).toHaveBeenCalledWith('c1');
+  });
+
+  it('opens the add modal from the header button', async () => {
+    renderSection(fakePhoneDescriptor({ load: vi.fn().mockResolvedValue([aPhone()]) }));
+
+    await fireEvent.click(await screen.findByText('section.add'));
+    // modalTitle = `${add} ${typeName}` with echoed keys
+    expect(await screen.findByText('friendDetail.modal.add modal.type')).toBeTruthy();
+  });
+
+  it('opens the add modal via the keyboard shortcut even when the section is empty', async () => {
+    renderSection(fakePhoneDescriptor({ load: vi.fn().mockResolvedValue([]) }));
+
+    // Empty section renders no header, but the shortcut listener is still mounted.
+    await waitFor(() => expect(screen.queryByText('section.add')).toBeNull());
+    window.dispatchEvent(new CustomEvent('shortcut:test-add'));
+
+    expect(await screen.findByText('friendDetail.modal.add modal.type')).toBeTruthy();
+  });
+
+  it('creates a new item and appends it to the list', async () => {
+    const created = aPhone({ phoneNumber: '+49 30 9999' });
+    const create = vi.fn().mockResolvedValue(created);
+    const descriptor = fakePhoneDescriptor({
+      load: vi.fn().mockResolvedValue([aPhone({ phoneNumber: '+1 555 0100' })]),
+      create,
+    });
+    renderSection(descriptor);
+
+    await fireEvent.click(await screen.findByText('section.add'));
+    await fireEvent.input(await screen.findByLabelText(/subresources\.phone\.phoneNumber/), {
+      target: { value: '+49 30 9999' },
+    });
+    await fireEvent.click(screen.getByText('subresources.common.save'));
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(create).toHaveBeenCalledWith(
+      'c1',
+      expect.objectContaining({ phone_number: '+49 30 9999' }),
+    );
+    expect((await screen.findAllByText('+49 30 9999')).length).toBeGreaterThan(0);
+  });
+
+  it('edits an existing row, calls update, and replaces it in the list', async () => {
+    const phone = aPhone({ phoneNumber: '+1 555 0100' });
+    const updated = aPhone({ id: phone.id, phoneNumber: '+1 555 0200' });
+    const update = vi.fn().mockResolvedValue(updated);
+    const descriptor = fakePhoneDescriptor({
+      load: vi.fn().mockResolvedValue([phone]),
+      update,
+    });
+    renderSection(descriptor);
+
+    await fireEvent.click((await screen.findAllByLabelText('Edit phone'))[0]);
+    expect(await screen.findByText('friendDetail.modal.edit modal.type')).toBeTruthy();
+
+    await fireEvent.input(await screen.findByLabelText(/subresources\.phone\.phoneNumber/), {
+      target: { value: '+1 555 0200' },
+    });
+    await fireEvent.click(screen.getByText('subresources.common.save'));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update).toHaveBeenCalledWith(
+      'c1',
+      phone.id,
+      expect.objectContaining({ phone_number: '+1 555 0200' }),
+    );
+    expect((await screen.findAllByText('+1 555 0200')).length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.queryAllByText('+1 555 0100')).toHaveLength(0));
+  });
+
+  it('confirms deletion, calls remove, and drops the row', async () => {
+    const phone = aPhone({ phoneNumber: '+1 555 0100' });
+    const remove = vi.fn().mockResolvedValue({ message: 'ok' });
+    const descriptor = fakePhoneDescriptor({
+      load: vi.fn().mockResolvedValue([phone]),
+      remove,
+    });
+    renderSection(descriptor);
+
+    await fireEvent.click((await screen.findAllByLabelText('Delete phone'))[0]);
+    expect(await screen.findByText('Delete Phone Number')).toBeTruthy();
+
+    await fireEvent.click(screen.getByText('subresources.common.delete'));
+    await waitFor(() => expect(remove).toHaveBeenCalledWith('c1', phone.id));
+    await waitFor(() => expect(screen.queryAllByText('+1 555 0100')).toHaveLength(0));
+  });
+
+  it('reloads instead of patching locally when the descriptor sets reloadAfterMutate (circle)', async () => {
+    const first = aPhone({ phoneNumber: '+1 555 0100' });
+    const second = aPhone({ phoneNumber: '+1 555 0200' });
+    // Circle-style: create/remove return only a message, so the section reloads.
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([first, second])
+      .mockResolvedValue([first]);
+    const create = vi.fn().mockResolvedValue({ message: 'added' });
+    const remove = vi.fn().mockResolvedValue({ message: 'removed' });
+    const descriptor = fakePhoneDescriptor({ load, create, remove, reloadAfterMutate: true });
+    renderSection(descriptor);
+
+    // Create -> create() then reload() surfaces the second item.
+    await fireEvent.click(await screen.findByText('section.add'));
+    await fireEvent.input(await screen.findByLabelText(/subresources\.phone\.phoneNumber/), {
+      target: { value: '+1 555 0200' },
+    });
+    await fireEvent.click(screen.getByText('subresources.common.save'));
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect((await screen.findAllByText('+1 555 0200')).length).toBeGreaterThan(0);
+
+    // Delete -> remove() then reload() drops it again.
+    await fireEvent.click((await screen.findAllByLabelText('Delete phone'))[0]);
+    await fireEvent.click(screen.getByText('subresources.common.delete'));
+    await waitFor(() => expect(remove).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryAllByText('+1 555 0200')).toHaveLength(0));
+  });
+
+  it('ignores a stale load when the collective changes while a request is in flight', async () => {
+    // Deferred loads let us resolve the old collective's request *after* the new one.
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+    const first = deferred<SubresourceItem[]>();
+    const second = deferred<SubresourceItem[]>();
+    const load = vi.fn((id: string) => (id === 'c1' ? first.promise : second.promise));
+    const descriptor = fakePhoneDescriptor({ load });
+
+    const { rerender } = render(SubresourceSection, {
+      descriptor,
+      collectiveId: 'c1',
+      collectiveName: 'Test Collective',
+    });
+
+    // Switch to a new collective; its (faster) response lands first.
+    await rerender({ descriptor, collectiveId: 'c2', collectiveName: 'Test Collective' });
+    second.resolve([aPhone({ phoneNumber: '+2 222' })]);
+    expect((await screen.findAllByText('+2 222')).length).toBeGreaterThan(0);
+
+    // The previous collective's slow response resolves late and must be dropped.
+    first.resolve([aPhone({ phoneNumber: '+1 111' })]);
+    await waitFor(() => expect(load).toHaveBeenCalledWith('c2'));
+    expect(screen.queryByText('+1 111')).toBeNull();
+    expect((await screen.findAllByText('+2 222')).length).toBeGreaterThan(0);
+  });
+
+  it('resets items and any open modal when the collective changes', async () => {
+    const phoneC1 = aPhone({ phoneNumber: '+1 555 0100' });
+    const phoneC2 = aPhone({ phoneNumber: '+2 222 0000' });
+    const load = vi.fn((id: string) => Promise.resolve(id === 'c1' ? [phoneC1] : [phoneC2]));
+    const descriptor = fakePhoneDescriptor({ load });
+
+    const { rerender } = render(SubresourceSection, {
+      descriptor,
+      collectiveId: 'c1',
+      collectiveName: 'Test Collective',
+    });
+
+    // Open the edit modal on the first collective.
+    await fireEvent.click((await screen.findAllByLabelText('Edit phone'))[0]);
+    expect(await screen.findByText('friendDetail.modal.edit modal.type')).toBeTruthy();
+
+    // Navigate to another collective without unmounting the component.
+    await rerender({ descriptor, collectiveId: 'c2', collectiveName: 'Test Collective' });
+
+    // Stale modal is closed, the previous item is gone, the new one is loaded.
+    await waitFor(() =>
+      expect(screen.queryByText('friendDetail.modal.edit modal.type')).toBeNull(),
+    );
+    await waitFor(() => expect(load).toHaveBeenCalledWith('c2'));
+    expect((await screen.findAllByText('+2 222 0000')).length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.queryAllByText('+1 555 0100')).toHaveLength(0));
+  });
+
+  it('does not prompt about unsaved changes for forms that do not opt into dirty tracking', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderSection(fakePhoneDescriptor({ load: vi.fn().mockResolvedValue([aPhone()]) }));
+
+    await fireEvent.click(await screen.findByText('section.add'));
+    await fireEvent.input(await screen.findByLabelText(/subresources\.phone\.phoneNumber/), {
+      target: { value: '+1 555 9999' },
+    });
+    // Close via the modal X. Without tracksDirty the modal must not prompt.
+    await fireEvent.click(screen.getByLabelText('subresources.common.close'));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByText('friendDetail.modal.add modal.type')).toBeNull());
+    confirmSpy.mockRestore();
+  });
+
+  it('prompts about unsaved changes when the descriptor opts into dirty tracking (circle)', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderSection(
+      fakePhoneDescriptor({ tracksDirty: true, load: vi.fn().mockResolvedValue([aPhone()]) }),
+    );
+
+    await fireEvent.click(await screen.findByText('section.add'));
+    await fireEvent.input(await screen.findByLabelText(/subresources\.phone\.phoneNumber/), {
+      target: { value: '+1 555 9999' },
+    });
+    await fireEvent.click(screen.getByLabelText('subresources.common.close'));
+
+    // Dirty -> DetailEditModal asks before discarding (confirm stubbed to cancel).
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('ignores an out-of-order reload for the same collective so the latest wins', async () => {
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+    const mountLoad = deferred<SubresourceItem[]>();
+    const reloadLoad = deferred<SubresourceItem[]>();
+    const pending = [mountLoad.promise, reloadLoad.promise];
+    let call = 0;
+    const load = vi.fn(() => pending[call++]);
+    // reloadAfterMutate makes create() trigger a second reload for the same id.
+    const descriptor = fakePhoneDescriptor({
+      load,
+      create: vi.fn().mockResolvedValue({ message: 'added' }),
+      reloadAfterMutate: true,
+    });
+    renderSection(descriptor);
+
+    // Empty section (mount load still pending) — open via the shortcut and save.
+    window.dispatchEvent(new CustomEvent('shortcut:test-add'));
+    await fireEvent.input(await screen.findByLabelText(/subresources\.phone\.phoneNumber/), {
+      target: { value: '+1 555 0100' },
+    });
+    await fireEvent.click(screen.getByText('subresources.common.save'));
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+
+    // The later reload resolves first; the earlier (mount) reload resolves late
+    // and must be dropped rather than reverting the list.
+    reloadLoad.resolve([aPhone({ phoneNumber: '+2 222 0000' })]);
+    expect((await screen.findAllByText('+2 222 0000')).length).toBeGreaterThan(0);
+    mountLoad.resolve([aPhone({ phoneNumber: '+1 111 0000' })]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(screen.queryByText('+1 111 0000')).toBeNull();
+    expect((await screen.findAllByText('+2 222 0000')).length).toBeGreaterThan(0);
+  });
+
+  it('omits the edit affordance for a non-editable (circle-style) descriptor', async () => {
+    const descriptor = fakePhoneDescriptor({
+      editable: false,
+      RowComponent: CircleRow as unknown as SubresourceDescriptor['RowComponent'],
+      rowProps: (item) => ({ circle: { id: item.id, name: 'Inner', color: null } }),
+      load: vi.fn().mockResolvedValue([aPhone()]),
+    });
+    renderSection(descriptor);
+
+    // CircleRow exposes only a remove action, no edit button.
+    expect((await screen.findAllByLabelText('Remove from circle')).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText('Edit phone')).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/components/friends/subresources/detail-edit-modal.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/detail-edit-modal.svelte
@@ -14,6 +14,13 @@ interface Props {
   isDirty?: boolean;
   /** Hide the footer Cancel/Save buttons (useful when children have their own buttons) */
   hideFooter?: boolean;
+  /**
+   * Wrap the content in a `<form>` (default). Set to false when the children
+   * render their own `<form>`, to avoid invalid nested forms. The footer Save
+   * button stays functional either way: it submits the form when true, and
+   * calls `onSave` directly when false.
+   */
+  asForm?: boolean;
   onSave: () => void;
   onClose: () => void;
   children: Snippet;
@@ -26,6 +33,7 @@ let {
   error = null,
   isDirty = false,
   hideFooter = false,
+  asForm = true,
   onSave,
   onClose,
   children,
@@ -101,8 +109,9 @@ function handleSubmit(e: Event) {
       </button>
     </div>
 
-    <!-- Form -->
-    <form onsubmit={handleSubmit} class="flex flex-col flex-1 overflow-hidden">
+    <!-- Form body. Rendered inside a <form> by default, or a plain <div> when
+         asForm is false (children supply their own <form>) to avoid nesting. -->
+    {#snippet body()}
       <!-- Scrollable content area -->
       <div class="p-4 space-y-4 overflow-y-auto flex-1">
         {@render children()}
@@ -128,7 +137,8 @@ function handleSubmit(e: Event) {
           {$i18n.t('subresources.common.cancel')}
         </button>
         <button
-          type="submit"
+          type={asForm ? 'submit' : 'button'}
+          onclick={asForm ? undefined : onSave}
           disabled={isLoading}
           class="flex-1 px-4 py-2 bg-forest text-white rounded-lg font-body font-semibold
                  hover:bg-forest-light transition-colors disabled:opacity-50
@@ -150,6 +160,16 @@ function handleSubmit(e: Event) {
         </button>
       </div>
       {/if}
-    </form>
+    {/snippet}
+
+    {#if asForm}
+      <form onsubmit={handleSubmit} class="flex flex-col flex-1 overflow-hidden">
+        {@render body()}
+      </form>
+    {:else}
+      <div class="flex flex-col flex-1 overflow-hidden">
+        {@render body()}
+      </div>
+    {/if}
   </div>
 </div>

--- a/apps/frontend/src/lib/components/friends/subresources/detail-edit-modal.test.ts
+++ b/apps/frontend/src/lib/components/friends/subresources/detail-edit-modal.test.ts
@@ -1,0 +1,49 @@
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '$lib/test';
+import DetailEditModal from './detail-edit-modal.svelte';
+
+vi.mock('$lib/i18n/index.js', () => ({
+  createI18n: () => ({
+    subscribe: (run: (v: { t: (k: string) => string }) => void) => {
+      run({ t: (k: string) => k });
+      return () => undefined;
+    },
+  }),
+}));
+
+const children = createRawSnippet(() => ({
+  render: () => '<p>body content</p>',
+}));
+
+describe('DetailEditModal', () => {
+  it('wraps content in a <form> by default and saves via submit', async () => {
+    const onSave = vi.fn();
+    const { container } = render(DetailEditModal, {
+      title: 'Edit',
+      onSave,
+      onClose: vi.fn(),
+      children,
+    });
+
+    expect(container.querySelectorAll('form')).toHaveLength(1);
+    await fireEvent.click(screen.getByText('subresources.common.save'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no <form> when asForm is false, and the footer Save still calls onSave', async () => {
+    const onSave = vi.fn();
+    const { container } = render(DetailEditModal, {
+      title: 'Edit',
+      asForm: false,
+      onSave,
+      onClose: vi.fn(),
+      children,
+    });
+
+    // No surrounding form, so the button is type=button calling onSave directly.
+    expect(container.querySelectorAll('form')).toHaveLength(0);
+    await fireEvent.click(screen.getByText('subresources.common.save'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #187.

## What

`collective-detail.svelte` (893 LOC) was the lone grab-bag component flagged in the PR #186 review — it mixed the header/notes template, collective-delete state, per-subresource CRUD for five types, member lifecycle, and keyboard wiring via a central `editingType` discriminator with a parallel `if/else` save chain and a `switch` delete chain.

This decomposes it **behavior-preservingly**, using a data-driven descriptor (per the issue's first bullet) plus an extracted member section:

| File | Role |
|---|---|
| `subresource-descriptors.ts` | One descriptor per type (phone/email/address/url/circle): icon, i18n keys, API calls, Row/Form components, and per-type quirks (address geocoding refetch, circle add-only) |
| `subresource-section.svelte` | A single **generic, branch-free** section driven by a descriptor — owns its CRUD/modal/delete state and add-shortcut listener, mirroring the friend section lifecycle |
| `member-section.svelte` | Member list, add-member modal, deactivate modal, the member add-shortcut, and the `visibleMemberContactIds` effect |
| `collective-detail.svelte` | Thin container (**893 → 193 LOC**) — header, notes, collective-delete confirmation, and section/member orchestration |

The central `if/else` save chain and `switch` delete chain collapse into the descriptor table. Reuses the existing `friends/subresources` shared components, the `$lib/api/collectives` CRUD fns, and the same markup/strings/shortcuts, so behavior is unchanged. Sections are always-mounted so the add-shortcut works even when a section is empty. Drops the dead `availableCircles` fetch (`CircleEditForm` uses the current circles).

## Tests

Adds the collective component's first coverage via the `$lib/test` infra from PR #186:
- `subresource-descriptors.test.ts` — delete-name extraction, row-prop mapping, editable/error mapping
- `subresource-section.test.ts` — render, add, create, delete, shortcut-opens-when-empty, non-editable affordance (injects a fake descriptor with `vi.fn()` CRUD — no API mocking needed)
- `member-section.test.ts` — member render, add modal, deactivate/reactivate/remove through the store

## Verification

- `aube type-check` / svelte-check: **0 errors**
- Full frontend suite: **239 passing** (17 new)
- Production build compiles the `collectives/[id]` route
- Manual in-browser pass (`aube dev`) still pending — see the #187 checklist

## Acceptance criteria
- [x] No behavioral change (add/edit/delete each subresource, member lifecycle, shortcuts) — preserved via shared components/API/markup; covered by tests
- [x] Component test coverage for the extracted pieces (uses `$lib/test`)
- [x] `aube type-check`, `aube run check`, and the full test suite pass
- [ ] Manually verified in-browser (`aube dev`) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)