### PR TITLE
Make wrapClient idempotent to prevent stack overflow on pooled clients

### DIFF
--- a/apps/backend/src/utils/db.ts
+++ b/apps/backend/src/utils/db.ts
@@ -29,7 +29,10 @@ function enhanceErrorWithStack(error: unknown, callSiteStack: string): Error {
 // client once it's wrapped prevents re-wrapping its `query` on every checkout,
 // which would otherwise nest the wrapper deeper each time until invoking
 // `client.query` overflows the call stack ("Maximum call stack size exceeded").
-const WRAPPED = Symbol('freundebuch.queryWrapped');
+// Symbol.for keeps the marker stable across module instances (e.g. tooling
+// resolving both db.js and db.ts), so a client wrapped by one instance is still
+// recognised as wrapped by another.
+const WRAPPED = Symbol.for('freundebuch.queryWrapped');
 
 /**
  * Wraps a pg.PoolClient to capture stack traces for query errors.

--- a/apps/backend/src/utils/db.ts
+++ b/apps/backend/src/utils/db.ts
@@ -25,10 +25,25 @@ function enhanceErrorWithStack(error: unknown, callSiteStack: string): Error {
   return err;
 }
 
+// Pooled clients are long-lived and reused across many checkouts. Marking a
+// client once it's wrapped prevents re-wrapping its `query` on every checkout,
+// which would otherwise nest the wrapper deeper each time until invoking
+// `client.query` overflows the call stack ("Maximum call stack size exceeded").
+const WRAPPED = Symbol('freundebuch.queryWrapped');
+
 /**
- * Wraps a pg.PoolClient to capture stack traces for query errors
+ * Wraps a pg.PoolClient to capture stack traces for query errors.
+ * Idempotent: a client whose query is already wrapped is returned unchanged,
+ * so reusing a pooled client never stacks wrappers.
+ *
+ * Exported for testing.
  */
-function wrapClient(client: pg.PoolClient): pg.PoolClient {
+export function wrapClient(client: pg.PoolClient): pg.PoolClient {
+  // biome-ignore lint/suspicious/noExplicitAny: marker property on the pg client
+  if ((client as any)[WRAPPED]) {
+    return client;
+  }
+
   // biome-ignore lint/suspicious/noExplicitAny: preserving pg's query overload signature
   const originalQuery: (...args: any[]) => any = client.query.bind(client);
 
@@ -55,6 +70,8 @@ function wrapClient(client: pg.PoolClient): pg.PoolClient {
 
   // biome-ignore lint/suspicious/noExplicitAny: matching pg's query signature
   client.query = wrappedQuery as any;
+  // biome-ignore lint/suspicious/noExplicitAny: marker property on the pg client
+  (client as any)[WRAPPED] = true;
 
   return client;
 }

--- a/apps/backend/tests/db.test.ts
+++ b/apps/backend/tests/db.test.ts
@@ -6,6 +6,7 @@ import {
   closePool,
   createPool,
   setupGracefulShutdown,
+  wrapClient,
 } from '../src/utils/db.js';
 
 // Mock pg module - use regular function to allow constructor usage
@@ -102,6 +103,44 @@ describe('db.ts', () => {
         statement_timeout: 30000,
         query_timeout: 30000,
       });
+    });
+  });
+
+  describe('wrapClient', () => {
+    it('wraps the client query exactly once across repeated checkouts', async () => {
+      // Pooled clients are reused: the pool calls wrapClient on the same
+      // physical client object every time it's checked out. Re-wrapping would
+      // nest the query wrapper one level deeper each time until invoking
+      // client.query overflows the call stack. Wrapping must be idempotent.
+      const realQuery = vi.fn().mockResolvedValue({ rows: [] });
+      const client = { query: realQuery } as unknown as pg.PoolClient;
+
+      const first = wrapClient(client);
+      const wrappedQuery = first.query;
+      expect(wrappedQuery).not.toBe(realQuery);
+
+      // Simulate many subsequent checkouts of the same pooled client.
+      for (let i = 0; i < 50; i++) {
+        const again = wrapClient(client);
+        expect(again).toBe(client);
+        // The query reference must stay stable — no additional wrapper layers.
+        expect(again.query).toBe(wrappedQuery);
+      }
+
+      // The wrapper still delegates to the original query exactly once.
+      await client.query('SELECT 1');
+      expect(realQuery).toHaveBeenCalledTimes(1);
+      expect(realQuery).toHaveBeenCalledWith('SELECT 1');
+    });
+
+    it('preserves the application stack trace on query rejection', async () => {
+      const dbError = new Error('boom');
+      const realQuery = vi.fn().mockRejectedValue(dbError);
+      const client = { query: realQuery } as unknown as pg.PoolClient;
+
+      wrapClient(client);
+
+      await expect(client.query('SELECT 1')).rejects.toThrow('boom');
     });
   });
 

--- a/apps/backend/tests/db.test.ts
+++ b/apps/backend/tests/db.test.ts
@@ -21,14 +21,6 @@ vi.mock('pg', () => {
   };
 });
 
-// Mock the db module to reset pool between tests
-vi.mock('../src/utils/db.ts', async () => {
-  const actual = await vi.importActual('../src/utils/db.ts');
-  return {
-    ...actual,
-  };
-});
-
 describe('db.ts', () => {
   beforeEach(() => {
     // Set required environment variables

--- a/apps/backend/tests/db.test.ts
+++ b/apps/backend/tests/db.test.ts
@@ -133,14 +133,28 @@ describe('db.ts', () => {
       expect(realQuery).toHaveBeenCalledWith('SELECT 1');
     });
 
-    it('preserves the application stack trace on query rejection', async () => {
+    it('enhances the rejection with the call-site stack trace', async () => {
       const dbError = new Error('boom');
       const realQuery = vi.fn().mockRejectedValue(dbError);
       const client = { query: realQuery } as unknown as pg.PoolClient;
 
       wrapClient(client);
 
-      await expect(client.query('SELECT 1')).rejects.toThrow('boom');
+      const rejection = await client.query('SELECT 1').then(
+        () => {
+          throw new Error('expected query to reject');
+        },
+        (err: unknown) => err as Error,
+      );
+
+      // The original DB error is preserved...
+      expect(rejection.message).toBe('boom');
+      // ...and the wrapper appended the call-site marker. Asserting only the
+      // message would still pass if enhanceErrorWithStack regressed.
+      expect(rejection.stack).toContain('--- Query initiated from ---');
+      // The appended section must carry real call-site frames, not just the marker.
+      const [, callSite = ''] = (rejection.stack ?? '').split('--- Query initiated from ---');
+      expect(callSite).toMatch(/\bat\b/);
     });
   });
 


### PR DESCRIPTION
## Summary
Fixed a critical bug where reusing pooled database clients would cause stack overflow errors by preventing the query wrapper from being applied multiple times to the same client.

## Key Changes
- Made `wrapClient()` idempotent by tracking wrapped clients with a Symbol marker (`WRAPPED`)
- When a client is checked out from the pool multiple times, `wrapClient()` now returns it unchanged instead of wrapping the query method again
- Exported `wrapClient()` for testing purposes
- Added comprehensive test coverage for idempotency and error handling

## Implementation Details
- Uses a Symbol property (`WRAPPED`) to mark clients that have already been wrapped, avoiding property name collisions
- The wrapper still delegates to the original query exactly once, preserving the error handling and stack trace enhancement behavior
- This prevents the wrapper from nesting deeper on each pool checkout, which would eventually cause "Maximum call stack size exceeded" errors during long-running applications that reuse pooled connections

https://claude.ai/code/session_01MKxNmLHzc7ygiEWQYHXwgP