### PR TITLE
chore(all): Fix lint findings and ignore installed skill dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ hk.local.pkl
 *.swo
 *~
 
+# Locally installed Claude Code skills (not project source)
+.claude/skills/
+.github/skills/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -17,15 +17,16 @@ function createAuth() {
 
   // Better Auth requires search_path=auth, so it needs its own pool.
   // Pool sizes are halved from the main pool to keep total connections in check.
-  _authPool = new Pool({
+  const authPool = new Pool({
     connectionString: config.DATABASE_URL,
     options: '-c search_path=auth',
     min: Math.max(1, Math.floor(config.DATABASE_POOL_MIN / 2)),
     max: Math.max(2, Math.floor(config.DATABASE_POOL_MAX / 2)),
   });
+  _authPool = authPool;
 
   return betterAuth({
-    database: _authPool,
+    database: authPool,
     basePath: '/api/auth',
     secret: config.BETTER_AUTH_SECRET,
     logger: {
@@ -157,7 +158,7 @@ function createAuth() {
             // Keep legacy auth.users in sync during transition period.
             // friends.friends.user_id is an integer FK to auth.users.id,
             // so new sign-ups need a legacy row until the FK is migrated.
-            await createLegacyUserForBetterAuth.run({ email: user.email }, _authPool!);
+            await createLegacyUserForBetterAuth.run({ email: user.email }, authPool);
           },
         },
       },

--- a/apps/frontend/src/lib/components/friends/subresources/relationship-edit-form.svelte
+++ b/apps/frontend/src/lib/components/friends/subresources/relationship-edit-form.svelte
@@ -72,8 +72,11 @@ export function getData(): {
   relationship_type_id: RelationshipTypeId;
   notes?: string;
 } {
+  if (!selectedFriend) {
+    throw new Error('getData() called without a selected friend; guard with isValid() first');
+  }
   return {
-    related_friend_id: selectedFriend!.id,
+    related_friend_id: selectedFriend.id,
     relationship_type_id: relationshipTypeId,
     notes: notes.trim() || undefined,
   };

--- a/apps/frontend/src/lib/components/friends/subresources/url-row.test.ts
+++ b/apps/frontend/src/lib/components/friends/subresources/url-row.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { aUrl, fireEvent, render, screen } from '$lib/test';
+import { aUrl, render, screen } from '$lib/test';
 import UrlRow from './url-row.svelte';
 
 // Renders twice (mobile + desktop), so queries use *All*.


### PR DESCRIPTION
## What

Clears the Biome lint findings in project source and stops local Claude Code skill installs from polluting lint/git.

### Lint fixes
- **auth.ts** — capture the auth pool in a local `const` so the create hook no longer needs a non-null assertion on the module-level `let`
- **relationship-edit-form.svelte** — guard `getData()` with an explicit null check instead of a non-null assertion
- **url-row.test.ts** — drop the unused `fireEvent` import

### Skill dirs
- gitignore `.claude/skills` and `.github/skills` — these hold a locally installed skill (`impeccable`), not project source, and nothing in the repo depends on them. Biome's `useIgnoreFile` then skips them too, so no separate lint exclusion is needed.

## Notes
- One pre-existing internal Biome crash on `editor/inline-preview/inline-preview.ts` (already in the ignore list) is unrelated and untouched.

## Test
- `npx biome lint .` — clean
- pre-push gate (danger → check → type-check → test) passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)