### PR TITLE
Add OAuth 2.1 authorization server for MCP clients (claude.ai)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ FRONTEND_URL=http://localhost:5173
 
 # Authentication (Better Auth)
 BETTER_AUTH_SECRET=your-better-auth-secret-change-this-in-production
+# Public origin of the deployment, used as the OAuth issuer / MCP resource base
+# for the claude.ai connector. Set to your public HTTPS URL in production
+# (e.g. https://freundebuch.example.com). When unset it falls back to
+# FRONTEND_URL. Must be identical for the backend and mcp-server.
+# BETTER_AUTH_URL=https://freundebuch.example.com
 
 # WebAuthn / Passkey (RP = Relying Party)
 # Set to your domain in production (e.g., freundebuch.example.com)

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { passkey } from '@better-auth/passkey';
 import bcrypt from 'bcrypt';
 import { betterAuth } from 'better-auth';
+import { mcp } from 'better-auth/plugins';
 import { Pool } from 'pg';
 import { createLegacyUserForBetterAuth } from '../models/queries/users.queries.js';
 import { getConfig } from '../utils/config.js';
@@ -15,6 +16,13 @@ let _authPool: Pool | null = null;
 function createAuth() {
   const config = getConfig();
 
+  // Public origin of this deployment. In production every surface (SPA, /api,
+  // /mcp) is served from the same host behind nginx, so the OAuth issuer and the
+  // MCP `resource` audience share that origin. Prefer BETTER_AUTH_URL (which
+  // Better Auth also reads from process.env for its issuer); fall back to
+  // FRONTEND_URL, which equals the public origin in production.
+  const publicBaseUrl = config.BETTER_AUTH_URL ?? config.FRONTEND_URL;
+
   // Better Auth requires search_path=auth, so it needs its own pool.
   // Pool sizes are halved from the main pool to keep total connections in check.
   _authPool = new Pool({
@@ -27,6 +35,12 @@ function createAuth() {
   return betterAuth({
     database: _authPool,
     basePath: '/api/auth',
+    // The public origin where auth is reachable. Required for the OAuth/MCP
+    // provider: the discovery metadata's `issuer` is derived from it, and the
+    // provider throws `invalid_issuer` when unset. In every environment the
+    // browser talks to auth via the frontend origin, so FRONTEND_URL is the
+    // correct fallback when BETTER_AUTH_URL is not explicitly set.
+    baseURL: publicBaseUrl,
     secret: config.BETTER_AUTH_SECRET,
     logger: {
       disabled: process.env.VITEST === 'true',
@@ -140,6 +154,71 @@ function createAuth() {
               deviceType: 'device_type',
               backedUp: 'backed_up',
               createdAt: 'created_at',
+            },
+          },
+        },
+      }),
+      // OAuth 2.1 authorization server for the MCP server, so clients like
+      // claude.ai can connect via the MCP Authorization spec (OAuth + PKCE +
+      // Dynamic Client Registration). Endpoints are exposed under
+      // /api/auth/oauth2/* and the discovery metadata under
+      // /api/auth/.well-known/*. Token validation happens in the mcp-server via
+      // getMcpSession against the shared `auth` schema.
+      mcp({
+        // Unauthenticated authorize requests are sent here; the login form then
+        // redirects back to the original authorize URL (see login-form.svelte).
+        loginPage: '/auth/login',
+        // RFC 9728 resource audience — the MCP endpoint's public URL.
+        resource: `${publicBaseUrl}/mcp`,
+        oidcConfig: {
+          // The mcp plugin injects `loginPage` from the top-level option, but
+          // OIDCOptions requires it at the type level — keep them in sync.
+          loginPage: '/auth/login',
+          // claude.ai registers itself dynamically (its Client ID field is
+          // optional), so DCR is the primary path.
+          allowDynamicClientRegistration: true,
+          // OAuth 2.1 requires PKCE.
+          requirePKCE: true,
+          // Custom consent screen (SvelteKit route).
+          consentPage: '/oauth/consent',
+          // The oidc-provider tables default to camelCase model/column names;
+          // map them to the snake_case tables created by the migration so the
+          // plugin reads/writes the right columns (mirrors the account/session
+          // field overrides above).
+          schema: {
+            oauthApplication: {
+              modelName: 'oauth_application',
+              fields: {
+                clientId: 'client_id',
+                clientSecret: 'client_secret',
+                redirectUrls: 'redirect_urls',
+                userId: 'user_id',
+                createdAt: 'created_at',
+                updatedAt: 'updated_at',
+              },
+            },
+            oauthAccessToken: {
+              modelName: 'oauth_access_token',
+              fields: {
+                accessToken: 'access_token',
+                refreshToken: 'refresh_token',
+                accessTokenExpiresAt: 'access_token_expires_at',
+                refreshTokenExpiresAt: 'refresh_token_expires_at',
+                clientId: 'client_id',
+                userId: 'user_id',
+                createdAt: 'created_at',
+                updatedAt: 'updated_at',
+              },
+            },
+            oauthConsent: {
+              modelName: 'oauth_consent',
+              fields: {
+                clientId: 'client_id',
+                userId: 'user_id',
+                consentGiven: 'consent_given',
+                createdAt: 'created_at',
+                updatedAt: 'updated_at',
+              },
             },
           },
         },

--- a/apps/backend/src/utils/config.ts
+++ b/apps/backend/src/utils/config.ts
@@ -35,6 +35,13 @@ const ConfigSchema = type({
 
   // Authentication (Better Auth)
   BETTER_AUTH_SECRET: SecretType,
+  // Public origin of the deployment (e.g. https://freundebuch.example.com).
+  // Better Auth reads process.env.BETTER_AUTH_URL directly for its issuer/base
+  // URL; we also declare it here so the OAuth `resource` audience and discovery
+  // metadata can be derived from config. Optional: when unset, Better Auth
+  // resolves the base URL per-request (preserving the existing dev behaviour)
+  // and we fall back to FRONTEND_URL for the resource value.
+  'BETTER_AUTH_URL?': 'string',
 
   // WebAuthn / Passkey
   'WEBAUTHN_RP_ID?': 'string',

--- a/apps/frontend/src/lib/components/login-form.svelte
+++ b/apps/frontend/src/lib/components/login-form.svelte
@@ -28,13 +28,39 @@ let isLoading = $state(false);
 let isPasskeyLoading = $state(false);
 let error = $state('');
 
+/**
+ * When the OAuth/MCP authorization server redirects an unauthenticated
+ * `authorize` request to this login page, it forwards the original authorize
+ * query (client_id, redirect_uri, response_type, ...). After a successful
+ * login we resume the flow by navigating back to the authorize endpoint with
+ * those same params. The target is a fixed same-origin backend path and the
+ * authorize endpoint re-validates redirect_uri against the registered client,
+ * so this cannot be turned into an open redirect.
+ */
+function resolveOAuthContinuation(): string | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('client_id') && params.get('redirect_uri') && params.get('response_type')) {
+    return `/api/auth/mcp/authorize?${params.toString()}`;
+  }
+  return null;
+}
+
 function handleSuccess() {
   if (onSuccess) {
     onSuccess();
-  } else {
-    // Redirect to home page after successful login
-    goto('/');
+    return;
   }
+
+  const oauthContinuation = resolveOAuthContinuation();
+  if (oauthContinuation) {
+    // Full navigation (not SPA goto): the authorize endpoint is a backend route.
+    window.location.href = oauthContinuation;
+    return;
+  }
+
+  // Redirect to home page after successful login
+  goto('/');
 }
 
 async function handleSubmit(e) {

--- a/apps/frontend/src/lib/components/mcp-setup-guide.svelte
+++ b/apps/frontend/src/lib/components/mcp-setup-guide.svelte
@@ -7,7 +7,7 @@ const i18n = createI18n();
 
 const mcpUrl = $derived(`${typeof window !== 'undefined' ? window.location.origin : ''}/mcp`);
 
-let activeTab = $state<'claude-desktop' | 'claude-code' | 'other'>('claude-desktop');
+let activeTab = $state<'claude-ai' | 'claude-desktop' | 'claude-code' | 'other'>('claude-ai');
 let copied = $state(false);
 
 async function copyUrl() {
@@ -90,6 +90,12 @@ const claudeDesktopConfig = $derived(
   <div class="border border-gray-200 rounded-lg overflow-hidden">
     <div class="flex border-b border-gray-200">
       <button
+        onclick={() => activeTab = 'claude-ai'}
+        class="flex-1 px-4 py-3 font-body font-medium text-sm transition-colors {activeTab === 'claude-ai' ? 'bg-white text-forest border-b-2 border-forest' : 'bg-gray-50 text-gray-600 hover:text-gray-800'}"
+      >
+        {$i18n.t('profile.mcp.tabs.claudeAi')}
+      </button>
+      <button
         onclick={() => activeTab = 'claude-desktop'}
         class="flex-1 px-4 py-3 font-body font-medium text-sm transition-colors {activeTab === 'claude-desktop' ? 'bg-white text-forest border-b-2 border-forest' : 'bg-gray-50 text-gray-600 hover:text-gray-800'}"
       >
@@ -110,7 +116,22 @@ const claudeDesktopConfig = $derived(
     </div>
 
     <div class="p-6 bg-white">
-      {#if activeTab === 'claude-desktop'}
+      {#if activeTab === 'claude-ai'}
+        <div class="space-y-4">
+          <p class="font-body text-sm text-gray-700">
+            {$i18n.t('profile.mcp.steps.claudeAi.intro')}
+          </p>
+          <ol class="list-decimal list-inside space-y-2 font-body text-sm text-gray-700">
+            <li>{$i18n.t('profile.mcp.steps.claudeAi.step1')}</li>
+            <li>{$i18n.t('profile.mcp.steps.claudeAi.step2')}</li>
+            <li>{$i18n.t('profile.mcp.steps.claudeAi.step3')}</li>
+            <li>{$i18n.t('profile.mcp.steps.claudeAi.step4')}</li>
+          </ol>
+          <div class="bg-green-50 border border-green-200 rounded-lg p-3 font-body text-xs text-green-700">
+            {$i18n.t('profile.mcp.steps.claudeAi.note')}
+          </div>
+        </div>
+      {:else if activeTab === 'claude-desktop'}
         <div class="space-y-4">
           <p class="font-body text-sm text-gray-700">
             {$i18n.t('profile.mcp.steps.claudeDesktop.intro')}

--- a/apps/frontend/src/lib/i18n/locales/de.json
+++ b/apps/frontend/src/lib/i18n/locales/de.json
@@ -739,11 +739,20 @@
       "appPasswordRequired": "MCP-Zugriff erfordert ein App-Passwort. Du kannst das gleiche App-Passwort für CardDAV und MCP verwenden oder ein separates erstellen.",
       "manageAppPasswords": "App-Passwörter verwalten",
       "tabs": {
+        "claudeAi": "claude.ai",
         "claudeDesktop": "Claude Desktop",
         "claudeCode": "Claude Code",
         "other": "Andere Clients"
       },
       "steps": {
+        "claudeAi": {
+          "intro": "Füge Freundebuch als benutzerdefinierten Connector hinzu – ohne App-Passwort, die Anmeldung erfolgt im Browser:",
+          "step1": "Öffne in claude.ai die Einstellungen → Connectors und wähle „Benutzerdefinierten Connector hinzufügen“.",
+          "step2": "Füge deine MCP-Server-URL (oben) als Remote-MCP-Server-URL ein und vergib einen Namen.",
+          "step3": "Klicke auf Hinzufügen. Claude öffnet eine Freundebuch-Anmeldeseite – melde dich an und bestätige den Zugriff.",
+          "step4": "Der Connector ist nun mit deinem Konto verknüpft; aktiviere ihn in einem Chat, um deine Freundebuch-Daten zu nutzen.",
+          "note": "Die Authentifizierung erfolgt über OAuth – du musst kein App-Passwort erstellen oder einfügen."
+        },
         "claudeDesktop": {
           "intro": "Füge diese Konfiguration zu deiner Claude Desktop-Konfigurationsdatei hinzu:",
           "step1": "Öffne die Claude Desktop-Einstellungen",
@@ -1348,6 +1357,25 @@
       "circle": "Freundeskreis",
       "collective": "Kollektiv",
       "employment": "Berufserfahrung"
+    }
+  },
+  "oauth": {
+    "consent": {
+      "title": "Zugriff autorisieren",
+      "subtitle": "{{client}} möchte auf dein Freundebuch-Konto zugreifen.",
+      "permissionsHeading": "Damit sind folgende Aktionen möglich:",
+      "scopes": {
+        "openid": "Deine Identität bestätigen",
+        "profile": "Dein Basisprofil lesen",
+        "email": "Deine E-Mail-Adresse lesen",
+        "offline_access": "Verbunden bleiben, während du abwesend bist"
+      },
+      "allow": "Erlauben",
+      "deny": "Ablehnen",
+      "error": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+      "invalidTitle": "Ungültige Anfrage",
+      "invalidBody": "Dieser Autorisierungslink ist ungültig oder abgelaufen.",
+      "backHome": "Zurück zur Startseite"
     }
   }
 }

--- a/apps/frontend/src/lib/i18n/locales/en.json
+++ b/apps/frontend/src/lib/i18n/locales/en.json
@@ -739,11 +739,20 @@
       "appPasswordRequired": "MCP access requires an app password. You can use the same app password for CardDAV and MCP, or create a separate one.",
       "manageAppPasswords": "Manage App Passwords",
       "tabs": {
+        "claudeAi": "claude.ai",
         "claudeDesktop": "Claude Desktop",
         "claudeCode": "Claude Code",
         "other": "Other Clients"
       },
       "steps": {
+        "claudeAi": {
+          "intro": "Add Freundebuch as a custom connector — no app password needed, you sign in through your browser:",
+          "step1": "In claude.ai, open Settings → Connectors and choose \"Add custom connector\".",
+          "step2": "Paste your MCP Server URL (above) as the Remote MCP server URL and give it a name.",
+          "step3": "Click Add. Claude opens a Freundebuch sign-in page — log in and approve access.",
+          "step4": "The connector is now linked to your account; enable it in a chat to use your Freundebuch data.",
+          "note": "Authentication uses OAuth, so you don't need to create or paste an app password."
+        },
         "claudeDesktop": {
           "intro": "Add this configuration to your Claude Desktop config file:",
           "step1": "Open Claude Desktop Settings",
@@ -1348,6 +1357,25 @@
       "circle": "Circle",
       "collective": "Collective",
       "employment": "Employment"
+    }
+  },
+  "oauth": {
+    "consent": {
+      "title": "Authorize access",
+      "subtitle": "{{client}} wants to access your Freundebuch account.",
+      "permissionsHeading": "This will allow it to:",
+      "scopes": {
+        "openid": "Verify your identity",
+        "profile": "Read your basic profile",
+        "email": "Read your email address",
+        "offline_access": "Stay connected when you're away"
+      },
+      "allow": "Allow",
+      "deny": "Deny",
+      "error": "Something went wrong. Please try again.",
+      "invalidTitle": "Invalid request",
+      "invalidBody": "This authorization link is invalid or has expired.",
+      "backHome": "Back to home"
     }
   }
 }

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -86,8 +86,9 @@ $effect(() => {
   }
 });
 
-// Routes exempt from onboarding redirect
-const onboardingExemptPaths = ['/onboarding', '/auth/'];
+// Routes exempt from onboarding redirect. `/oauth/` is exempt so the OAuth
+// consent step is not interrupted mid-flow (which would drop the consent code).
+const onboardingExemptPaths = ['/onboarding', '/auth/', '/oauth/'];
 
 // Redirect to onboarding if user needs to complete it
 $effect(() => {

--- a/apps/frontend/src/routes/oauth/consent/+page.svelte
+++ b/apps/frontend/src/routes/oauth/consent/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { page } from '$app/stores';
+import AlertBanner from '$lib/components/alert-banner.svelte';
+import { createI18n } from '$lib/i18n/index.js';
+
+const i18n = createI18n();
+
+// The authorization server redirects here with these params (see the `mcp`
+// plugin's consentPage flow).
+const consentCode = $derived($page.url.searchParams.get('consent_code') ?? '');
+const clientId = $derived($page.url.searchParams.get('client_id') ?? '');
+const scopes = $derived(
+  ($page.url.searchParams.get('scope') ?? '').split(/\s+/).filter((s) => s.length > 0),
+);
+
+let clientName = $state('');
+let isSubmitting = $state(false);
+let error = $state('');
+
+// Human-readable descriptions for the standard scopes; unknown scopes fall
+// back to showing the raw scope string.
+function scopeLabel(scope: string): string {
+  const key = `oauth.consent.scopes.${scope}`;
+  const translated = $i18n.t(key);
+  return translated === key ? scope : translated;
+}
+
+onMount(async () => {
+  if (!clientId) return;
+  try {
+    const res = await fetch(`/api/auth/oauth2/client/${encodeURIComponent(clientId)}`, {
+      credentials: 'include',
+    });
+    if (res.ok) {
+      const data = await res.json();
+      clientName = data?.name ?? '';
+    }
+  } catch {
+    // Non-fatal: fall back to showing the client id.
+  }
+});
+
+async function submitConsent(accept: boolean) {
+  if (isSubmitting) return;
+  error = '';
+  isSubmitting = true;
+
+  try {
+    const res = await fetch('/api/auth/oauth2/consent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ accept, consent_code: consentCode }),
+    });
+
+    if (!res.ok) {
+      error = $i18n.t('oauth.consent.error');
+      isSubmitting = false;
+      return;
+    }
+
+    const data = await res.json();
+    if (data?.redirectURI) {
+      // Full navigation back to the client's callback (external origin).
+      window.location.href = data.redirectURI;
+      return;
+    }
+
+    error = $i18n.t('oauth.consent.error');
+    isSubmitting = false;
+  } catch {
+    error = $i18n.t('oauth.consent.error');
+    isSubmitting = false;
+  }
+}
+</script>
+
+<svelte:head>
+	<title>{$i18n.t('oauth.consent.title')} | Freundebuch</title>
+</svelte:head>
+
+<div class="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+	<div class="w-full max-w-md bg-white rounded-xl shadow-lg p-8">
+		{#if !consentCode}
+			<div class="text-center">
+				<h2 class="text-3xl font-heading text-forest mb-4">{$i18n.t('oauth.consent.invalidTitle')}</h2>
+				<p class="text-gray-600 font-body mb-6">{$i18n.t('oauth.consent.invalidBody')}</p>
+				<a
+					href="/"
+					class="inline-block bg-forest text-white py-3 px-6 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors"
+				>
+					{$i18n.t('oauth.consent.backHome')}
+				</a>
+			</div>
+		{:else}
+			<h2 class="text-3xl font-heading text-forest mb-2">{$i18n.t('oauth.consent.title')}</h2>
+			<p class="text-gray-600 font-body mb-6">
+				{$i18n.t('oauth.consent.subtitle', { client: clientName || clientId })}
+			</p>
+
+			{#if error}
+				<div class="mb-6">
+					<AlertBanner variant="error">{error}</AlertBanner>
+				</div>
+			{/if}
+
+			<div class="mb-6">
+				<p class="text-sm font-body font-semibold text-gray-700 mb-3">
+					{$i18n.t('oauth.consent.permissionsHeading')}
+				</p>
+				<ul class="space-y-2">
+					{#each scopes as scope (scope)}
+						<li class="flex items-start gap-2 text-sm font-body text-gray-700">
+							<span class="text-forest mt-0.5">✓</span>
+							<span>{scopeLabel(scope)}</span>
+						</li>
+					{/each}
+				</ul>
+			</div>
+
+			<div class="flex gap-3">
+				<button
+					type="button"
+					onclick={() => submitConsent(false)}
+					disabled={isSubmitting}
+					class="flex-1 bg-white text-gray-800 py-3 px-4 rounded-lg font-body font-semibold border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					{$i18n.t('oauth.consent.deny')}
+				</button>
+				<button
+					type="button"
+					onclick={() => submitConsent(true)}
+					disabled={isSubmitting}
+					class="flex-1 bg-forest text-white py-3 px-4 rounded-lg font-body font-semibold hover:bg-forest-light transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					{isSubmitting ? $i18n.t('common.loading') : $i18n.t('oauth.consent.allow')}
+				</button>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -9,6 +9,17 @@ const ConfigSchema = type({
   // No default: deploying to production without explicitly setting ENV would
   // silently use development defaults (e.g. pino-pretty transport). Fail closed.
   ENV: '"development" | "production" | "test"',
+  // Shared with the backend's Better Auth instance. The MCP server co-locates a
+  // Better Auth instance (imported from @freundebuch/backend) to validate OAuth
+  // bearer tokens via getMcpSession; it must use the same secret and database
+  // as the authorization server so token lookups resolve. Declared here so a
+  // missing secret fails fast at boot rather than on the first OAuth request.
+  BETTER_AUTH_SECRET: 'string',
+  // Public origin of this deployment (e.g. https://freundebuch.example.com),
+  // used to build the RFC 9728 `resource_metadata` URL in the 401 Bearer
+  // challenge. Optional: when unset, it is derived per-request from the
+  // X-Forwarded-Proto / Host headers set by nginx.
+  'BETTER_AUTH_URL?': 'string',
   '+': 'delete',
 });
 

--- a/apps/mcp-server/src/http-handler.ts
+++ b/apps/mcp-server/src/http-handler.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type pg from 'pg';
 import type { Logger } from 'pino';
 import { createMcpServer } from './server.js';
+import { getPublicBaseUrl, verifyBearerToken } from './utils/bearer-auth.js';
 import type { Services } from './utils/service-factory.js';
 
 // Brute-force / rate limiting is handled at the infrastructure layer — see
@@ -20,6 +22,10 @@ interface HandlerDeps {
   services: Services;
   logger: Logger;
   sessions: Map<string, Session>;
+  /** Shared pg pool — used to resolve OAuth subjects to the legacy external_id. */
+  pool: pg.Pool;
+  /** Public origin, for the OAuth protected-resource metadata URL in 401s. */
+  betterAuthUrl?: string;
   maxBodyBytes?: number;
 }
 
@@ -58,13 +64,60 @@ function sendJson(
   res.end(JSON.stringify(body));
 }
 
-function sendUnauthorized(res: ServerResponse) {
+/**
+ * 401 advertising the OAuth 2.1 flow. This is the default challenge for
+ * requests without credentials: the `WWW-Authenticate: Bearer` header with a
+ * `resource_metadata` pointer is what makes an MCP client (e.g. claude.ai)
+ * discover the authorization server and start the OAuth flow (RFC 9728).
+ */
+function sendBearerUnauthorized(res: ServerResponse, req: IncomingMessage, betterAuthUrl?: string) {
+  const base = getPublicBaseUrl(req, betterAuthUrl);
+  const resourceMetadata = `${base}/.well-known/oauth-protected-resource`;
+  sendJson(
+    res,
+    401,
+    { error: 'Unauthorized' },
+    {
+      'WWW-Authenticate': `Bearer resource_metadata="${resourceMetadata}"`,
+      // Browser-based MCP clients need to read the challenge to begin OAuth.
+      'Access-Control-Expose-Headers': 'WWW-Authenticate',
+    },
+  );
+}
+
+/**
+ * 401 with a Basic challenge. Only used when a client actually attempted Basic
+ * auth (app password) but failed, so existing CLI/DAV-style clients still get a
+ * Basic prompt instead of being pushed into the OAuth flow.
+ */
+function sendBasicUnauthorized(res: ServerResponse) {
   sendJson(
     res,
     401,
     { error: 'Unauthorized' },
     { 'WWW-Authenticate': 'Basic realm="Freundebuch MCP"' },
   );
+}
+
+/**
+ * 401 whose challenge scheme matches the credentials the client presented — a
+ * Bearer challenge for OAuth clients (so they can restart RFC 9728 discovery /
+ * reauth), a Basic challenge for app-password clients. Used for requests that
+ * authenticated successfully but are still rejected, e.g. a session id owned by
+ * a different user: re-challenging in the wrong scheme would push an OAuth
+ * client into Basic and break its reauth flow.
+ */
+function sendUnauthorizedForScheme(
+  res: ServerResponse,
+  req: IncomingMessage,
+  authHeader: string | undefined,
+  betterAuthUrl?: string,
+) {
+  if (authHeader?.startsWith('Bearer ')) {
+    sendBearerUnauthorized(res, req, betterAuthUrl);
+  } else {
+    sendBasicUnauthorized(res);
+  }
 }
 
 type ReadResult = { ok: true; body: string } | { ok: false; reason: 'too-large' | 'stream-error' };
@@ -162,7 +215,7 @@ function readSessionIdHeader(
 export function createMcpRequestHandler(
   deps: HandlerDeps,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
-  const { services, logger, sessions } = deps;
+  const { services, logger, sessions, pool, betterAuthUrl } = deps;
   const maxBodyBytes = deps.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
 
   return async function handleRequest(req, res) {
@@ -180,30 +233,57 @@ export function createMcpRequestHandler(
       return;
     }
 
-    // Authenticate every request
+    // Authenticate every request. Two schemes are accepted:
+    //  - Bearer: OAuth access tokens issued by the Better Auth authorization
+    //    server (used by claude.ai and other remote MCP clients).
+    //  - Basic: app passwords (used by existing CLI/desktop clients).
+    // Both resolve to the same `{ userId (legacy external_id), email }` shape.
     const authHeader = req.headers.authorization;
-    if (!authHeader?.startsWith('Basic ')) {
-      sendUnauthorized(res);
+    let authResult: { userId: string; email: string } | null = null;
+
+    if (authHeader?.startsWith('Bearer ')) {
+      authResult = await verifyBearerToken(req, pool, logger);
+      if (!authResult) {
+        logger.warn(
+          { ip: getClientIp(req) },
+          'MCP bearer-auth failure (infrastructure rate limiting should throttle repeats)',
+        );
+        sendBearerUnauthorized(res, req, betterAuthUrl);
+        return;
+      }
+    } else if (authHeader?.startsWith('Basic ')) {
+      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
+      const colonIndex = decoded.indexOf(':');
+      if (colonIndex === -1) {
+        sendBasicUnauthorized(res);
+        return;
+      }
+
+      const email = decoded.slice(0, colonIndex);
+      const password = decoded.slice(colonIndex + 1);
+
+      const basicResult = await services.appPasswords.verifyAppPassword(email, password);
+      if (!basicResult) {
+        logger.warn(
+          { ip: getClientIp(req), email },
+          'MCP basic-auth failure (infrastructure rate limiting should throttle repeats)',
+        );
+        sendBasicUnauthorized(res);
+        return;
+      }
+      authResult = { userId: basicResult.userId, email: basicResult.email };
+    } else {
+      // No credentials (or an unsupported scheme): advertise the OAuth flow so
+      // MCP clients begin discovery. App-password clients send Basic
+      // proactively and never reach this branch.
+      sendBearerUnauthorized(res, req, betterAuthUrl);
       return;
     }
 
-    const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8');
-    const colonIndex = decoded.indexOf(':');
-    if (colonIndex === -1) {
-      sendUnauthorized(res);
-      return;
-    }
-
-    const email = decoded.slice(0, colonIndex);
-    const password = decoded.slice(colonIndex + 1);
-
-    const authResult = await services.appPasswords.verifyAppPassword(email, password);
+    // Every non-returning branch above assigns authResult; this guard also
+    // narrows the type for the rest of the handler.
     if (!authResult) {
-      logger.warn(
-        { ip: getClientIp(req), email },
-        'MCP basic-auth failure (infrastructure rate limiting should throttle repeats)',
-      );
-      sendUnauthorized(res);
+      sendBearerUnauthorized(res, req, betterAuthUrl);
       return;
     }
 
@@ -233,7 +313,7 @@ export function createMcpRequestHandler(
       const existingSession = sessionId ? sessions.get(sessionId) : undefined;
       if (existingSession) {
         if (existingSession.userId !== authResult.userId) {
-          sendUnauthorized(res);
+          sendUnauthorizedForScheme(res, req, authHeader, betterAuthUrl);
           return;
         }
         await existingSession.transport.handleRequest(req, res, parsedBody);
@@ -271,7 +351,7 @@ export function createMcpRequestHandler(
         return;
       }
       if (getSession.userId !== authResult.userId) {
-        sendUnauthorized(res);
+        sendUnauthorizedForScheme(res, req, authHeader, betterAuthUrl);
         return;
       }
       await getSession.transport.handleRequest(req, res);
@@ -285,7 +365,7 @@ export function createMcpRequestHandler(
         return;
       }
       if (deleteSession.userId !== authResult.userId) {
-        sendUnauthorized(res);
+        sendUnauthorizedForScheme(res, req, authHeader, betterAuthUrl);
         return;
       }
       await deleteSession.transport.handleRequest(req, res);

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -18,7 +18,15 @@ const services = createServices(pool, logger);
 
 const sessions = new Map<string, Session>();
 
-const httpServer = createServer(createMcpRequestHandler({ services, logger, sessions }));
+const httpServer = createServer(
+  createMcpRequestHandler({
+    services,
+    logger,
+    sessions,
+    pool,
+    betterAuthUrl: config.BETTER_AUTH_URL,
+  }),
+);
 
 httpServer.listen(config.MCP_PORT, () => {
   logger.info({ port: config.MCP_PORT }, 'Freundebuch MCP server started');

--- a/apps/mcp-server/src/utils/bearer-auth.ts
+++ b/apps/mcp-server/src/utils/bearer-auth.ts
@@ -1,0 +1,109 @@
+import type { IncomingMessage } from 'node:http';
+import { getAuth } from '@freundebuch/backend/lib/auth.js';
+import type pg from 'pg';
+import type { Logger } from 'pino';
+
+export interface BearerAuthContext {
+  /** Legacy auth.users.external_id (UUID) — what the MCP tools expect. */
+  userId: string;
+  email: string;
+}
+
+/**
+ * Resolve a Better Auth user id to the legacy auth.users.external_id (UUID).
+ *
+ * The MCP tools scope every query by the legacy external_id, but OAuth tokens
+ * resolve to a Better Auth user id (an opaque string). Bridge the two by email,
+ * exactly as apps/backend/src/middleware/auth.ts does via
+ * getLegacyExternalIdByEmail — the difference here is we start from the Better
+ * Auth user id (from the token) rather than a validated session.
+ */
+async function resolveLegacyExternalId(
+  pool: pg.Pool,
+  betterAuthUserId: string,
+): Promise<{ externalId: string; email: string } | null> {
+  const result = await pool.query<{ external_id: string; email: string }>(
+    `SELECT lu.external_id, bu.email
+       FROM auth."user" bu
+       JOIN auth.users lu ON lu.email = bu.email
+      WHERE bu.id = $1
+      LIMIT 1`,
+    [betterAuthUserId],
+  );
+  const row = result.rows[0];
+  return row ? { externalId: row.external_id, email: row.email } : null;
+}
+
+/**
+ * Validate an `Authorization: Bearer <token>` header against the OAuth access
+ * tokens issued by the co-located Better Auth authorization server, and resolve
+ * the token to the legacy external_id the MCP tools expect.
+ *
+ * Returns null when the token is missing, unknown, or expired. getMcpSession
+ * only checks that the token exists — it does NOT enforce expiry — so we check
+ * `accessTokenExpiresAt` here.
+ */
+export async function verifyBearerToken(
+  req: IncomingMessage,
+  pool: pg.Pool,
+  logger: Logger,
+): Promise<BearerAuthContext | null> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  // Forward only the Authorization header — that is all getMcpSession reads.
+  const headers = new Headers();
+  headers.set('authorization', authHeader);
+
+  let session: { userId?: string; accessTokenExpiresAt?: string | Date } | null;
+  try {
+    session = await getAuth().api.getMcpSession({ headers });
+  } catch (err) {
+    logger.error({ err }, 'Error validating MCP bearer token');
+    return null;
+  }
+
+  if (!session?.userId) {
+    return null;
+  }
+
+  // getMcpSession does not enforce expiry — reject expired/undated tokens.
+  const expiresAt = session.accessTokenExpiresAt
+    ? new Date(session.accessTokenExpiresAt).getTime()
+    : Number.NaN;
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+    logger.warn('MCP bearer token missing expiry or expired');
+    return null;
+  }
+
+  const resolved = await resolveLegacyExternalId(pool, session.userId);
+  if (!resolved) {
+    logger.warn({ betterAuthUserId: session.userId }, 'No legacy user for OAuth token subject');
+    return null;
+  }
+
+  return { userId: resolved.externalId, email: resolved.email };
+}
+
+/**
+ * Build the public origin of this deployment for the RFC 9728 protected-resource
+ * metadata URL. Prefer the configured BETTER_AUTH_URL (so it matches the OAuth
+ * issuer exactly); otherwise derive it from the proxy headers nginx sets.
+ */
+export function getPublicBaseUrl(req: IncomingMessage, configuredBaseUrl?: string): string {
+  if (configuredBaseUrl) {
+    return configuredBaseUrl.replace(/\/+$/, '');
+  }
+  const proto =
+    (typeof req.headers['x-forwarded-proto'] === 'string' && req.headers['x-forwarded-proto']) ||
+    'https';
+  const host =
+    (typeof req.headers['x-forwarded-host'] === 'string' && req.headers['x-forwarded-host']) ||
+    (typeof req.headers.host === 'string' && req.headers.host) ||
+    'localhost';
+  // Only the first proto value is meaningful if a comma-joined list slips through.
+  const scheme = proto.split(',')[0].trim();
+  return `${scheme}://${host}`;
+}

--- a/apps/mcp-server/tests/helpers.ts
+++ b/apps/mcp-server/tests/helpers.ts
@@ -122,10 +122,11 @@ async function createTestUserWithAppPassword(
 function startMcpHttpServer(
   services: Services,
   logger: Logger,
+  pool: pg.Pool,
 ): Promise<{ server: http.Server; baseUrl: string; sessions: Map<string, Session> }> {
   return new Promise((resolve) => {
     const sessions = new Map<string, Session>();
-    const handler = createMcpRequestHandler({ services, logger, sessions });
+    const handler = createMcpRequestHandler({ services, logger, sessions, pool });
     const httpServer = http.createServer(handler);
 
     httpServer.listen(0, () => {
@@ -336,7 +337,7 @@ export function setupMcpTestSuite() {
     const testUser = await createTestUserWithAppPassword(pool, 'mcp-test@example.com');
     const otherUser = await createTestUserWithAppPassword(pool, 'mcp-other@example.com');
 
-    const { server: httpServer, baseUrl } = await startMcpHttpServer(services, logger);
+    const { server: httpServer, baseUrl } = await startMcpHttpServer(services, logger, pool);
 
     context = {
       container,

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -61,7 +61,7 @@ describe('MCP Server', { timeout: 60000 }, () => {
       expect(response.status).toBe(405);
     });
 
-    it('should return 401 for /mcp without auth', async () => {
+    it('should return 401 with an OAuth Bearer challenge for /mcp without auth', async () => {
       const { baseUrl } = getContext();
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
@@ -69,7 +69,12 @@ describe('MCP Server', { timeout: 60000 }, () => {
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
       });
       expect(response.status).toBe(401);
-      expect(response.headers.get('www-authenticate')).toContain('Basic');
+      // Unauthenticated requests advertise the OAuth flow so MCP clients
+      // (e.g. claude.ai) begin discovery via the protected-resource metadata.
+      const challenge = response.headers.get('www-authenticate') ?? '';
+      expect(challenge).toContain('Bearer');
+      expect(challenge).toContain('resource_metadata=');
+      expect(challenge).toContain('/.well-known/oauth-protected-resource');
     });
 
     it('should return 413 for bodies exceeding the size cap', async () => {
@@ -253,17 +258,19 @@ describe('MCP Server', { timeout: 60000 }, () => {
       expect(response.status).toBe(401);
     });
 
-    it('should reject Bearer auth (only Basic is supported)', async () => {
+    it('should reject an invalid/unknown Bearer token with an OAuth challenge', async () => {
       const { baseUrl } = getContext();
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: 'Bearer some-token',
+          // A token that is not a valid issued OAuth access token.
+          Authorization: 'Bearer some-invalid-token',
         },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
       });
       expect(response.status).toBe(401);
+      expect(response.headers.get('www-authenticate') ?? '').toContain('Bearer');
     });
 
     it('should reject revoked app password', async () => {

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -25,6 +25,7 @@ export default {
         'all', // affects everything
         'backend', // Backend/API changes
         'frontend', // Frontend/UI changes
+        'mcp-server', // MCP server changes
         'shared', // Shared package changes
         'database', // Database migrations/schema changes
         'docs', // Documentation

--- a/database/migrations/1779667600000_oauth-provider.ts
+++ b/database/migrations/1779667600000_oauth-provider.ts
@@ -1,0 +1,136 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+/**
+ * OAuth 2.1 provider tables for the Better Auth `mcp` plugin.
+ *
+ * These back the OAuth authorization server that lets remote MCP clients
+ * (e.g. claude.ai) connect to the Freundebuch MCP server via the MCP
+ * Authorization spec (OAuth + PKCE + Dynamic Client Registration).
+ *
+ * The plugin's default model/field names are camelCase (`oauthApplication`,
+ * `clientId`, ...). We create snake_case tables/columns to match this repo's
+ * conventions and map them back via the plugin `schema` overrides in
+ * `apps/backend/src/lib/auth.ts`. Access/refresh tokens are stored hashed by
+ * Better Auth — no plaintext secrets at rest.
+ */
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Registered OAuth clients. With Dynamic Client Registration enabled, one row
+  // is created per client that registers (claude.ai registers itself).
+  pgm.createTable(
+    { schema: 'auth', name: 'oauth_application' },
+    {
+      id: { type: 'text', primaryKey: true },
+      name: { type: 'text', notNull: true },
+      icon: { type: 'text' },
+      metadata: { type: 'text' },
+      client_id: { type: 'text', notNull: true, unique: true },
+      client_secret: { type: 'text' },
+      redirect_urls: { type: 'text', notNull: true },
+      type: { type: 'text', notNull: true },
+      disabled: { type: 'boolean', notNull: true, default: false },
+      user_id: {
+        type: 'text',
+        references: { schema: 'auth', name: 'user' },
+        onDelete: 'CASCADE',
+        comment: 'Owner of the client registration (nullable for anonymous DCR)',
+      },
+      created_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+      updated_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+    },
+  );
+
+  pgm.createIndex({ schema: 'auth', name: 'oauth_application' }, 'user_id', {
+    name: 'idx_oauth_application_user_id',
+  });
+
+  // Issued access/refresh tokens. Bearer tokens presented to /mcp are validated
+  // against this table by the mcp-server (getMcpSession). Nullable refresh
+  // fields tolerate grants that do not issue a refresh token.
+  pgm.createTable(
+    { schema: 'auth', name: 'oauth_access_token' },
+    {
+      id: { type: 'text', primaryKey: true },
+      access_token: { type: 'text', notNull: true, unique: true },
+      refresh_token: { type: 'text', unique: true },
+      access_token_expires_at: { type: 'timestamptz' },
+      refresh_token_expires_at: { type: 'timestamptz' },
+      // client_id references oauth_application.client_id (a unique, non-PK
+      // column). Better Auth enforces this relationship in application code;
+      // we keep it as an indexed column without a DB-level FK to avoid
+      // constraining against a non-primary key.
+      client_id: { type: 'text', notNull: true },
+      user_id: {
+        type: 'text',
+        references: { schema: 'auth', name: 'user' },
+        onDelete: 'CASCADE',
+      },
+      scopes: { type: 'text' },
+      created_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+      updated_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+    },
+  );
+
+  pgm.createIndex({ schema: 'auth', name: 'oauth_access_token' }, 'client_id', {
+    name: 'idx_oauth_access_token_client_id',
+  });
+  pgm.createIndex({ schema: 'auth', name: 'oauth_access_token' }, 'user_id', {
+    name: 'idx_oauth_access_token_user_id',
+  });
+
+  // Per-user, per-client consent records so a user is not re-prompted every time.
+  pgm.createTable(
+    { schema: 'auth', name: 'oauth_consent' },
+    {
+      id: { type: 'text', primaryKey: true },
+      // See note on oauth_access_token.client_id — indexed, no DB-level FK.
+      client_id: { type: 'text', notNull: true },
+      user_id: {
+        type: 'text',
+        notNull: true,
+        references: { schema: 'auth', name: 'user' },
+        onDelete: 'CASCADE',
+      },
+      scopes: { type: 'text' },
+      consent_given: { type: 'boolean', notNull: true, default: false },
+      created_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+      updated_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('current_timestamp'),
+      },
+    },
+  );
+
+  pgm.createIndex({ schema: 'auth', name: 'oauth_consent' }, 'client_id', {
+    name: 'idx_oauth_consent_client_id',
+  });
+  pgm.createIndex({ schema: 'auth', name: 'oauth_consent' }, 'user_id', {
+    name: 'idx_oauth_consent_user_id',
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable({ schema: 'auth', name: 'oauth_consent' }, { ifExists: true });
+  pgm.dropTable({ schema: 'auth', name: 'oauth_access_token' }, { ifExists: true });
+  pgm.dropTable({ schema: 'auth', name: 'oauth_application' }, { ifExists: true });
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,12 @@ services:
       MCP_PORT: 3100
       LOG_LEVEL: ${LOG_LEVEL:-info}
       ENV: production
+      # Shared with the backend so the co-located Better Auth instance can
+      # validate OAuth bearer tokens against the same database (same secret).
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      # Public origin, for the OAuth resource metadata URL. Must match the
+      # backend's issuer.
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://freundebuch.schumacher.im}
     networks:
       - internal
     healthcheck:
@@ -80,6 +86,9 @@ services:
       PORT: 3000
       FRONTEND_URL: https://freundebuch.schumacher.im
       BACKEND_URL: https://freundebuch.schumacher.im
+      # Public origin used as the OAuth issuer / MCP resource base for the
+      # claude.ai connector. Must match the mcp-server's BETTER_AUTH_URL.
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://freundebuch.schumacher.im}
 
       # Authentication
       JWT_SECRET: ${JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       POSTGIS_ADDRESS_ENABLED: ${POSTGIS_ADDRESS_ENABLED:-false}
       POSTGIS_ADDRESS_DACH_ONLY: ${POSTGIS_ADDRESS_DACH_ONLY:-true}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-dev-better-auth-secret-change-in-prod}
+      # Public origin (nginx), used as the OAuth issuer / MCP resource base.
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:8080}
       WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-localhost}
     ports:
       - "3000:3000"
@@ -85,6 +87,11 @@ services:
       MCP_PORT: 3100
       LOG_LEVEL: debug
       ENV: development
+      # Shared with the backend so the co-located Better Auth instance can
+      # validate OAuth bearer tokens against the same database.
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-dev-better-auth-secret-change-in-prod}
+      # Public origin (nginx) for the OAuth resource metadata URL.
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:8080}
     ports:
       - "3100:3100"
     volumes:

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -79,6 +79,49 @@ http {
             return 301 /caldav/;
         }
 
+        # OAuth 2.1 / MCP authorization discovery metadata (RFC 8414 / RFC 9728).
+        # Better Auth (the MCP OAuth provider) serves these documents under
+        # /api/auth/.well-known/* on the backend, but OAuth clients such as
+        # claude.ai probe them at the origin root — map the root paths onto the
+        # backend endpoints.
+        location = /.well-known/oauth-authorization-server {
+            proxy_pass http://backend/api/auth/.well-known/oauth-authorization-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/openid-configuration {
+            proxy_pass http://backend/api/auth/.well-known/openid-configuration;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/oauth-protected-resource {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # RFC 9728 also allows the resource path to be appended to the metadata
+        # URL (…/oauth-protected-resource/mcp); serve the same document.
+        location = /.well-known/oauth-protected-resource/mcp {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)
         location ~ ^/(carddav|caldav)(/.*)?$ {
             fastcgi_pass sabredav;

--- a/docker/nginx.dev.conf
+++ b/docker/nginx.dev.conf
@@ -59,6 +59,49 @@ http {
             return 301 /caldav/;
         }
 
+        # OAuth 2.1 / MCP authorization discovery metadata (RFC 8414 / RFC 9728).
+        # Better Auth (the MCP OAuth provider) serves these documents under
+        # /api/auth/.well-known/* on the backend, but OAuth clients such as
+        # claude.ai probe them at the origin root — map the root paths onto the
+        # backend endpoints.
+        location = /.well-known/oauth-authorization-server {
+            proxy_pass http://backend/api/auth/.well-known/oauth-authorization-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/openid-configuration {
+            proxy_pass http://backend/api/auth/.well-known/openid-configuration;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/oauth-protected-resource {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # RFC 9728 also allows the resource path to be appended to the metadata
+        # URL (…/oauth-protected-resource/mcp); serve the same document.
+        location = /.well-known/oauth-protected-resource/mcp {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)
         location ~ ^/(carddav|caldav)(/.*)?$ {
             fastcgi_pass sabredav;

--- a/docker/nginx.multiservice.conf.template
+++ b/docker/nginx.multiservice.conf.template
@@ -77,6 +77,49 @@ http {
             return 301 /caldav/;
         }
 
+        # OAuth 2.1 / MCP authorization discovery metadata (RFC 8414 / RFC 9728).
+        # Better Auth (the MCP OAuth provider) serves these documents under
+        # /api/auth/.well-known/* on the backend, but OAuth clients such as
+        # claude.ai probe them at the origin root — map the root paths onto the
+        # backend endpoints.
+        location = /.well-known/oauth-authorization-server {
+            proxy_pass http://backend/api/auth/.well-known/oauth-authorization-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/openid-configuration {
+            proxy_pass http://backend/api/auth/.well-known/openid-configuration;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/oauth-protected-resource {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # RFC 9728 also allows the resource path to be appended to the metadata
+        # URL (…/oauth-protected-resource/mcp); serve the same document.
+        location = /.well-known/oauth-protected-resource/mcp {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)
         location ~ ^/(carddav|caldav)(/.*)?$ {
             fastcgi_pass sabredav;

--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -77,6 +77,49 @@ http {
             return 301 https://$host/caldav/;
         }
 
+        # OAuth 2.1 / MCP authorization discovery metadata (RFC 8414 / RFC 9728).
+        # Better Auth (the MCP OAuth provider) serves these documents under
+        # /api/auth/.well-known/* on the backend, but OAuth clients such as
+        # claude.ai probe them at the origin root — map the root paths onto the
+        # backend endpoints.
+        location = /.well-known/oauth-authorization-server {
+            proxy_pass http://backend/api/auth/.well-known/oauth-authorization-server;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/openid-configuration {
+            proxy_pass http://backend/api/auth/.well-known/openid-configuration;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /.well-known/oauth-protected-resource {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # RFC 9728 also allows the resource path to be appended to the metadata
+        # URL (…/oauth-protected-resource/mcp); serve the same document.
+        location = /.well-known/oauth-protected-resource/mcp {
+            proxy_pass http://backend/api/auth/.well-known/oauth-protected-resource;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # CardDAV/CalDAV - route to SabreDAV (PHP-FPM)
         location ~ ^/(carddav|caldav)(/.*)?$ {
             fastcgi_pass sabredav;


### PR DESCRIPTION
## Summary

Implements an OAuth 2.1 authorization server for the MCP endpoint, enabling remote MCP clients like claude.ai to authenticate via browser-based OAuth flow instead of requiring app passwords. The implementation uses Better Auth's `mcp` plugin and follows RFC 9728 (OAuth 2.1 for Securing MCP) and RFC 8414 (OAuth Authorization Server Metadata).

## Key Changes

- **OAuth 2.1 Provider Setup**: Integrated Better Auth's `mcp` plugin with PKCE requirement, dynamic client registration support, and custom consent screen
- **Database Schema**: Added three new tables (`oauth_application`, `oauth_access_token`, `oauth_consent`) to store OAuth clients, tokens, and user consent records
- **Bearer Token Authentication**: Implemented `verifyBearerToken()` in the MCP server to validate OAuth access tokens and resolve them to legacy user IDs
- **Dual Authentication**: MCP endpoint now accepts both Bearer tokens (OAuth) and Basic auth (app passwords) for backward compatibility
- **Consent Flow**: Created `/oauth/consent` SvelteKit route with i18n support for users to approve scope requests
- **OAuth Discovery Metadata**: Configured nginx to proxy RFC 8414/9728 discovery endpoints (`.well-known/oauth-*`) from backend to origin root
- **Login Flow Integration**: Updated login form to detect OAuth authorization requests and resume the flow after successful authentication
- **UI Updates**: Added claude.ai setup instructions to MCP setup guide with OAuth-specific guidance
- **Configuration**: Added `BETTER_AUTH_URL` environment variable for explicit OAuth issuer configuration

## Implementation Details

- OAuth tokens are validated via Better Auth's `getMcpSession()` API, which checks token existence but not expiry—expiry validation is enforced in `verifyBearerToken()`
- User resolution bridges Better Auth user IDs to legacy `external_id` (UUID) via email lookup, maintaining compatibility with existing MCP tools
- The consent screen displays human-readable scope descriptions via i18n keys (`oauth.consent.scopes.*`)
- All OAuth tables use snake_case naming to match repository conventions, with schema mapping in Better Auth config
- Bearer token validation includes expiry checks and proper error logging for debugging
- Unauthenticated requests receive a 401 with `WWW-Authenticate: Bearer resource_metadata="..."` header to trigger MCP client discovery

https://claude.ai/code/session_01MKLm9NFtNexo3yZ3XnEwie