### PR TITLE
feat(mcp-server): Add create_encounter tool

### DIFF
--- a/apps/mcp-server/src/tools/encounters.ts
+++ b/apps/mcp-server/src/tools/encounters.ts
@@ -86,20 +86,21 @@ export function registerEncountersTools(
         .trim()
         .min(1)
         .max(ENCOUNTER_TITLE_MAX_LENGTH)
-        .optional()
+        .nullish()
         .describe('Optional title; if omitted the UI derives a label for calls/messages'),
       locationText: z
         .string()
-        .optional()
+        .nullish()
         .describe('Optional free-text location where the encounter took place'),
-      description: z.string().optional().describe('Optional notes or description of what happened'),
+      description: z.string().nullish().describe('Optional notes or description of what happened'),
     },
     async ({ encounterDate, friendIds, encounterType, title, locationText, description }) => {
       const encounter = await services.encounters.createEncounter(getUserId(), {
         encounter_date: encounterDate,
         friend_ids: friendIds,
         encounter_type: encounterType,
-        title,
+        // `title` has no null variant in EncounterInput; treat an explicit null as unset.
+        title: title ?? undefined,
         location_text: locationText,
         description,
       });

--- a/apps/mcp-server/src/tools/encounters.ts
+++ b/apps/mcp-server/src/tools/encounters.ts
@@ -1,3 +1,4 @@
+import { ENCOUNTER_TITLE_MAX_LENGTH, ENCOUNTER_TYPES } from '@freundebuch/shared/index.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { Services } from '../utils/service-factory.js';
@@ -58,6 +59,50 @@ export function registerEncountersTools(
       if (!encounter) {
         return { content: [{ type: 'text' as const, text: 'Encounter not found.' }] };
       }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(encounter, null, 2) }],
+      };
+    },
+  );
+
+  server.tool(
+    'create_encounter',
+    'Create a new encounter (meeting, event, or interaction) and associate it with one or more friends. Requires a date and at least one friend. Returns the created encounter with its ID and associated friends.',
+    {
+      encounterDate: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+        .describe('Date the encounter took place (ISO 8601 date, e.g. "2024-06-15")'),
+      friendIds: z
+        .array(z.string().uuid())
+        .min(1)
+        .describe('IDs (UUIDs) of the friends involved in the encounter; at least one is required'),
+      encounterType: z
+        .enum(ENCOUNTER_TYPES)
+        .default('in_person')
+        .describe('Kind of contact: in_person, phone_call, video_call, or message'),
+      title: z
+        .string()
+        .trim()
+        .min(1)
+        .max(ENCOUNTER_TITLE_MAX_LENGTH)
+        .optional()
+        .describe('Optional title; if omitted the UI derives a label for calls/messages'),
+      locationText: z
+        .string()
+        .optional()
+        .describe('Optional free-text location where the encounter took place'),
+      description: z.string().optional().describe('Optional notes or description of what happened'),
+    },
+    async ({ encounterDate, friendIds, encounterType, title, locationText, description }) => {
+      const encounter = await services.encounters.createEncounter(getUserId(), {
+        encounter_date: encounterDate,
+        friend_ids: friendIds,
+        encounter_type: encounterType,
+        title,
+        location_text: locationText,
+        description,
+      });
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(encounter, null, 2) }],
       };

--- a/apps/mcp-server/tests/integration.test.ts
+++ b/apps/mcp-server/tests/integration.test.ts
@@ -423,7 +423,7 @@ describe('MCP Server', { timeout: 60000 }, () => {
       return { baseUrl, sessionId, email: testUser.email, password: testUser.appPassword };
     }
 
-    it('should list all 12 tools', async () => {
+    it('should list all 13 tools', async () => {
       const { baseUrl, testUser } = getContext();
       const sessionId = await initMcpSession(baseUrl, testUser.email, testUser.appPassword);
 
@@ -436,7 +436,7 @@ describe('MCP Server', { timeout: 60000 }, () => {
       const result = body as { result?: { tools?: Array<{ name: string }> } };
       const toolNames = result.result?.tools?.map((t) => t.name) ?? [];
 
-      expect(toolNames.length).toBeGreaterThanOrEqual(12);
+      expect(toolNames.length).toBeGreaterThanOrEqual(13);
       expect(toolNames).toContain('list_friends');
       expect(toolNames).toContain('get_friend');
       expect(toolNames).toContain('search_friends');
@@ -449,6 +449,7 @@ describe('MCP Server', { timeout: 60000 }, () => {
       expect(toolNames).toContain('get_collective');
       expect(toolNames).toContain('list_encounters');
       expect(toolNames).toContain('get_encounter');
+      expect(toolNames).toContain('create_encounter');
     });
 
     it('list_friends should return a paginated list', async () => {
@@ -573,6 +574,50 @@ describe('MCP Server', { timeout: 60000 }, () => {
       const result = body as { result?: { content?: Array<{ text?: string }> } };
       const data = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
       expect(data.encounters.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('create_encounter should create an encounter with friends', async () => {
+      const { pool, testUser } = getContext();
+      const friendResult = await pool.query(
+        `INSERT INTO friends.friends (user_id, display_name)
+         SELECT u.id, 'Encounter Friend'
+         FROM auth.users u WHERE u.external_id = $1
+         RETURNING external_id`,
+        [testUser.externalId],
+      );
+      const friendId = friendResult.rows[0].external_id;
+
+      const { baseUrl, sessionId, email, password } = await getSessionAndAuth();
+      const { body } = await callTool(
+        baseUrl,
+        'create_encounter',
+        {
+          title: 'Lunch downtown',
+          encounterDate: '2024-07-01',
+          encounterType: 'in_person',
+          friendIds: [friendId],
+          locationText: 'The Diner',
+          description: 'Caught up over lunch.',
+        },
+        { email, password, sessionId },
+      );
+
+      const result = body as { result?: { content?: Array<{ text?: string }> } };
+      const encounter = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
+      expect(encounter.id).toBeTruthy();
+      expect(encounter.title).toBe('Lunch downtown');
+      expect(encounter.encounterType).toBe('in_person');
+      expect(encounter.encounterDate).toBe('2024-07-01');
+      expect(encounter.locationText).toBe('The Diner');
+      expect(encounter.friends).toHaveLength(1);
+      expect(encounter.friends[0].id).toBe(friendId);
+
+      // Verify it was persisted
+      const persisted = await pool.query(
+        `SELECT title FROM encounters.encounters WHERE external_id = $1`,
+        [encounter.id],
+      );
+      expect(persisted.rows[0]?.title).toBe('Lunch downtown');
     });
 
     it('get_upcoming_dates should return dates array', async () => {


### PR DESCRIPTION
Adds a write tool to the MCP server so encounters can be created via
MCP, mapping the friendly camelCase arguments onto the existing
EncountersService.createEncounter input. Requires a date and at least
one friend; title, type, location, and description are optional.

Updates the integration tests to cover the new tool and the tool count.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N4DC7V4ok2X7xNK5xoMJGV